### PR TITLE
Update MaaS scripts to use Keystone v3

### DIFF
--- a/maas/heat_api_local_check.py
+++ b/maas/heat_api_local_check.py
@@ -54,7 +54,7 @@ def check(args, tenant_id):
 
 def main(args):
     auth_ref = get_auth_ref()
-    tenant_id = auth_ref['token']['tenant']['id']
+    tenant_id = auth_ref['project']['id']
     check(args, tenant_id)
 
 

--- a/maas/keystone_api_local_check.py
+++ b/maas/keystone_api_local_check.py
@@ -24,7 +24,7 @@ from keystoneclient.openstack.common.apiclient import exceptions as exc
 
 def check(args):
 
-    IDENTITY_ENDPOINT = 'http://{ip}:35357/v2.0'.format(ip=args.ip)
+    IDENTITY_ENDPOINT = 'http://{ip}:35357/v3'.format(ip=args.ip)
 
     try:
         keystone = get_keystone_client(endpoint=IDENTITY_ENDPOINT)
@@ -42,7 +42,7 @@ def check(args):
         milliseconds = (end - start) * 1000
 
         # gather some vaguely interesting metrics to return
-        tenant_count = len(keystone.tenants.list())
+        project_count = len(keystone.projects.list())
         user_count = len(keystone.users.list())
 
     status_ok()
@@ -54,7 +54,8 @@ def check(args):
                '%.3f' % milliseconds,
                'ms')
         metric('keystone_user_count', 'uint32', user_count, 'users')
-        metric('keystone_tenant_count', 'uint32', tenant_count, 'tenants')
+        metric('keystone_tenant_count', 'uint32', project_count, 'tenants')
+        metric('keystone_tenant_count', 'uint32', project_count, 'tenants')
 
 
 def main(args):

--- a/maas/nova_api_local_check.py
+++ b/maas/nova_api_local_check.py
@@ -27,8 +27,8 @@ SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
 
 def check(args):
     auth_ref = get_auth_ref()
-    auth_token = auth_ref['token']['id']
-    tenant_id = auth_ref['token']['tenant']['id']
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
 
     COMPUTE_ENDPOINT = 'http://{ip}:8774/v2/{tenant_id}' \
                        .format(ip=args.ip, tenant_id=tenant_id)
@@ -51,7 +51,8 @@ def check(args):
 
         # gather some metrics
         status_count = collections.Counter(
-            [s.status for s in nova.servers.list(search_opts={'all_tenants': 1})]
+            [s.status for s in nova.servers.list(
+             search_opts={'all_tenants': 1})]
         )
 
     status_ok()

--- a/maas/nova_service_check.py
+++ b/maas/nova_service_check.py
@@ -21,11 +21,12 @@ from maas_common import (get_auth_ref, get_nova_client, status_err, status_ok,
 
 def check(args):
     auth_ref = get_auth_ref()
-    auth_token = auth_ref['token']['id']
-    tenant_id = auth_ref['token']['tenant']['id']
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
 
     COMPUTE_ENDPOINT = 'http://{hostname}:8774/v2/{tenant_id}' \
                        .format(hostname=args.hostname, tenant_id=tenant_id)
+
     try:
         nova = get_nova_client(auth_token=auth_token,
                                bypass_url=COMPUTE_ENDPOINT)

--- a/maas/service_api_local_check.py
+++ b/maas/service_api_local_check.py
@@ -29,9 +29,9 @@ def check(args):
         auth_ref = get_auth_ref()
         keystone = get_keystone_client(auth_ref)
         auth_token = keystone.auth_token
-        tenant_id = keystone.tenant_id
+        project_id = keystone.project_id
         headers['auth_token'] = auth_token
-        path_options['tenant_id'] = tenant_id
+        path_options['project_id'] = project_id
 
     scheme = args.ssl and 'https' or 'http'
     endpoint = '{scheme}://{ip}:{port}'.format(ip=args.ip, port=args.port,
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         parser.add_argument('--path', default='',
                             help='Service API path, this should include '
                                  'placeholders for the version "{version}" and '
-                                 'tenant ID "{tenant_id}" if required.')
+                                 'project ID "{project_id}" if required.')
         parser.add_argument('--auth', action='store_true', default=False,
                             help='Does this API check require auth?')
         parser.add_argument('--ssl', action='store_true', default=False,


### PR DESCRIPTION
Now that os-ansible-deployment uses Keystone v3 by default, we need to
upgrade MaaS to use v3 as well. v3 is necessary for Keystone
Federation/ADFS happening usptream which we will be consuming, so we
need to upgrade our monitoring scripts to adjust for that.

Addresses #273