### PR TITLE
Add FORKS env variable to deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,6 @@
 
 set -e -u -x
 set -o pipefail
-source /opt/rpc-openstack/os-ansible-deployment/scripts/scripts-library.sh
 
 export ADMIN_PASSWORD=${ADMIN_PASSWORD:-"secrete"}
 export DEPLOY_AIO=${DEPLOY_AIO:-"no"}
@@ -12,7 +11,9 @@ export DEPLOY_ELK=${DEPLOY_ELK:-"yes"}
 export DEPLOY_MAAS=${DEPLOY_MAAS:-"no"}
 export DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"no"}
 export DEPLOY_CEILOMETER=${DEPLOY_CEILOMETER:-"no"}
+export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 
+source /opt/rpc-openstack/os-ansible-deployment/scripts/scripts-library.sh
 OSAD_DIR='/opt/rpc-openstack/os-ansible-deployment'
 RPCD_DIR='/opt/rpc-openstack/rpcd'
 


### PR DESCRIPTION
Currently the FORKS variable is set by osads scripts-library
to 25. This can cause issues with multinode deployments and the
ssh service in containers not being up in time for plays.

This will allow the user of the deploy script to override the
FORKS ansible variable to suite their environment.

Closes issue #276 