### PR TITLE
Fix yaml linting errors in rpcd

### DIFF
--- a/rpcd/playbooks/beaver.yml
+++ b/rpcd/playbooks/beaver.yml
@@ -21,71 +21,71 @@
     - { role: "beaver" }
   vars:
     beaver_log_monitors:
-      - { name: "cinder",
-          log_file: "/var/log/cinder/*",
-          tags: "cinder,openstack,oslofmt",
-          multiline_regex_before: '.*\sTRACE\s.*' }
-      - { name: "nova",
-          log_file: "/var/log/nova/*",
-          tags: "nova,openstack,oslofmt",
-          multiline_regex_before: '.*\sTRACE\s.*' }
-      - { name: "heat",
-          log_file: "/var/log/heat/*",
-          tags: "heat,openstack,oslofmt",
-          multiline_regex_before: '.*\sTRACE\s.*' }
-      - { name: "keystone",
-          log_file: "/var/log/keystone/keystone.log",
-          tags: "keystone,openstack,oslofmt",
-          multiline_regex_before: '.*\sTRACE\s.*' }
-      - { name: "keystone-access",
-          log_file: "/var/log/keystone/ssl_access.log",
-          tags: "keystone,openstack,apache-access" }
-      - { name: "keystone-error",
-          log_file: "/var/log/keystone/keystone-apache-error.log",
-          tags: "keystone,openstack,apache-error" }
-      - { name: "glance",
-          log_file: "/var/log/glance/*",
-          tags: "glance,openstack,oslofmt",
-          multiline_regex_before: '.*\sTRACE\s.*' }
-      - { name: "horizon",
-          log_file: "/var/log/horizon/*.log",
-          tags: "horizon,openstack" }
-      - { name: "swift-proxy",
-          log_file: "/var/log/swift/proxy*.log",
-          tags: "swift,openstack" }
-      - { name: "swift-account",
-          log_file: "/openstack/log/{{ inventory_hostname }}/account*.log",
-          tags: "swift,openstack" }
-      - { name: "swift-container",
-          log_file: "/openstack/log/{{ inventory_hostname }}/container*.log",
-          tags: "swift,openstack" }
-      - { name: "swift-object",
-          log_file: "/openstack/log/{{ inventory_hostname }}/object*.log",
-          tags: "swift,openstack" }
-      - { name: "neutron",
-          log_file: "/var/log/neutron/*",
-          tags: "neutron,openstack,oslofmt" }
-      - { name: "mysql",
-          log_file: "/var/log/mysql_logs/*.log",
-          tags: "mysql,infrastructure",
-          multiline_regex_after: '(^#\sUser@Host:\s)',
-          multiline_regex_before: '(.*)'  }
-      - { name: "rabbitmq",
-          log_file: "/var/log/rabbitmq/rabbit@{{ inventory_hostname }}.log",
-          tags: "rabbitmq,infrastructure",
-          multiline_regex_after: '(^=.*)',
-          multiline_regex_before: '(^\s\*.*)|(^[a-zA-Z]+.*)' }
-      - { name: "elasticsearch",
-          log_file: "/var/log/elasticsearch/*.log",
-          tags: "elasticsearch,infrastructure",
-          multiline_regex_after: '(^org.elasticsearch.*)',
-          multiline_regex_before: '(^\s+at\s.*)|(^org.elasticsearch.*)|(^Caused by.*)|(^\s+\.\.\.)' }
-      - { name: "logstash",
-          log_file: "/var/log/logstash/*.log",
-          tags: "logstash,infrastructure" }
-      - { name: "beaver",
-          log_file: "/var/log/beaver/beaver.log",
-          tags: "beaver,infrastructure" }
-      - { name: "auth",
-          log_file: "/var/log/auth.log",
-          tags: "auth,infrastructure" }
+      - name: "cinder"
+        log_file: "/var/log/cinder/*"
+        tags: "cinder,openstack,oslofmt"
+        multiline_regex_before: '.*\sTRACE\s.*'
+      - name: "nova"
+        log_file: "/var/log/nova/*"
+        tags: "nova,openstack,oslofmt"
+        multiline_regex_before: '.*\sTRACE\s.*'
+      - name: "heat"
+        log_file: "/var/log/heat/*"
+        tags: "heat,openstack,oslofmt"
+        multiline_regex_before: '.*\sTRACE\s.*'
+      - name: "keystone"
+        log_file: "/var/log/keystone/keystone.log"
+        tags: "keystone,openstack,oslofmt"
+        multiline_regex_before: '.*\sTRACE\s.*'
+      - name: "keystone-access"
+        log_file: "/var/log/keystone/ssl_access.log"
+        tags: "keystone,openstack,apache-access"
+      - name: "keystone-error"
+        log_file: "/var/log/keystone/keystone-apache-error.log"
+        tags: "keystone,openstack,apache-error"
+      - name: "glance"
+        log_file: "/var/log/glance/*"
+        tags: "glance,openstack,oslofmt"
+        multiline_regex_before: '.*\sTRACE\s.*'
+      - name: "horizon"
+        log_file: "/var/log/horizon/*.log"
+        tags: "horizon,openstack"
+      - name: "swift-proxy"
+        log_file: "/var/log/swift/proxy*.log"
+        tags: "swift,openstack"
+      - name: "swift-account"
+        log_file: "/openstack/log/{{ inventory_hostname }}/account*.log"
+        tags: "swift,openstack"
+      - name: "swift-container"
+        log_file: "/openstack/log/{{ inventory_hostname }}/container*.log"
+        tags: "swift,openstack"
+      - name: "swift-object"
+        log_file: "/openstack/log/{{ inventory_hostname }}/object*.log"
+        tags: "swift,openstack"
+      - name: "neutron"
+        log_file: "/var/log/neutron/*"
+        tags: "neutron,openstack,oslofmt"
+      - name: "mysql"
+        log_file: "/var/log/mysql_logs/*.log"
+        tags: "mysql,infrastructure"
+        multiline_regex_after: '(^#\sUser@Host:\s)'
+        multiline_regex_before: '(.*)'
+      - name: "rabbitmq"
+        log_file: "/var/log/rabbitmq/rabbit@{{ inventory_hostname }}.log"
+        tags: "rabbitmq,infrastructure"
+        multiline_regex_after: '(^=.*)'
+        multiline_regex_before: '(^\s\*.*)|(^[a-zA-Z]+.*)'
+      - name: "elasticsearch"
+        log_file: "/var/log/elasticsearch/*.log"
+        tags: "elasticsearch,infrastructure"
+        multiline_regex_after: '(^org.elasticsearch.*)'
+        multiline_regex_before: '(^\s+at\s.*)|(^org.elasticsearch.*)|(^Caused by.*)|(^\s+\.\.\.)'
+      - name: "logstash"
+        log_file: "/var/log/logstash/*.log"
+        tags: "logstash,infrastructure"
+      - name: "beaver"
+        log_file: "/var/log/beaver/beaver.log"
+        tags: "beaver,infrastructure"
+      - name: "auth"
+        log_file: "/var/log/auth.log"
+        tags: "auth,infrastructure"

--- a/rpcd/playbooks/elasticsearch.yml
+++ b/rpcd/playbooks/elasticsearch.yml
@@ -33,8 +33,7 @@
         container_command: |
           [[ ! -d "/var/lib/elasticsearch" ]] && mkdir -p "/var/lib/elasticsearch"
         container_config:
-          - "lxc.mount.entry=/openstack/{{ container_name
-            }}/var/lib/elasticsearch var/lib/elasticsearch none bind 0 0"
+          - "lxc.mount.entry=/openstack/{{ container_name }}/var/lib/elasticsearch var/lib/elasticsearch none bind 0 0"
           - "lxc.aa_profile=unconfined"
       delegate_to: "{{ physical_host }}"
       when: is_metal == false or is_metal == "False"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -23,7 +23,7 @@
       - { 'name': 'cinder_api_local_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["cinder_api_local_status"] != 1) { return new AlarmStatus(CRITICAL, "API unavailable"); }' }
   user: root
   when: >
-    inventory_hostname in groups['cinder_api'] 
+    inventory_hostname in groups['cinder_api']
 
 - include: local_setup.yml
   vars:

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -62,5 +62,5 @@
   until: pip_install|success
   retries: 5
   delay: 10
-  tags: 
+  tags:
     - holland_install


### PR DESCRIPTION
This change cleans up the errors seen in the linting script. One line in
particular in playbooks/elasticsearch.yml looks like it was split to
maintain line length, but there isn't currently an Ansible yaml rule
for that, at least not one that is defined in ansible-lint's defaults.

Addresses #240 
