### PR TITLE
Allow for token expires time in multiple formats

### DIFF
--- a/maas/maas_common.py
+++ b/maas/maas_common.py
@@ -327,8 +327,14 @@ class MaaSException(Exception):
 
 
 def is_token_expired(token):
-    expires = datetime.datetime.strptime(token['expires'],
-                                         '%Y-%m-%dT%H:%M:%SZ')
+    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%fZ'):
+        try:
+            expires = datetime.datetime.strptime(token['expires'], fmt)
+            break
+        except ValueError as e:
+            pass
+    else:
+        raise e
     return datetime.datetime.now() >= expires
 
 


### PR DESCRIPTION
Keystone tokens have an 'expires' property. Currently, is_token_expired
in maas_common expects this to be of the format '%Y-%m-%dT%H:%M:%SZ'.
os-ansible-deployment has switched to using fernet tokens by default.
These have an expires time in the format of '%Y-%m-%dT%H:%M:%S.%fZ'.
This causes the OpenStack MaaS plugins to fail.

This commit modifies is_token_expired to be able to parse either format
of 'expires'.

Closes-bug: https://github.com/rcbops/rpc-openstack/issues/199