### PR TITLE
Fix MaaS testing

### DIFF
--- a/maas/testing/fake_hp_monitoring.py
+++ b/maas/testing/fake_hp_monitoring.py
@@ -22,7 +22,9 @@ if args == ['-s', 'show server']:
 elif args == ['-s', 'show dimm']:
     print('Status Ok')
 elif args == ['ctrl', 'all', 'show', 'config']:
-    print('logicaldrive OK')
+    print('logicaldrive OK)')
+elif args == ['ctrl', 'all', 'show', 'status']:
+    print('Controller Status OK\nCache Status OK\nBattery/Capacitor Status OK')
 else:
     sys.exit('fake_hp_monitoring.py has received the following '
              'unexpected arguments - "%s".' % str(args))

--- a/maas/testing/tests/integration/maas_hp_hardware
+++ b/maas/testing/tests/integration/maas_hp_hardware
@@ -34,6 +34,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -77,6 +89,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -119,6 +143,18 @@
                     },
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
                         "unit": "unknown"
                     }
                 },
@@ -181,6 +217,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -224,6 +272,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -266,6 +326,18 @@
                     },
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
                         "unit": "unknown"
                     }
                 },
@@ -328,6 +400,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -371,6 +455,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -413,6 +509,18 @@
                     },
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
                         "unit": "unknown"
                     }
                 },
@@ -492,6 +600,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -535,6 +655,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -577,6 +709,18 @@
                     },
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
                         "unit": "unknown"
                     }
                 },
@@ -639,6 +783,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -682,6 +838,18 @@
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
                         "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
+                        "unit": "unknown"
                     }
                 },
                 "monitoring_zones_poll": null,
@@ -724,6 +892,18 @@
                     },
                     "hardware_processors_status": {
                         "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_battery_status": {
+                        "name": "hardware_controller_battery_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_cache_status": {
+                        "name": "hardware_controller_cache_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_controller_status": {
+                        "name": "hardware_controller_status",
                         "unit": "unknown"
                     }
                 },

--- a/maas/testing/tests/integration/maas_local
+++ b/maas/testing/tests/integration/maas_local
@@ -1259,7 +1259,11 @@
                         "-H",
                         "IP_ADDRESS",
                         "-n",
-                        "CONTROLLER_rabbit_mq_container-UID"
+                        "CONTROLLER_rabbit_mq_container-UID",
+                        "-U",
+                        "maas_user",
+                        "-p",
+                        "PASSWORD"
                     ],
                     "file": "rabbitmq_status.py"
                 },
@@ -1678,6 +1682,44 @@
                     },
                     "neutron-metering-agent_status": {
                         "name": "neutron-metering-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_metadata_agent_proxy_check--CONTROLLER_neutron_agents_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_metadata_agent_proxy_status--CONTROLLER_neutron_agents_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-metadata-agent-proxy_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-metadata-agent-proxy non-responsive\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_metadata_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-metadata-agent-proxy_status": {
+                        "name": "neutron-metadata-agent-proxy_status",
                         "unit": "unknown"
                     }
                 },

--- a/rpcd/playbooks/test-maas.yml
+++ b/rpcd/playbooks/test-maas.yml
@@ -21,6 +21,7 @@
         dest: /usr/local/bin/hpasmcli
         mode: 0755
       tags:
+        - setup
         - setup-fake-hp
 
     - name: Create fake hpssacli
@@ -29,6 +30,7 @@
         dest: /usr/local/bin/hpssacli
         mode: 0755
       tags:
+        - setup
         - setup-fake-hp
 
     # This attempts to work around the frequent memory errors with the agent
@@ -48,6 +50,7 @@
     - pip: name=virtualenv
       tags:
         - setup
+        - setup-venv
 
     - name: Create virtualenv
       pip:
@@ -57,6 +60,14 @@
         virtualenv: /opt/rpc-openstack/maas/testing/venv
       tags:
         - setup
+        - setup-venv
+
+    - command: "./venv/bin/python /opt/rpc-openstack/scripts/rpc-maas-tool.py delete --entities {{ groups.hosts | join(' ') }} --force --username {{ rackspace_cloud_username }} --api_key {{ rackspace_cloud_api_key }}"
+      args:
+        chdir: /opt/rpc-openstack/maas/testing
+      tags:
+        - setup
+        - setup-delete-existing-checks
 
     - name: Generate MaaS definitions file
       shell: "export OS_USERNAME={{ rackspace_cloud_username }}; export OS_PASSWORD={{ rackspace_cloud_api_key }}; export OS_REGION_NAME=LON; ./venv/bin/python generate-definitions.py heat_multi_node {{ groups['hosts'] | join(' ') }}  --raw_output"


### PR DESCRIPTION
Rackspace Cloud have made two recent changes that break the testing:
  1. Rackspace Cloud servers automatically get a ping check created
  2. MaaS remote checks have a new attribute called collectors

Currently the MaaS testing does not form part of a gate, a recent update
to a RabbitMQ check has not been reflected in the appropriate test file.

This commit addresses the aforementioned issues.

The test-maas.yml playbook will delete any existing checks from the
entities.

The collectors attribute will be removed because it does not need
verifying.

The generate-definitions.py script has been updated to allow specific
attributes to be templated. This is required to allow a password in the
RabbitMQ check to be replaced.

Closes-Issue: https://github.com/rcbops/rpc-openstack/issues/351

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rcbops/rpc-openstack/352)
<!-- Reviewable:end -->
