### PR TITLE
[kilo] Deploy & Upgrade adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rpc-openstack
 Optional add-ons for Rackspace Private Cloud
 
-# os-ansible-deploy integration
+# os-ansible-deployment integration
 
 The rpc-openstack repo includes add-ons for the Rackspace Private Cloud product
 that integrate with the 
@@ -53,7 +53,10 @@ above.
      `cp -R os-ansible-deployment/etc/openstack_deploy /etc/openstack_deploy`
   2. recursively copy the RPC configuration files:
      `cp -R rpcd/etc/openstack_deploy /etc/openstack_deploy`
-  3. Edit configurations in `/etc/openstack_deploy` for example:
+  3. If the ELK stack is not going to be used, remove the container
+     configurations from the environment:
+     `rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml`
+  4. Edit configurations in `/etc/openstack_deploy` for example:
     1. `openstack_user_variables.yml.example` or
        `openstack_user_variables.yml.aio`
     2. There is a tool to generate the inventory for RAX datacenters, otherwise

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,13 +54,13 @@ if [[ "${DEPLOY_OSAD}" == "yes" ]]; then
     rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml
   fi
 
-  # setup the hosts and build the basic containers
-  install_bits setup-hosts.yml
-
   # setup the haproxy load balancer
   if [[ "${DEPLOY_HAPROXY}" == "yes" ]]; then
     install_bits haproxy-install.yml
   fi
+
+  # setup the hosts and build the basic containers
+  install_bits setup-hosts.yml
 
   # setup the infrastructure
   install_bits setup-infrastructure.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,6 +39,12 @@ which openstack-ansible || ./scripts/bootstrap-ansible.sh
 # begin the openstack installation
 cd "${OSAD_DIR}"/playbooks/
 
+# ensure that the ELK containers aren't created if they're not
+# going to be used
+if [[ "${DEPLOY_ELK}" != "yes" ]]; then
+  rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml
+fi
+
 # setup the hosts and build the basic containers
 install_bits setup-hosts.yml
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,7 @@ source /opt/rpc-openstack/os-ansible-deployment/scripts/scripts-library.sh
 export ADMIN_PASSWORD=${ADMIN_PASSWORD:-"secrete"}
 export DEPLOY_AIO=${DEPLOY_AIO:-"no"}
 export DEPLOY_HAPROXY=${DEPLOY_HAPROXY:-"no"}
+export DEPLOY_OSAD=${DEPLOY_OSAD:-"yes"}
 export DEPLOY_ELK=${DEPLOY_ELK:-"yes"}
 export DEPLOY_MAAS=${DEPLOY_MAAS:-"yes"}
 
@@ -14,7 +15,7 @@ OSAD_DIR='/opt/rpc-openstack/os-ansible-deployment'
 RPCD_DIR='/opt/rpc-openstack/rpcd'
 
 # begin the bootstrap process
-cd "${OSAD_DIR}"
+cd ${OSAD_DIR}
 
 # bootstrap the AIO
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
@@ -24,7 +25,7 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   export DEPLOY_MAAS="no"
   if [[ ! -d /etc/openstack_deploy/ ]]; then
     ./scripts/bootstrap-aio.sh
-    cp -R "${RPCD_DIR}"/etc/openstack_deploy/* /etc/openstack_deploy/
+    cp -R ${RPCD_DIR}/etc/openstack_deploy/* /etc/openstack_deploy/
     sed -i 's/# elasticsearch_heap_size_mb/elasticsearch_heap_size_mb/' /etc/openstack_deploy/user_extras_variables.yml
     sed -i "s/kibana_password:.*/kibana_password: ${ADMIN_PASSWORD}/" /etc/openstack_deploy/user_extras_secrets.yml
   fi
@@ -37,30 +38,32 @@ which openstack-ansible || ./scripts/bootstrap-ansible.sh
 ./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_extras_secrets.yml
 
 # begin the openstack installation
-cd "${OSAD_DIR}"/playbooks/
+if [[ "${DEPLOY_OSAD}" == "yes" ]]; then
+  cd ${OSAD_DIR}/playbooks/
 
-# ensure that the ELK containers aren't created if they're not
-# going to be used
-if [[ "${DEPLOY_ELK}" != "yes" ]]; then
-  rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml
+  # ensure that the ELK containers aren't created if they're not
+  # going to be used
+  if [[ "${DEPLOY_ELK}" != "yes" ]]; then
+    rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml
+  fi
+
+  # setup the hosts and build the basic containers
+  install_bits setup-hosts.yml
+
+  # setup the haproxy load balancer
+  if [[ "${DEPLOY_HAPROXY}" == "yes" ]]; then
+    install_bits haproxy-install.yml
+  fi
+
+  # setup the infrastructure
+  install_bits setup-infrastructure.yml
+
+  # setup openstack
+  install_bits setup-openstack.yml
 fi
-
-# setup the hosts and build the basic containers
-install_bits setup-hosts.yml
-
-# setup the haproxy load balancer
-if [[ "${DEPLOY_HAPROXY}" == "yes" ]]; then
-  install_bits haproxy-install.yml
-fi
-
-# setup the infrastructure
-install_bits setup-infrastructure.yml
-
-# setup openstack
-install_bits setup-openstack.yml
 
 # begin the RPC installation
-cd "${RPCD_DIR}"/playbooks/
+cd ${RPCD_DIR}/playbooks/
 
 # build the RPC python package repository
 install_bits repo-build.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,8 +26,12 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   if [[ ! -d /etc/openstack_deploy/ ]]; then
     ./scripts/bootstrap-aio.sh
     cp -R ${RPCD_DIR}/etc/openstack_deploy/* /etc/openstack_deploy/
+    # ensure that the elasticsearch JVM heap size is limited
     sed -i 's/# elasticsearch_heap_size_mb/elasticsearch_heap_size_mb/' /etc/openstack_deploy/user_extras_variables.yml
+    # set the kibana admin password
     sed -i "s/kibana_password:.*/kibana_password: ${ADMIN_PASSWORD}/" /etc/openstack_deploy/user_extras_secrets.yml
+    # set the load balancer name to the host's name
+    sed -i "s/lb_name: .*/lb_name: '$(hostname)'/" /etc/openstack_deploy/user_extras_variables.yml
   fi
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,9 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
     sed -i "s/kibana_password:.*/kibana_password: ${ADMIN_PASSWORD}/" /etc/openstack_deploy/user_extras_secrets.yml
     # set the load balancer name to the host's name
     sed -i "s/lb_name: .*/lb_name: '$(hostname)'/" /etc/openstack_deploy/user_extras_variables.yml
+    # set the ansible inventory hostname to the host's name
+    sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
+    sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
   fi
 fi
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -19,15 +19,14 @@ set -eux pipefail
 OSAD_DIR='/opt/rpc-openstack/os-ansible-deployment'
 RPCD_DIR='/opt/rpc-openstack/rpcd'
 
-# Do the actual upgrade
-cd /opt/rpc-openstack/os-ansible-deployment
-/opt/rpc-openstack/os-ansible-deployment/scripts/run-upgrade.sh
+# Do the upgrade for os-ansible-deployment components
+cd ${OSAD_DIR}
+${OSAD_DIR}/scripts/run-upgrade.sh
 
-# install RPC-specific stuff
-source /opt/rpc-openstack/os-ansible-deployment/scripts/scripts-library.sh
-cd "${RPCD_DIR}"/playbooks/
+# Prevent the deployment script from re-running the OSAD playbooks
+export DEPLOY_OSAD="no"
 
-# TODO(nolan) need to remove the stuff in the maas directory. Maybe make a
-# play for upgrade-maas?
-
-install_bits site.yml
+# Do the upgrade for the RPC components
+source ${OSAD_DIR}/scripts/scripts-library.sh
+cd ${RPCD_DIR}
+${RPCD_DIR}/scripts/deploy.sh


### PR DESCRIPTION
This PR includes documentation and script fixes which adjust the deployment and upgrade processes. The upgrade process is now set to re-use the deployment script, and the deployment script will no longer create the ELK stack containers if they are not going to be used. The documentation also now includes an extra step to do the same for non-AIO builds.

This PR is a backport of https://github.com/rcbops/rpc-openstack/pull/157 to the kilo branch.