### PR TITLE
set uri correctly for maas checks by default

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -121,7 +121,7 @@ maas_scheme: http
 # maas_keystone_scheme: https
 # maas_neutron_scheme: https
 # maas_nova_scheme: https
-# maas_horizon_scheme: https
+maas_horizon_scheme: https
 # maas_heat_api_scheme: https
 # maas_heat_cfn_scheme: https
 # maas_heat_cloudwatch_scheme: https


### PR DESCRIPTION
it seems that by default we are enabling ssl for horizon (self signed)
because of this we need to set the default uri for checks to be https
or maas will get confused (the check already defaults to port 443 (hard
coded)).

fixes #249