### PR TITLE
Allow users to resume upgrade execution by using resume.sh wrapper

### DIFF
--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Script originally written by Evan Callicoat
+#
+# Execute each command from stdin. If the command fails
+# output a sensible error message and include instructions
+# to allow the user to resume execution at the next step.
+
+# Set options
+set -euo pipefail
+
+# Initial step count
+STEP=0
+
+# Handle errors
+handle_error() {
+    # Store command that caused error
+    cmd="$BASH_COMMAND"
+
+    # If we didn't run any steps yet
+    if [[ $STEP -eq 0 ]]; then
+        echo "Error before running steps: $cmd"
+    # Otherwise inform how to resume
+    else
+        echo "******************** FAILURE ********************"
+        echo "Error executing step $STEP: $step"
+        echo "Please resume with: $0 $STEP"
+        echo "******************** FAILURE ********************"
+    fi
+}
+
+# Hook errors to handler
+trap handle_error ERR
+
+# Load up command steps from stdin
+readarray -t -O 1 STEPS
+
+# If no step arg specified
+if [[ $# -lt 1 ]]; then
+    # Start at step 1
+    start=1
+else
+    # Otherwise start at arg
+    start=$1
+
+    # Offset for counter ordering
+    STEP=$(($1-1))
+fi
+
+# Dispatch steps in order, from starting step
+for step in "${STEPS[@]:$start}"; do
+    # Bump step-counter
+    STEP=$((STEP+1))
+
+    # Talk about it
+    echo "Running step $STEP: $step"
+
+    # Do the needful
+    eval $step
+done

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -16,27 +16,12 @@
 # (c) 2015, Nolan Brubaker <nolan.brubaker@rackspace.com>
 set -eux -o pipefail
 
-FAILED=0
+export BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
+export OSAD_DIR="$BASE_DIR/os-ansible-deployment"
+export RPCD_DIR="$BASE_DIR/rpcd"
 
-function run_or_print() {
-        command="$@"
-        if [ $FAILED -ne 0 ]; then
-                echo "  ${command}"
-        else
-                eval "$command"
-                FAILED=$?
-                if [ $FAILED -ne 0 ]; then
-                    echo "******************** FAILURE ********************"
-                    echo "The upgrade script has failed. Please rerun the following task to continue"
-                    echo "Failed on task ${command}"
-                    echo "Do NOT rerun the upgrade script!"
-                    echo "Please execute the remaining tasks:"
-                fi
-        fi
-}
+./scripts/resume.sh < scripts/upgrade.steps
 
-BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
-OSAD_DIR="$BASE_DIR/os-ansible-deployment"
-RPCD_DIR="$BASE_DIR/rpcd"
-
-resume.sh < upgrade.steps
+unset BASE_DIR
+unset OSAD_DIR
+unset RPCD_DIR

--- a/scripts/upgrade.steps
+++ b/scripts/upgrade.steps
@@ -5,6 +5,6 @@ cd ${OSAD_DIR}
 ${OSAD_DIR}/scripts/run-upgrade.sh
 source ${OSAD_DIR}/scripts/scripts-library.sh
 cd ${BASE_DIR}
-${BASE_DIR}/scripts/deploy.sh
+DEPLOY_OSAD="no" ${BASE_DIR}/scripts/deploy.sh
 cd ${RPCD_DIR}/playbooks
 ansible hosts -m shell -a 'rm /root/.auth_ref.json'

--- a/scripts/upgrade.steps
+++ b/scripts/upgrade.steps
@@ -1,0 +1,10 @@
+cp ${RPCD_DIR}/etc/openstack_deploy/user_variables.yml /tmp/upgrade_user_variables.yml
+${BASE_DIR}/scripts/update-yaml.py /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
+mv /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
+cd ${OSAD_DIR}
+${OSAD_DIR}/scripts/run-upgrade.sh
+source ${OSAD_DIR}/scripts/scripts-library.sh
+cd ${BASE_DIR}
+${BASE_DIR}/scripts/deploy.sh
+cd ${RPCD_DIR}/playbooks
+ansible hosts -m shell -a 'rm /root/.auth_ref.json'


### PR DESCRIPTION
This update includes a wrapper script written by Evan which receives a list of commands to execute on stdin. If an error occurs while executing a step, the script informs the user and gives instructions for resuming.

Closes: #324
