### PR TITLE
Rename spice console check

### DIFF
--- a/maas/testing/tests/integration/maas_local
+++ b/maas/testing/tests/integration/maas_local
@@ -1175,7 +1175,7 @@
                 "timeout": 30,
                 "type": "agent.plugin"
             },
-            "nova_spice_console_check--CONTROLLER_nova_console_container-UID": {
+            "nova_console_check--CONTROLLER_nova_console_container-UID": {
                 "active_suppressions": [],
                 "alarms": {
                     "nova_spice_api_local_status--CONTROLLER_nova_console_container-UID": {

--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -291,7 +291,7 @@
 
 - include: local_setup.yml
   vars:
-    check_name: nova_spice_console_check
+    check_name: nova_console_check
     check_details: file=service_api_local_check.py,args=nova_spice,args={{ ansible_ssh_host }},args=6082,args=--path,args=spice_auto.html
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"


### PR DESCRIPTION
Fix name of maas check created through playbook and related tests to
reflect the general purpose rather than the technology choice used for
nova consoles.

Related to #326