### PR TITLE
backport of rcbops/rpc-openstack/pull/333

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -291,7 +291,7 @@
 
 - include: local_setup.yml
   vars:
-    check_name: nova_spice_console_check
+    check_name: nova_console_check
     check_details: file=service_api_local_check.py,args=nova_spice,args={{ ansible_ssh_host }},args=6082
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"


### PR DESCRIPTION
testing wasn't backported so wasn't a straight cherrypick.

Signed-off-by: Matthew Thode <mthode@mthode.org>