### PR TITLE
SHA bump for OSAD to match kilo as of 30/07/2015

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/os-ansible-deployment
 
 # RPC Extras version
-rpc_release: 11.0.0rc8
+rpc_release: 11.0.0rc10
 
 # Definitions for the repo server, these should match your OSAD
 # deployment


### PR DESCRIPTION
This bump addresses the issue found in #299

Also, the RC version for kilo is bumped.