### PR TITLE
Fix ordering of host_only.yml

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/host_only.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/host_only.yml
@@ -17,13 +17,13 @@
 
 - include: package_install.yml
 
-- include: network.yml
-
 - include: raxmon_cli_config.yml
 
 - include: raxmon_agent_install.yml
   vars:
     entity_name: "{{ inventory_hostname }}{{ maas_fqdn_extension }}"
+
+- include: network.yml
 
 - include: cdm.yml
 


### PR DESCRIPTION
The network.yml include requires raxmon-cli to be setup, this is only
done by the subsequent 2 includes.

network.yml needs to be moved to happen after the raxmon-cli is setup.

Fixes-Bug: #197