### PR TITLE
keep galera_cluster_name the same as juno

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -34,3 +34,6 @@ ssl_cipher_suite: "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AE
 # Keystone overrides
 keystone_token_provider: "keystone.token.providers.uuid.Provider"
 keystone_token_driver: "keystone.token.persistence.backends.sql.Token"
+
+# Galera overrides
+galera_cluster_name: rpc_galera_cluster


### PR DESCRIPTION
A juno deploy will have galera_cluster_name set to rpc_galera_cluster.
When upgrading to kilo, we need to keep this name the same (osad kilo
changes the default to openstack_galera_cluster) otherwise rolling
restarts of the cluster during upgrades will timeout and fail.

Closes: #308