### PR TITLE
Set defaults for galera vars

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/client.my.cnf.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/client.my.cnf.j2
@@ -2,5 +2,5 @@
 
 [client]
 host={{ container_address }}
-user={{ galera_root_user }}
+user={{ galera_root_user|default('root') }}
 password={{ galera_root_password }}

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -19,5 +19,4 @@
   roles:
     - { role: "rpc_maas", tags: [ "maas-setup" ] }
   vars_files:
-    - "{{ rpc_repo_path }}/playbooks/inventory/group_vars/all.yml"
     - "{{ rpc_repo_path }}/playbooks/roles/os_cinder/defaults/main.yml"


### PR DESCRIPTION
Commit eb95036a7ea0e98fc931dd19f416015c66f3620c in os-a-d relocated a
number of variables in playbooks/inventory/group_vars/all.yml to
etc/openstack_deploy/user_group_vars.yml.  However, in the process some
vars (namely galera_root_user) were not moved and this breaks execution
of the rpc_maas role as we include
playbooks/inventory/group_vars/all.yml in set-maas.yml playbook.

This change sets defaults for galera_root_user and removes inclusion of
playbooks/inventory/group_vars/all.yml since it is no longer required.

We will eventually want to use galera_client role here instead, however
the immediate issue identified is that already deployed hosts will run
into apt issues as they try to go from ubuntu mariadb packages to those
packaged by mariadb themself.

Closes issue #149

(cherry picked from commit bdc95511efceeaff901c7103f29dfb3d231b0244)