### PR TITLE
Ensure Kilo user_variables are present for upgrade

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -18,6 +18,13 @@ set -eux pipefail
 
 BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
 OSAD_DIR="$BASE_DIR/os-ansible-deployment"
+RPCD_DIR="$BASE_DIR/rpcd"
+
+# Merge new overrides into existing user_variables before upgrade
+# contents of existing user_variables take precedence over new overrides
+cp ${RPCD_DIR}/etc/openstack_deploy/user_variables.yml /tmp/upgrade_user_variables.yml
+${BASE_DIR}/scripts/update-yaml.py /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
+mv /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 
 # Do the upgrade for os-ansible-deployment components
 cd ${OSAD_DIR}


### PR DESCRIPTION
New user_variables introduced for Kilo will not be present at time of
upgrade due to the upstream (os-ansible-deployment) run-upgrade.sh
script's processing flow. Applying them to the pre-upgraded
user_variables ensures they are available as upstream upgrade runs
playbooks.

Related to #310