### PR TITLE
remove auth_ref on disk after upgrade finishes

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -37,3 +37,7 @@ export DEPLOY_OSAD="no"
 source ${OSAD_DIR}/scripts/scripts-library.sh
 cd ${BASE_DIR}
 ${BASE_DIR}/scripts/deploy.sh
+
+# the auth_ref on disk is now not usable by the new plugins
+cd ${RPCD_DIR}/playbooks 
+ansible hosts -m shell -a 'rm /root/.auth_ref.json'


### PR DESCRIPTION
The auth_ref is in a format that the new plugins can't read.  We remove
it at the end of the script.  The next time a plugin is called, a new
auth_ref gets generated in the new format, so this is a one time thing
after upgrade.

(cherry picked from commit b4b39b0608c683c8f9282635d4037f0b4e08ab22)