### PR TITLE
Disable prompt on run-upgrade.sh

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -36,7 +36,7 @@ openstack-ansible -i "localhost," patcher.yml
 
 # Do the upgrade for os-ansible-deployment components
 cd ${OSAD_DIR}
-${OSAD_DIR}/scripts/run-upgrade.sh
+echo 'YES' > ${OSAD_DIR}/scripts/run-upgrade.sh
 
 # Prevent the deployment script from re-running the OSAD playbooks
 export DEPLOY_OSAD="no"


### PR DESCRIPTION
This change makes the script uninterrupted (in the happy path case), so
that users don't have to enter input during the process.

(cherry picked from commit e58b261af9160a0b0cadb6be978ae37f17e03a16)