### PR TITLE
Add MaaS specific rabbitmq user

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -134,6 +134,12 @@ maas_scheme: http
 maas_keystone_user: maas
 
 #
+# maas_rabbitmq_user: The rabbitmq user that is created for rabbitmq tests to use.
+#
+#
+maas_rabbitmq_user: maas_user
+
+#
 # maas_alarm_local_consecutive_count: The number of consecutive failures before an alert is
 #                                     generated for local checks.
 #

--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -304,7 +304,7 @@
 - include: local_setup.yml
   vars:
     check_name: rabbitmq_status
-    check_details: file={{ check_name }}.py,args=-H,args={{ ansible_ssh_host }},args=-n,args={{ inventory_hostname.split('.')[0] }}
+    check_details: file={{ check_name }}.py,args=-H,args={{ ansible_ssh_host }},args=-n,args={{ inventory_hostname.split('.')[0] }},args=-U,args={{ maas_rabbitmq_user }},args=-p,args={{ maas_rabbitmq_password }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -21,6 +21,10 @@
   when: >
     inventory_hostname == groups['utility'][0]
 
+- include: rabbitmq_user.yml
+  when: >
+    inventory_hostname == groups['rabbitmq_all'][0]
+
 - include: create_my_cnf.yml
   when: >
     inventory_hostname in groups['galera']

--- a/rpcd/playbooks/roles/rpc_maas/tasks/rabbitmq_user.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/rabbitmq_user.yml
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
-maas_rabbitmq_password:
+- name: Ensure MaaS rabbitmq user as administrator
+  rabbitmq_user:
+    user: "{{ maas_rabbitmq_user }}"
+    password: "{{ maas_rabbitmq_password }}"
+    vhost: "/"
+    configure_priv: ".*"
+    read_priv: ".*"
+    write_priv: ".*"
+    tags: "administrator"
+    state: "present"
+  tags:
+    - rabbitmq-user


### PR DESCRIPTION
Since we are removing the guest/guest user from rabbitmq as part of
os-ad we need to create a maas specific user that has "administrator"
privileges, otherwise the monitors don't work.

This patch adds a maas_user to rabbit, with a password specified in
user_extras_secrets. This is then passed to the monitors for rabbit as
they are created.

This won't adjust existing MaaS checks, so existing checks will need to
be removed and re-added or manually adjusted to address this problem.

Fixes: #223
(cherry picked from commit 6fc27ad7fd5a0b0191adc366faa91f8261f3c50e)