### PR TITLE
Disable Unattended Upgrades

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/disable_unattended_upgrades.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/disable_unattended_upgrades.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 - name: Disable unattended upgrades
-  lineinfile:
-    dest: '/etc/apt/apt.conf.d/50unattended-upgrades'
-    regexp: '\-security\";$'
-    line: '//   "${distro_id}:${distro_codename}-security";'
+  file:
+    name: '/etc/apt/apt.conf.d/50unattended-upgrades'
+    state: absent


### PR DESCRIPTION
Unattended upgrades for the security branch is enabled by default.
After some period of time, the /boot partition fills up with new
kernels, which is unexpected and undesired.

This patch disables the security updates as part of the rpc_support
playbook by removing the configuration file.

Fixes #24

(cherry picked from commit bb4a9bc7d8c920bec04aca8a315edbae13ec400d)