### PR TITLE
Add a linting script for rpcd.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+
+script: ./scripts/linting.sh

--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -12,23 +12,23 @@ timeout = 120
 
 # Set the path to the folder in os-ansible-deployment which holds the dynamic
 # inventory script - new config setting for ansible v1.9 and above
-inventory = /opt/rpc-openstack/os-ansible-deployment/playbooks/inventory/
+inventory = ../../os-ansible-deployment/playbooks/inventory/
 
 # Set the path to the folder in os-ansible-deployment which holds the dynamic
 # inventory script - uncomment if using ansible below v1.9
-#hostfile = /opt/rpc-openstack/os-ansible-deployment/playbooks/inventory/
+#hostfile = ../../os-ansible-deployment/playbooks/inventory/
 
 # Set the path to the folder in os-ansible-deployment which holds the
 # libraries required
-library = /opt/rpc-openstack/os-ansible-deployment/playbooks/library/
+library = ../../os-ansible-deployment/playbooks/library/
 
 # Set the path to the folder in os-ansible-deployment which holds the roles
 # that are depended on by the rpc-openstack roles
-roles_path = /opt/rpc-openstack/os-ansible-deployment/playbooks/roles/
+roles_path = ../../os-ansible-deployment/playbooks/roles/
 
 # Set the path to the folder in os-ansible-deployment which holds the
 # lookup plugins required
-lookup_plugins = /opt/rpc-openstack/os-ansible-deployment/playbooks/plugins/lookups/
+lookup_plugins = ../../os-ansible-deployment/playbooks/plugins/lookups/
 
 [ssh_connection]
 pipelining = True

--- a/scripts/linting.sh
+++ b/scripts/linting.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -euo pipefail
+
+trap "exit -1" ERR
+
+# Track whether linting failed; we don't want to bail on lint failures
+failed=0
+
+## Main ----------------------------------------------------------------------
+echo "Running Basic Ansible Lint Check"
+
+
+# Install the development requirements.
+if [[ -f "os-ansible-deployment/dev-requirements.txt" ]]; then
+  pip2 install -r os-ansible-deployment/dev-requirements.txt || pip install -r os-ansible-deployment/dev-requirements.txt
+else
+  pip2 install ansible-lint || pip install ansible-lint
+fi
+
+# Run hacking/flake8 check for all python files
+# Ignores the following rules due to how ansible modules work in general
+#     F403 'from ansible.module_utils.basic import *' used; unable to detect undefined names
+#     H303  No wildcard (*) import.
+# Excluding our upstream submodule, and our vendored f5 configuration script.
+flake8 $(grep -rln -e '^#!/usr/bin/env python' -e '^#!/bin/python' -e '^#!/usr/bin/python' * ) || failed=1
+
+# Perform our simple sanity checks.
+pushd rpcd/playbooks
+  # Put local inventory in a var so we're not polluting the file system too much
+  LOCAL_INVENTORY='[all]\nlocalhost ansible_connection=local'
+
+  # Do a basic syntax check on all playbooks and roles.
+  echo "Running Syntax Check"
+  ansible-playbook -i <(echo $LOCAL_INVENTORY) --syntax-check *.yml --list-tasks || failed=1
+
+  # Perform a lint check on all playbooks and roles.
+  echo "Running Lint Check"
+  ansible-lint --version || failed=1
+  ansible-lint *.yml || failed=1
+popd
+
+if [[ $failed -eq 1 ]]; then
+  echo "Failed linting"
+  exit -1
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[flake8]
+# Ignores the following rules due to how ansible modules work in general
+#     F403 'from ansible.module_utils.basic import *' used; unable to detect undefined names
+#     H303  No wildcard (*) import.
+# Excluding our upstream submodule, and our vendored f5 configuration script.
+ignore=F403,H303
+exclude=os-ansible-deployment,f5-config.py


### PR DESCRIPTION
Linting for rpc-openstack should only cover the RPC-specific playbooks,
roles, scripts, and modules, since
os-ansible-deployment/openstack-ansible already does their own upstream
linting.

This change also uses relative paths in the ansible.cfg file so that
linting will work from Travis's container-based infrastructure. With the
hardcoded paths, we would have had to use sudo in the script, and add
configuration options to our .travis.yml. Also, their sudo-capable
infrastructure is considered legacy, so it's probably best avoided.

The relative paths mean we should be able to lint from whatever
directory we want, and if working within a virtualenv, run linting
without being root.

Also, the flake8 ignores and excludes were moved into a tox.ini file to
reduce line noise.

Fixes #240 

(cherry picked from commit e5fbfdc697350bd19599c32445043dfb912f0b58)