### PR TITLE
Add patcher role

### DIFF
--- a/rpcd/patches/glance_sha.patch
+++ b/rpcd/patches/glance_sha.patch
@@ -1,0 +1,27 @@
+From 86960c1708a9a231de80c1bcc3067f01c48a0ee9 Mon Sep 17 00:00:00 2001
+From: Jesse Pretorius <jesse.pretorius@rackspace.co.uk>
+Date: Fri, 14 Aug 2015 09:21:32 +0100
+Subject: [PATCH] Update glance for CVE-2015-5163
+
+This patch includes the upstream backport:
+ - https://review.openstack.org/212568
+
+Change-Id: Iaab3a9d1007ccae6d51942fe045e274b7a518e9f
+Closes-Bug: #1484766
+---
+ playbooks/defaults/repo_packages/openstack_services.yml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/playbooks/defaults/repo_packages/openstack_services.yml b/playbooks/defaults/repo_packages/openstack_services.yml
+index ad4e72c..bd458e9 100644
+--- a/playbooks/defaults/repo_packages/openstack_services.yml
++++ b/playbooks/defaults/repo_packages/openstack_services.yml
+@@ -42,7 +42,7 @@ cinder_git_dest: "/opt/cinder_{{ cinder_git_install_branch | replace('/', '_') }
+ 
+ ## Glance service
+ glance_git_repo: https://github.com/openstack/glance
+-glance_git_install_branch: 4f0c41df05f3ede4ae57753d0d034a790709293b # HEAD of "stable/kilo" as of 23.07.2015
++glance_git_install_branch: eb99e45829a1b4c93db5692bdbf636a86faa56c4 # HEAD of "stable/kilo" as of 13.08.2015
+ glance_git_dest: "/opt/glance_{{ glance_git_install_branch | replace('/', '_') }}"
+ 
+ 

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We're running this locally for a few reasons:
+#   1) This needs to happen pre-run of the ansible playbooks.
+#   2) Since it's a pre-run, the inventory won't necessarily be
+#      available or accurate
+- name: Patch OSAD files
+  hosts: 127.0.0.1
+  connection: local
+  gather_facts: No
+  user: root
+  roles:
+    - { role: "patcher", tags: [ "patcher" ] }

--- a/rpcd/playbooks/roles/patcher/defaults/main.yml
+++ b/rpcd/playbooks/roles/patcher/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The directory we want to apply patches to.
+patcher_dest_dir: "/opt/rpc-openstack/os-ansible-deployment"
+
+# The directory we want to apply patches from
+patcher_src_dir: "/opt/rpc-openstack/rpcd/patches"
+
+
+# The files we want to apply.
+patcher_files:
+  - glance_sha.patch
+  - httpd.patch

--- a/rpcd/playbooks/roles/patcher/meta/main.yml
+++ b/rpcd/playbooks/roles/patcher/meta/main.yml
@@ -1,0 +1,28 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: rcbops
+  description: OpenStack Ansible patcher
+  company: Rackspace
+  license: Apache2
+  min_ansible_version: 1.6.6
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+  categories:
+    - rackspace
+    - patching

--- a/rpcd/playbooks/roles/patcher/tasks/main.yml
+++ b/rpcd/playbooks/roles/patcher/tasks/main.yml
@@ -1,0 +1,22 @@
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Apply patch files
+  patch:
+    src: "{{ patcher_src_dir }}/{{ item }}"
+    basedir: "{{ patcher_dest_dir}}"
+    strip: 1
+  with_items: patcher_files
+  tags:
+    - apply-patches

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -50,6 +50,10 @@ which openstack-ansible || ./scripts/bootstrap-ansible.sh
 # ensure all needed passwords and tokens are generated
 ./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_extras_secrets.yml
 
+# Apply any patched files.
+cd ${RPCD_DIR}/playbooks
+openstack-ansible -i "localhost," patcher.yml
+
 # begin the openstack installation
 if [[ "${DEPLOY_OSAD}" == "yes" ]]; then
   cd ${OSAD_DIR}/playbooks/

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -26,6 +26,14 @@ cp ${RPCD_DIR}/etc/openstack_deploy/user_variables.yml /tmp/upgrade_user_variabl
 ${BASE_DIR}/scripts/update-yaml.py /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 mv /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 
+# Upgrade Ansible in-place so we have access to the patch module.
+cd ${OSAD_DIR}
+${OSAD_DIR}/scripts/bootstrap-ansible.sh
+
+# Apply any patched files.
+cd ${RPCD_DIR}/playbooks
+openstack-ansible -i "localhost," patcher.yml
+
 # Do the upgrade for os-ansible-deployment components
 cd ${OSAD_DIR}
 ${OSAD_DIR}/scripts/run-upgrade.sh


### PR DESCRIPTION
There may arise times where it is beneficial for the rpc-openstack
project to use a SHA unrlated to an os-ansible-deployment tag, but still
apply some patches to the os-ansible-deployment files.

This role will patch files in the os-ansible-deployment submodule of
rpc-openstack. It does so prior to an actual deployment of the stack,
and thus must use the local machine, not one from Ansible's inventory.

Also, when run during upgrades, Ansible in Juno doesn't have the
'patch' module, so we upgrade that prior.

This initial version includes a patch incorporating the following fixes
from upstream:

    https://review.openstack.org/#/c/212021/

Addresses #344