### PR TITLE
Update MaaS scripts to use Keystone v3

### DIFF
--- a/maas/heat_api_local_check.py
+++ b/maas/heat_api_local_check.py
@@ -54,7 +54,7 @@ def check(args, tenant_id):
 
 def main(args):
     auth_ref = get_auth_ref()
-    tenant_id = auth_ref['token']['tenant']['id']
+    tenant_id = auth_ref['project']['id']
     check(args, tenant_id)
 
 

--- a/maas/keystone_api_local_check.py
+++ b/maas/keystone_api_local_check.py
@@ -24,7 +24,7 @@ from keystoneclient.openstack.common.apiclient import exceptions as exc
 
 def check(args):
 
-    IDENTITY_ENDPOINT = 'http://{ip}:35357/v2.0'.format(ip=args.ip)
+    IDENTITY_ENDPOINT = 'http://{ip}:35357/v3'.format(ip=args.ip)
 
     try:
         keystone = get_keystone_client(endpoint=IDENTITY_ENDPOINT)
@@ -42,7 +42,7 @@ def check(args):
         milliseconds = (end - start) * 1000
 
         # gather some vaguely interesting metrics to return
-        tenant_count = len(keystone.tenants.list())
+        project_count = len(keystone.projects.list())
         user_count = len(keystone.users.list())
 
     status_ok()
@@ -54,7 +54,8 @@ def check(args):
                '%.3f' % milliseconds,
                'ms')
         metric('keystone_user_count', 'uint32', user_count, 'users')
-        metric('keystone_tenant_count', 'uint32', tenant_count, 'tenants')
+        metric('keystone_tenant_count', 'uint32', project_count, 'tenants')
+        metric('keystone_tenant_count', 'uint32', project_count, 'tenants')
 
 
 def main(args):

--- a/maas/maas_common.py
+++ b/maas/maas_common.py
@@ -86,11 +86,11 @@ else:
         auth_ref = get_auth_ref()
 
         if not token:
-            token = auth_ref['token']['id']
+            token = auth_ref['auth_token']
         if not endpoint:
             endpoint = get_endpoint_url_for_service(
                 'image',
-                auth_ref['serviceCatalog'])
+                auth_ref['catalog'])
 
         glance = g_client('1', endpoint=endpoint, token=token)
 
@@ -102,7 +102,7 @@ else:
             [i.id for i in image]
         except g_exc.HTTPUnauthorized:
             auth_ref = force_reauth()
-            token = auth_ref['token']['id']
+            token = auth_ref['auth_token']
 
             glance = get_glance_client(token, endpoint, previous_tries + 1)
         # we only want to pass HTTPException back to the calling poller
@@ -132,11 +132,11 @@ else:
         auth_ref = get_auth_ref()
 
         if not auth_token:
-            auth_token = auth_ref['token']['id']
+            auth_token = auth_ref['auth_token']
         if not bypass_url:
             bypass_url = get_endpoint_url_for_service(
                 'compute',
-                auth_ref['serviceCatalog'])
+                auth_ref['catalog'])
 
         nova = nova_client('2', auth_token=auth_token, bypass_url=bypass_url)
 
@@ -153,7 +153,7 @@ else:
 
         except AttributeError:
             auth_ref = force_reauth()
-            auth_token = auth_ref['token']['id']
+            auth_token = auth_ref['auth_token']
 
             nova = get_nova_client(auth_token, bypass_url, previous_tries + 1)
 
@@ -169,7 +169,7 @@ else:
         return nova
 
 try:
-    from keystoneclient.v2_0 import client as k_client
+    from keystoneclient.v3 import client as k_client
     from keystoneclient.openstack.common.apiclient import exceptions as k_exc
 except ImportError:
     def keystone_auth(*args, **kwargs):
@@ -207,8 +207,8 @@ else:
             auth_ref = get_auth_ref()
         if not endpoint:
             endpoint = get_endpoint_url_for_service('identity',
-                                                    auth_ref['serviceCatalog'],
-                                                    'adminURL')
+                                                    auth_ref['catalog'],
+                                                    'admin')
 
         keystone = k_client.Client(auth_ref=auth_ref, endpoint=endpoint)
 
@@ -246,11 +246,11 @@ else:
         auth_ref = get_auth_ref()
 
         if not token:
-            token = auth_ref['token']['id']
+            token = auth_ref['auth_token']
         if not endpoint_url:
             endpoint_url = get_endpoint_url_for_service(
                 'network',
-                auth_ref['serviceCatalog'])
+                auth_ref['catalog'])
 
         neutron = n_client.Client('2.0',
                                   token=token,
@@ -268,7 +268,7 @@ else:
         # local token) we'll just catch the exception it throws and move on
         except n_exc.NoAuthURLProvided:
             auth_ref = force_reauth()
-            token = auth_ref['token']['id']
+            token = auth_ref['auth_token']
 
             neutron = get_neutron_client(token, endpoint_url,
                                          previous_tries + 1)
@@ -301,18 +301,18 @@ else:
         auth_ref = get_auth_ref()
 
         if not token:
-            token = auth_ref['token']['id']
+            token = auth_ref['auth_token']
         if not endpoint:
             endpoint = get_endpoint_url_for_service(
                 'orchestration',
-                auth_ref['serviceCatalog'])
+                auth_ref['catalog'])
 
         heat = heat_client.Client('1', endpoint=endpoint, token=token)
         try:
             heat.build_info.build_info()
         except h_exc.HTTPUnauthorized:
             auth_ref = force_reauth()
-            token = auth_ref['token']['id']
+            token = auth_ref['auth_token']
             heat = get_heat_client(token, endpoint, previous_tries + 1)
         except h_exc.HTTPException:
             raise
@@ -327,8 +327,14 @@ class MaaSException(Exception):
 
 
 def is_token_expired(token):
-    expires = datetime.datetime.strptime(token['expires'],
-                                         '%Y-%m-%dT%H:%M:%SZ')
+    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%fZ'):
+        try:
+            expires = datetime.datetime.strptime(token['expires_at'], fmt)
+            break
+        except ValueError as e:
+            pass
+    else:
+        raise e
     return datetime.datetime.now() >= expires
 
 
@@ -338,7 +344,7 @@ def get_auth_ref():
     if auth_ref is None:
         auth_ref = keystone_auth(auth_details)
 
-    if is_token_expired(auth_ref['token']):
+    if is_token_expired(auth_ref):
         auth_ref = keystone_auth(auth_details)
 
     return auth_ref
@@ -387,10 +393,12 @@ def get_auth_details(openrc_file=OPENRC):
 
 
 def get_endpoint_url_for_service(service_type, service_catalog,
-                                 url_type='publicURL'):
-    for i in service_catalog:
-        if i['type'] == service_type:
-            return i['endpoints'][0][url_type]
+                                 url_type='public'):
+    for service in service_catalog:
+        if service['type'] == service_type:
+            for endpoint in service['endpoints']:
+                if endpoint['interface'] == url_type:
+                    return endpoint['url']
 
 
 def force_reauth():

--- a/maas/nova_api_local_check.py
+++ b/maas/nova_api_local_check.py
@@ -27,8 +27,8 @@ SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
 
 def check(args):
     auth_ref = get_auth_ref()
-    auth_token = auth_ref['token']['id']
-    tenant_id = auth_ref['token']['tenant']['id']
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
 
     COMPUTE_ENDPOINT = 'http://{ip}:8774/v2/{tenant_id}' \
                        .format(ip=args.ip, tenant_id=tenant_id)
@@ -51,7 +51,8 @@ def check(args):
 
         # gather some metrics
         status_count = collections.Counter(
-            [s.status for s in nova.servers.list(search_opts={'all_tenants': 1})]
+            [s.status for s in nova.servers.list(
+             search_opts={'all_tenants': 1})]
         )
 
     status_ok()

--- a/maas/nova_service_check.py
+++ b/maas/nova_service_check.py
@@ -21,11 +21,12 @@ from maas_common import (get_auth_ref, get_nova_client, status_err, status_ok,
 
 def check(args):
     auth_ref = get_auth_ref()
-    auth_token = auth_ref['token']['id']
-    tenant_id = auth_ref['token']['tenant']['id']
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
 
     COMPUTE_ENDPOINT = 'http://{hostname}:8774/v2/{tenant_id}' \
                        .format(hostname=args.hostname, tenant_id=tenant_id)
+
     try:
         nova = get_nova_client(auth_token=auth_token,
                                bypass_url=COMPUTE_ENDPOINT)

--- a/maas/service_api_local_check.py
+++ b/maas/service_api_local_check.py
@@ -29,9 +29,9 @@ def check(args):
         auth_ref = get_auth_ref()
         keystone = get_keystone_client(auth_ref)
         auth_token = keystone.auth_token
-        tenant_id = keystone.tenant_id
+        project_id = keystone.project_id
         headers['auth_token'] = auth_token
-        path_options['tenant_id'] = tenant_id
+        path_options['project_id'] = project_id
 
     scheme = args.ssl and 'https' or 'http'
     endpoint = '{scheme}://{ip}:{port}'.format(ip=args.ip, port=args.port,
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         parser.add_argument('--path', default='',
                             help='Service API path, this should include '
                                  'placeholders for the version "{version}" and '
-                                 'tenant ID "{tenant_id}" if required.')
+                                 'project ID "{project_id}" if required.')
         parser.add_argument('--auth', action='store_true', default=False,
                             help='Does this API check require auth?')
         parser.add_argument('--ssl', action='store_true', default=False,


### PR DESCRIPTION
Now that os-ansible-deployment uses Keystone v3 by default, we need to
upgrade MaaS to use v3 as well. v3 is necessary for Keystone
Federation/ADFS happening usptream which we will be consuming, so we
need to upgrade our monitoring scripts to adjust for that.

Co-Authored-By: Darren Birkett <darren.birkett@rackspace.co.uk>
Addresses #273
Addresses #199

Conflicts:
	maas/maas_common.py

To simplify dependency management for this cherry-pick, this also
includes changes in 936f23971e35b66f68e5be994f477d0632e6deb5 which were
never backported to Kilo.
(cherry picked from commit 182e5623405afffc44af42f2a5f906f4f7e8bb23)