### PR TITLE
use uuid tokens and sql persistence driver

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -22,3 +22,7 @@ nova_cross_az_attach: False
 ssl_protocol: "ALL -SSLv2 -SSLv3"
 # Cipher suite string from https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
 ssl_cipher_suite: "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
+
+# Keystone overrides
+keystone_token_provider: "keystone.token.providers.uuid.Provider"
+keystone_token_driver: "keystone.token.persistence.backends.sql.Token"


### PR DESCRIPTION
Upstream osad uses fernet tokens as the default. In rpc we want to
continue to use uuid for the time being, so this commit adds a var to
override the default, as well as setting the token persistence driver back to sql

Partially-Closes: https://github.com/rcbops/rpc-openstack/issues/258