### PR TITLE
Avoid generating multiple idential node creations

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -610,7 +610,10 @@ def main():
         priority = 100
         for node in value['hosts']:
             node['node_name'] = '%s_NODE_%s' % (PREFIX_NAME, node['hostname'])
-            nodes.append(NODES % node)
+            node_new = NODES % node
+            if node_new not in nodes:
+                nodes.append(node_new)
+
             if value.get('persist'):
                 persist = PERSIST_OPTION
             else:


### PR DESCRIPTION
When a node is part of multiple pools, do not recreate
the same definitions each time.