### PR TITLE
set uri correctly for maas checks by default

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -121,7 +121,7 @@ maas_scheme: http
 # maas_keystone_scheme: https
 # maas_neutron_scheme: https
 # maas_nova_scheme: https
-# maas_horizon_scheme: https
+maas_horizon_scheme: https
 # maas_heat_api_scheme: https
 # maas_heat_cfn_scheme: https
 # maas_heat_cloudwatch_scheme: https

--- a/rpcd/playbooks/roles/rpc_maas/tasks/remote.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/remote.yml
@@ -132,7 +132,7 @@
     scheme: "{{ maas_horizon_scheme | default(maas_scheme)}}"
     ip_address: "{{ maas_external_ip_address }}"
     port: 443
-    path: ""
+    path: "/auth/login/"
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
     alarm_name: lb_api_alarm_horizon
     criteria: ":set consecutiveCount={{ maas_alarm_remote_consecutive_count }} if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }"


### PR DESCRIPTION
It seems that by default we are enabling ssl for horizon (self signed)
because of this we need to set the default uri for checks to be https
or maas will get confused (the check already defaults to port 443 (hard
coded)).

fixes #249