### PR TITLE
Use novaclient version 2 instead of 3

### DIFF
--- a/maas/maas_common.py
+++ b/maas/maas_common.py
@@ -138,7 +138,7 @@ else:
                 'compute',
                 auth_ref['serviceCatalog'])
 
-        nova = nova_client('3', auth_token=auth_token, bypass_url=bypass_url)
+        nova = nova_client('2', auth_token=auth_token, bypass_url=bypass_url)
 
         try:
             flavors = nova.flavors.list()


### PR DESCRIPTION
The novaclient library has removed client version 3 (see
https://review.openstack.org/#/c/169378/).  This commit updates
get_nova_client() method in maas_common.py to use version 2 instead.

Closes issue #177