### PR TITLE
Add user_variable.yml file to rpcd

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Nova overrides
+nova_cross_az_attach: False
+
+## Apache SSL Settings
+# These do not need to be configured unless you're creating certificates for
+# services running behind Apache (currently, Horizon and Keystone).
+ssl_protocol: "ALL -SSLv2 -SSLv3"
+# Cipher suite string from https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+ssl_cipher_suite: "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,7 +25,9 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   export DEPLOY_MAAS="no"
   if [[ ! -d /etc/openstack_deploy/ ]]; then
     ./scripts/bootstrap-aio.sh
-    cp -R ${RPCD_DIR}/etc/openstack_deploy/* /etc/openstack_deploy/
+    pushd ${RPCD_DIR}
+        for i in $(find etc/openstack_deploy/ -type f -iname '*.yml'); do ../scripts/update-yaml.py /$i $i; done
+    popd
     # ensure that the elasticsearch JVM heap size is limited
     sed -i 's/# elasticsearch_heap_size_mb/elasticsearch_heap_size_mb/' /etc/openstack_deploy/user_extras_variables.yml
     # set the kibana admin password

--- a/scripts/update-yaml.py
+++ b/scripts/update-yaml.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import argparse
+import errno
+import yaml
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('base', help='The path to the yaml file with the base configuration.')
+    parser.add_argument('overrides', help='The path to the yaml file with overrides.')
+    return parser.parse_args()
+
+
+def get_config(path):
+    try:
+        with open(path) as f:
+            data = f.read()
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            data = None
+        else:
+            raise e
+
+    if data is None:
+        return {}
+    else:
+        # assume config is a dict
+        return yaml.safe_load(data)
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    base = get_config(args.base)
+    overrides = get_config(args.overrides)
+    config = dict(base.items() + overrides.items())
+    if config:
+        with open(args.base, 'w') as f:
+            f.write(str(yaml.safe_dump(config, default_flow_style=False)))


### PR DESCRIPTION
This pull request is in response to https://bugs.launchpad.net/openstack-ansible/+bug/1457140

A commit is in os-ansible-deployment (master) to allow the requested variable to be set in the template.

This repo is for deploying an opinionated version of OpenStack using
os-ansible-deployment. There are instances where the defaults that a
Rackspace deployment will use differ from the upstream deployment
project. This commit creates a user_variables.yml file to use for
specifying these defaults and so this file should be used instead of
the one in os-ansible-deployment.

The user_variables.yml file in os-ansible-deployment currently sets two
variables that are not specified by default, by the associated roles.
These variables, ssl_protocol and ssl_cipher_suite, are specified in
this new file.

Support have requested that the nova configuration option
[cinder]/cross_az_attach be set to False and so is set here to override
the upstream default of True.