### PR TITLE
Prevent /boot from filling up by disabling unattended upgrades

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/disable_unattended_upgrades.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/disable_unattended_upgrades.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Disable unattended upgrades
+  lineinfile:
+    dest: '/etc/apt/apt.conf.d/50unattended-upgrades'
+    regexp: '\-security\";$'
+    line: '//   "${distro_id}:${distro_codename}-security";'

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -23,6 +23,8 @@
   when: >
     inventory_hostname in groups['hosts']
 
+- include: disable_unattended_upgrades.yml
+
 - include: support_preinstall.yml
 
 - include: bashrc.yml


### PR DESCRIPTION
Simply disables the security branch of unattended upgrades (the only one enabled by default).

Closes #24