### PR TITLE
Add patcher role

### DIFF
--- a/rpcd/patches/keystone-httpd-lp-bug-1481339.patch
+++ b/rpcd/patches/keystone-httpd-lp-bug-1481339.patch
@@ -1,0 +1,89 @@
+--- a/playbooks/roles/os_keystone/defaults/main.yml
++++ b/playbooks/roles/os_keystone/defaults/main.yml
+@@ -124,6 +124,8 @@ keystone_service_adminurl: "{{ keystone_service_adminurl_v3 }}"
+ 
+ ## Apache setup
+ keystone_apache_log_level: info
++keystone_wsgi_threads: "{{ ansible_processor_vcpus | default(2) // 2 }}"
++keystone_wsgi_processes: "{{ ansible_processor_vcpus | default(1) }}"
+ 
+ keystone_ssl_enabled: false
+ keystone_ssl_cert_path: /etc/ssl/certs
+--- a/playbooks/roles/os_keystone/templates/keystone-httpd.conf.j2	2015-08-14 20:26:08.660413962 +0000
++++ b/playbooks/roles/os_keystone/templates/keystone-httpd.conf.j2	2015-08-14 21:08:13.036642173 +0000
+@@ -1,10 +1,16 @@
+ # {{ ansible_managed }}
+ 
+-{% set threads = ansible_processor_vcpus|default(2) // 2 %}
+-
+-WSGIDaemonProcess keystone user={{ keystone_system_user_name }} group=nogroup processes={{ ansible_processor_cores|default(1) }} threads={{ threads if threads > 0 else 1 }}
+-
+ <VirtualHost *:{{ keystone_service_port }}>
++    WSGIDaemonProcess     keystone-service user={{ keystone_system_user_name }} group={{ keystone_system_group_name }} processes={{ keystone_wsgi_processes }} threads={{ keystone_wsgi_threads }} display-name=%{GROUP}
++    WSGIProcessGroup      keystone-service
++    WSGIScriptAlias       / /var/www/cgi-bin/keystone/main
++    WSGIApplicationGroup  %{GLOBAL}
++    WSGIPassAuthorization On
++
++    <IfVersion >= 2.4>
++      ErrorLogFormat "%{cu}t %M"
++    </IfVersion>
++
+     LogLevel  {{  keystone_apache_log_level }}
+     ErrorLog  /var/log/keystone/keystone-apache-error.log
+     CustomLog /var/log/keystone/ssl_access.log combined
+@@ -25,11 +31,44 @@
+     SSLOptions +StdEnvVars +ExportCertData
+     {% endif %}
+ 
+-    WSGIScriptAlias /  /var/www/cgi-bin/keystone/main
+-    WSGIProcessGroup keystone
++    {% if keystone_sp is defined -%}
++    ShibURLScheme {{ keystone_service_publicuri_proto }}
++
++    <Location /Shibboleth.sso>
++        SetHandler shib
++    </Location>
++
++    <Location /v3/auth/OS-FEDERATION/websso/saml2>
++        AuthType shibboleth
++        ShibRequestSetting requireSession 1
++        ShibRequestSetting exportAssertion 1
++        ShibRequireSession On
++        ShibExportAssertion On
++        Require valid-user
++    </Location>
++
++    <LocationMatch /v3/OS-FEDERATION/identity_providers/.*?/protocols/saml2/auth>
++        ShibRequestSetting requireSession 1
++        AuthType shibboleth
++        ShibExportAssertion Off
++        Require valid-user
++    </LocationMatch>
++
++    WSGIScriptAliasMatch ^(/v3/OS-FEDERATION/identity_providers/.*?/protocols/.*?/auth)$ /var/www/cgi-bin/keystone/main/$1
++    {%- endif %}
+ </VirtualHost>
+ 
+ <VirtualHost *:{{ keystone_admin_port }}>
++    WSGIDaemonProcess     keystone-admin user={{ keystone_system_user_name }} group={{ keystone_system_group_name }} processes={{ keystone_wsgi_processes }} threads={{ keystone_wsgi_threads }} display-name=%{GROUP}
++    WSGIProcessGroup      keystone-admin
++    WSGIScriptAlias       / /var/www/cgi-bin/keystone/admin
++    WSGIApplicationGroup  %{GLOBAL}
++    WSGIPassAuthorization On
++
++    <IfVersion >= 2.4>
++      ErrorLogFormat "%{cu}t %M"
++    </IfVersion>
++
+     LogLevel  {{  keystone_apache_log_level }}
+     ErrorLog  /var/log/keystone/keystone-apache-error.log
+     CustomLog /var/log/keystone/ssl_access.log combined
+@@ -49,7 +88,4 @@
+     SSLCipherSuite {{ keystone_ssl_cipher_suite }}
+     SSLOptions +StdEnvVars +ExportCertData
+     {% endif %}
+-
+-    WSGIScriptAlias / /var/www/cgi-bin/keystone/admin
+-    WSGIProcessGroup keystone
+ </VirtualHost>

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We're running this locally for a few reasons:
+#   1) This needs to happen pre-run of the ansible playbooks.
+#   2) Since it's a pre-run, the inventory won't necessarily be
+#      available or accurate
+- name: Patch OSAD files
+  hosts: 127.0.0.1
+  connection: local
+  gather_facts: No
+  user: root
+  roles:
+    - { role: "patcher", tags: [ "patcher" ] }

--- a/rpcd/playbooks/roles/patcher/defaults/main.yml
+++ b/rpcd/playbooks/roles/patcher/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The directory we want to apply patches to.
+patcher_dest_dir: "/opt/rpc-openstack/os-ansible-deployment"
+
+# The directory we want to apply patches from
+patcher_src_dir: "/opt/rpc-openstack/rpcd/patches"
+
+
+# The files we want to apply.
+patcher_files:
+  - keystone-httpd-lp-bug-1481339.patch

--- a/rpcd/playbooks/roles/patcher/meta/main.yml
+++ b/rpcd/playbooks/roles/patcher/meta/main.yml
@@ -1,0 +1,28 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: rcbops
+  description: OpenStack Ansible patcher
+  company: Rackspace
+  license: Apache2
+  min_ansible_version: 1.6.6
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+  categories:
+    - rackspace
+    - patching

--- a/rpcd/playbooks/roles/patcher/tasks/main.yml
+++ b/rpcd/playbooks/roles/patcher/tasks/main.yml
@@ -1,0 +1,22 @@
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Apply patch files
+  patch:
+    src: "{{ patcher_src_dir }}/{{ item }}"
+    basedir: "{{ patcher_dest_dir}}"
+    strip: 1
+  with_items: patcher_files
+  tags:
+    - apply-patches

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,6 +49,10 @@ which openstack-ansible || ./scripts/bootstrap-ansible.sh
 # ensure all needed passwords and tokens are generated
 ./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_extras_secrets.yml
 
+# Apply any patched files.
+cd ${RPCD_DIR}/playbooks
+openstack-ansible -i "localhost," patcher.yml
+
 # begin the openstack installation
 if [[ "${DEPLOY_OSAD}" == "yes" ]]; then
   cd ${OSAD_DIR}/playbooks/

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -26,6 +26,14 @@ cp ${RPCD_DIR}/etc/openstack_deploy/user_variables.yml /tmp/upgrade_user_variabl
 ${BASE_DIR}/scripts/update-yaml.py /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 mv /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 
+# Upgrade Ansible in-place so we have access to the patch module.
+cd ${OSAD_DIR}
+${OSAD_DIR}/scripts/bootstrap-ansible.sh
+
+# Apply any patched files.
+cd ${RPCD_DIR}/playbooks
+openstack-ansible -i "localhost," patcher.yml
+
 # Do the upgrade for os-ansible-deployment components
 cd ${OSAD_DIR}
 ${OSAD_DIR}/scripts/run-upgrade.sh


### PR DESCRIPTION
There may arise times where it is beneficial for the rpc-openstack
project to use a SHA unrlated to an os-ansible-deployment tag, but still
apply some patches to the os-ansible-deployment files.

This role will patch files in the os-ansible-deployment submodule of
rpc-openstack. It does so prior to an actual deployment of the stack,
and thus must use the local machine, not one from Ansible's inventory.

Also, when run during upgrades, Ansible in Juno doesn't have the
'patch' module, so we upgrade that prior.

The first patch included is functionally equivalent to this upstream
change:
    https://review.openstack.org/#/c/212021/

Address #344
(cherry picked from commit 10a30f7ca8bd331ddc55e31cbc21947ad94cb3e5)