### PR TITLE
Change output redirect to pipe

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -36,7 +36,7 @@ openstack-ansible -i "localhost," patcher.yml
 
 # Do the upgrade for os-ansible-deployment components
 cd ${OSAD_DIR}
-echo 'YES' > ${OSAD_DIR}/scripts/run-upgrade.sh
+echo 'YES' | ${OSAD_DIR}/scripts/run-upgrade.sh
 
 # Prevent the deployment script from re-running the OSAD playbooks
 export DEPLOY_OSAD="no"


### PR DESCRIPTION
The output redirect will overwrite the run-upgrade script, which is not
what we want. This change properly sends the output to the stdin.

Addresses #360