### PR TITLE
Add script to handle changing osad git tag

### DIFF
--- a/scripts/bump-osa-sha.sh
+++ b/scripts/bump-osa-sha.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if (( $# < 1 )); then
+    echo "Please provide a tag value."
+    exit 1
+fi
+pushd openstack-ansible
+    git fetch
+    git checkout $1
+popd
+
+git add openstack-ansible
+
+git commit -m "SHA bump for OSA to match $1 as of $(date +%d/%m/%Y)"  --edit


### PR DESCRIPTION
This script will change the SHA used by the os-ansible-deployment
submodule to match a tag from the upstream repository. It will also
provide a commit message template that can be edited by the commiter.

Fixes #218 