### PR TITLE
Revert "create entities if missing"

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -42,15 +42,6 @@
   shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
   register: entity_count
 
-- name: Create missing entities
-  shell: "raxmon-entities-create --label={{ entity_name }}"
-  when: entity_count.stdout|int == 0
-
-- name: Entity {{ entity_name }} count
-  shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
-  register: entity_count
-  when: entity_count.stdout|int == 0
-
 - name: At most one {{ entity_name }} entity exists
   fail:
     msg: "Entity count of {{ entity_count.stdout }} != 1 for entity with the label {{ entity_name }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/remote_setup.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/remote_setup.yml
@@ -18,17 +18,6 @@
   register: entity_count
   delegate_to: "{{ physical_host }}"
 
-- name: Create missing entities
-  shell: "raxmon-entities-create --label={{ entity_name }}"
-  when: entity_count.stdout|int == 0
-  delegate_to: "{{ physical_host }}"
-
-- name: Entity {{ entity_name }} count
-  shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
-  register: entity_count
-  when: entity_count.stdout|int == 0
-  delegate_to: "{{ physical_host }}"
-
 - name: At most one {{ entity_name }} entity exists
   fail:
     msg: "Entity count of {{ entity_count.stdout }} != 1 for entity with the label {{ entity_name }}"


### PR DESCRIPTION
This change reverts 096b0a2 as we originally made a conscious decision to not create entities via rpc_maas.  These entities should be created at provisioning time and a lack of existence could indicate a problem with host provisioning.  Also, the rpc_maas role fails to run with this commit in place.   It looks like the entity_count var gets re-registered even when the task is skipped resulting in there being no stdout field. In this case it would probably be best to just re-issue the count task again without a when condition.

This reverts commit 096b0a2a2bf679e326bbc9b75933c901ca3241c5.

Closes issue #149