### PR TITLE
Fix typo in swift.yml

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
@@ -88,7 +88,7 @@
     alarm_name: lb_api_alarm_swift_proxy
     criteria: ":set consecutiveCount={{ maas_alarm_remote_consecutive_count }} if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }"
   when:
-    - defined groups['swift_proxy'][0]
+    - groups['swift_proxy'][0] is defined
     - inventory_hostname == groups['swift_proxy'][0]
 
 # Setup swift host local swift-recon checks


### PR DESCRIPTION
The when statement added by 13ddcb5 to swift.yml is incorrect and
causes an ansible run to fail.

Closes issue #172