### PR TITLE
SHA bump for OSAD to match kilo as of 22/07/2015 This SHA bump is largely to grab some important fixes for the upcoming 11.0.0 release.

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/os-ansible-deployment
 
 # RPC Extras version
-rpc_release: 11.0.0rc3
+rpc_release: 11.0.0rc8
 
 # Definitions for the repo server, these should match your OSAD
 # deployment


### PR DESCRIPTION
Of major concern is fixing RabbitMQ upgrade failures.
(https://bugs.launchpad.net/openstack-ansible/+bug/1474992)

Fixes #269

(cherry picked from commit 05bd9966c8e2b12f09548f0df770925b66460b2b)