### PR TITLE
Backport swift.yml changes to kilo

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
@@ -87,8 +87,9 @@
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
     alarm_name: lb_api_alarm_swift_proxy
     criteria: ":set consecutiveCount={{ maas_alarm_remote_consecutive_count }} if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }"
-  when: >
-    inventory_hostname == groups['swift_proxy'][0]
+  when:
+    - defined groups['swift_proxy'][0]
+    - inventory_hostname == groups['swift_proxy'][0]
 
 # Setup swift host local swift-recon checks
 - include: local_setup.yml

--- a/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
@@ -88,7 +88,7 @@
     alarm_name: lb_api_alarm_swift_proxy
     criteria: ":set consecutiveCount={{ maas_alarm_remote_consecutive_count }} if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }"
   when:
-    - defined groups['swift_proxy'][0]
+    - groups['swift_proxy'][0] is defined
     - inventory_hostname == groups['swift_proxy'][0]
 
 # Setup swift host local swift-recon checks


### PR DESCRIPTION
This PR backports the following commits from master to kilo:

13ddcb5 allow for mass when not setting up swift
3804f0e Fix typo in swift.yml

Closes issue #172 