### PR TITLE
Add patch for container configurations

### DIFF
--- a/rpcd/patches/lxc-container-config-lp-bug-1487130.patch
+++ b/rpcd/patches/lxc-container-config-lp-bug-1487130.patch
@@ -1,0 +1,551 @@
+diff --git c/playbooks/galera-install.yml w/playbooks/galera-install.yml
+index 77958f8..c8a74e3 100644
+--- c/playbooks/galera-install.yml
++++ w/playbooks/galera-install.yml
+@@ -67,6 +67,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Galera extra lxc config
+       lxc_container:
+         name: "{{ container_name }}"
+@@ -75,7 +84,7 @@
+         container_config:
+           - "lxc.mount.entry=/openstack/{{ container_name }} var/lib/mysql none bind 0 0"
+       delegate_to: "{{ physical_host }}"
+-      when: is_metal == false or is_metal == "False"
++      when: not is_metal | bool
+       tags:
+         - galera-mysql-dir
+     - name: Flush net cache
+diff --git c/playbooks/memcached-install.yml w/playbooks/memcached-install.yml
+index f0b51b4..1140da1 100644
+--- c/playbooks/memcached-install.yml
++++ w/playbooks/memcached-install.yml
+@@ -17,6 +17,16 @@
+   hosts: memcached
+   max_fail_percentage: 20
+   user: root
++  pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+   roles:
+     - { role: "memcached_server", tags: [ "memcached-server" ] }
+     - role: "system_crontab_coordination"
+diff --git c/playbooks/os-ceilometer-install.yml w/playbooks/os-ceilometer-install.yml
+index 7fb4a6c..6e06ffc 100644
+--- c/playbooks/os-ceilometer-install.yml
++++ w/playbooks/os-ceilometer-install.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Flush net cache
+       command: /usr/local/bin/lxc-system-manage flush-net-cache
+       delegate_to: "{{ physical_host }}"
+@@ -46,7 +55,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-ceilometer" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - ceilometer-logs
+         - ceilometer-log-dirs
+@@ -58,7 +67,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-ceilometer", dest: "/var/log/ceilometer", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - ceilometer-logs
+   roles:
+diff --git c/playbooks/os-cinder-install.yml w/playbooks/os-cinder-install.yml
+index a05040b..76bd4cc 100644
+--- c/playbooks/os-cinder-install.yml
++++ w/playbooks/os-cinder-install.yml
+@@ -18,6 +18,17 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=unconfined"
++      delegate_to: "{{ physical_host }}"
++      when: >
++        not is_metal | bool and
++        inventory_hostname in groups['cinder_volume']
++      tags:
++        - lxc-aa-profile
+     - name: Add volume group block device to cinder
+       shell: |
+         {% if item.1.volume_group is defined %}
+@@ -36,25 +47,18 @@
+       delegate_to: "{{ physical_host }}"
+       tags:
+         - cinder-lxc-devices
+-    - name: Cinder extra lxc config
+-      lxc_container:
+-        name: "{{ container_name }}"
+-        container_config:
+-          - "lxc.aa_profile=unconfined"
+-          - "lxc.cgroup.devices.allow=a *:* rmw"
+-      delegate_to: "{{ physical_host }}"
+-      when: (is_metal == false or is_metal == "False") and inventory_hostname not in groups['cinder_volume']
+-      tags:
+-        - cinder-container-setup
+     - name: Cinder volume extra lxc config
+       lxc_container:
+         name: "{{ container_name }}"
+         container_config:
+-          - "lxc.aa_profile=unconfined"
++          - "lxc.autodev=0"
+           - "lxc.cgroup.devices.allow=a *:* rmw"
+           - "lxc.mount.entry = udev dev devtmpfs defaults 0 0"
+       delegate_to: "{{ physical_host }}"
+-      when: (is_metal == false or is_metal == "False") and inventory_hostname in groups['cinder_volume']
++      when: >
++        not is_metal | bool and
++        inventory_hostname in groups['cinder_volume'] and
++        cinder_backend_lvm_inuse
+       tags:
+         - cinder-container-setup
+       register: lxc_config
+@@ -92,7 +96,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-cinder" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - cinder-logs
+         - cinder-log-dirs
+@@ -104,7 +108,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-cinder", dest: "/var/log/cinder", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - cinder-logs
+   roles:
+diff --git c/playbooks/os-glance-install.yml w/playbooks/os-glance-install.yml
+index 226d442..ceb5244 100644
+--- c/playbooks/os-glance-install.yml
++++ w/playbooks/os-glance-install.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Glance extra lxc config
+       lxc_container:
+         name: "{{ container_name }}"
+@@ -26,7 +35,7 @@
+         container_config:
+           - "lxc.mount.entry=/openstack/{{ container_name }} var/lib/glance/images none bind 0 0"
+       delegate_to: "{{ physical_host }}"
+-      when: is_metal == false or is_metal == "False"
++      when: not is_metal | bool
+       tags:
+         - glance-cache-dir
+     - name: Flush net cache
+@@ -57,7 +66,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-glance" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - glance-logs
+         - glance-log-dirs
+@@ -69,7 +78,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-glance", dest: "/var/log/glance", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - glance-logs
+   roles:
+diff --git c/playbooks/os-heat-install.yml w/playbooks/os-heat-install.yml
+index 641be0e..ec3f3da 100644
+--- c/playbooks/os-heat-install.yml
++++ w/playbooks/os-heat-install.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Sort the rabbitmq servers
+       dist_sort:
+         value_to_lookup: "{{ container_name }}"
+@@ -33,7 +42,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-heat" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - heat-logs
+         - heat-log-dirs
+@@ -45,7 +54,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-heat", dest: "/var/log/heat", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - heat-logs
+   roles:
+diff --git c/playbooks/os-horizon-install.yml w/playbooks/os-horizon-install.yml
+index 295c9af..da71cd2 100644
+--- c/playbooks/os-horizon-install.yml
++++ w/playbooks/os-horizon-install.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Sort the rabbitmq servers
+       dist_sort:
+         value_to_lookup: "{{ container_name }}"
+@@ -33,7 +42,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-horizon" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - horizon-logs
+         - horizon-log-dirs
+@@ -45,7 +54,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-horizon", dest: "/var/log/horizon", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - horizon-logs
+   roles:
+diff --git c/playbooks/os-keystone-install.yml w/playbooks/os-keystone-install.yml
+index 3911dab..2392570 100644
+--- c/playbooks/os-keystone-install.yml
++++ w/playbooks/os-keystone-install.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Sort the rabbitmq servers
+       dist_sort:
+         value_to_lookup: "{{ container_name }}"
+@@ -33,7 +42,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-keystone" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - keystone-logs
+         - keystone-log-dirs
+@@ -45,7 +54,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-keystone", dest: "/var/log/keystone", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - keystone-logs
+   roles:
+diff --git c/playbooks/os-neutron-install.yml w/playbooks/os-neutron-install.yml
+index 503ff4a..b1712fc 100644
+--- c/playbooks/os-neutron-install.yml
++++ w/playbooks/os-neutron-install.yml
+@@ -18,17 +18,29 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=unconfined"
++      delegate_to: "{{ physical_host }}"
++      when: >
++        not is_metal | bool and
++        inventory_hostname in groups['neutron_agent']
++      tags:
++        - lxc-aa-profile
+     - name: Neutron extra lxc config
+       lxc_container:
+         name: "{{ container_name }}"
+         container_command: |
+           [[ ! -d "/lib/modules" ]] && mkdir -p "/lib/modules"
+         container_config:
+-          - "lxc.aa_profile=unconfined"
+           - "lxc.cgroup.devices.allow=a *:* rmw"
+           - "lxc.mount.entry=/lib/modules lib/modules none bind 0 0"
+       delegate_to: "{{ physical_host }}"
+-      when: is_metal == false or is_metal == "False"
++      when: >
++        not is_metal | bool and
++        inventory_hostname in groups['neutron_agent']
+       tags:
+         - neutron-container-setup
+     - name: Flush net cache
+@@ -59,7 +71,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-neutron" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - neutron-logs
+         - neutron-log-dirs
+@@ -71,7 +83,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-neutron", dest: "/var/log/neutron", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - neutron-logs
+     - name: Create the neutron provider networks facts
+diff --git c/playbooks/os-nova-install.yml w/playbooks/os-nova-install.yml
+index 0deb1b6..7b605d7 100644
+--- c/playbooks/os-nova-install.yml
++++ w/playbooks/os-nova-install.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Sort the rabbitmq servers
+       dist_sort:
+         value_to_lookup: "{{ container_name }}"
+@@ -49,7 +58,7 @@
+       delegate_to: "{{ physical_host }}"
+       when: >
+         inventory_hostname in groups['nova_compute'] and
+-        (is_metal == false or is_metal == "False")
++        not is_metal | bool
+       tags:
+         - nova-kvm
+         - nova-kvm-container-devices
+@@ -63,7 +72,7 @@
+         'added' in device_add.stdout.lower()
+       when: >
+         inventory_hostname in groups['nova_compute'] and
+-        (is_metal == false or is_metal == "False") and
++        not is_metal | bool and
+         nova_virt_type == 'kvm'
+       tags:
+         - nova-kvm
+@@ -74,7 +83,7 @@
+         state: directory
+       with_items:
+         - { path: "/openstack/log/{{ inventory_hostname }}-nova" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - nova-logs
+         - nova-log-dirs
+@@ -86,7 +95,7 @@
+         force: "yes"
+       with_items:
+         - { src: "/openstack/log/{{ inventory_hostname }}-nova", dest: "/var/log/nova", state: "link" }
+-      when: is_metal == true or is_metal == "True"
++      when: is_metal | bool
+       tags:
+         - nova-logs
+   roles:
+diff --git c/playbooks/rabbitmq-install.yml w/playbooks/rabbitmq-install.yml
+index c8370e5..45adad9 100644
+--- c/playbooks/rabbitmq-install.yml
++++ w/playbooks/rabbitmq-install.yml
+@@ -17,6 +17,16 @@
+   hosts: rabbitmq_all
+   max_fail_percentage: 0
+   user: root
++  pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+   roles:
+     - role: "rabbitmq_server"
+       tags:
+diff --git c/playbooks/repo-server.yml w/playbooks/repo-server.yml
+index 34acb6a..20e49d9 100644
+--- c/playbooks/repo-server.yml
++++ w/playbooks/repo-server.yml
+@@ -18,6 +18,15 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Package repo extra lxc config
+       lxc_container:
+         name: "{{ container_name }}"
+@@ -26,7 +35,7 @@
+         container_config:
+           - "lxc.mount.entry=/openstack/{{ container_name }} var/www none bind 0 0"
+       delegate_to: "{{ physical_host }}"
+-      when: is_metal == false or is_metal == "False"
++      when: not is_metal | bool
+       tags:
+         - repo-dirs
+     - name: Flush net cache
+diff --git c/playbooks/roles/lxc_container_create/tasks/container_create.yml w/playbooks/roles/lxc_container_create/tasks/container_create.yml
+index b5ab225..e30c699 100644
+--- c/playbooks/roles/lxc_container_create/tasks/container_create.yml
++++ w/playbooks/roles/lxc_container_create/tasks/container_create.yml
+@@ -76,8 +76,7 @@
+       mkdir -p /var/log/{{ properties.service_name }}
+     container_config:
+       - "lxc.mount.entry=/openstack/backup/{{ inventory_hostname }} var/backup none defaults,bind,rw 0 0"
+-      - "lxc.mount.entry=/openstack/log/{{ inventory_hostname }} var/log/{{ properties.service_name }} none defaults,bind,rw 0 0"
+-      - "lxc.aa_profile=lxc-openstack"
++      - "lxc.mount.entry=/openstack/log/{{ inventory_hostname }} var/log/{{ properties.log_directory | default(properties.service_name) }} none defaults,bind,rw 0 0"
+   when: properties.service_name is defined
+   delegate_to: "{{ physical_host }}"
+   tags:
+diff --git c/playbooks/rsyslog-install.yml w/playbooks/rsyslog-install.yml
+index 0a51d52..29d1520 100644
+--- c/playbooks/rsyslog-install.yml
++++ w/playbooks/rsyslog-install.yml
+@@ -18,12 +18,21 @@
+   max_fail_percentage: 20
+   user: root
+   pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+     - name: Ensure log stroage directory exists
+       file:
+         path: "/openstack/{{ container_name }}/log-storage"
+         state: "directory"
+       delegate_to: "{{ physical_host }}"
+-      when: is_metal == false or is_metal == "False"
++      when: not is_metal | bool
+       tags:
+         - rsyslog-storage-dirs
+     - name: Rsyslog server extra lxc config
+@@ -34,7 +43,7 @@
+         container_config:
+           - "lxc.mount.entry=/openstack/{{ container_name }}/log-storage {{ storage_directory.lstrip('/') }} none bind 0 0"
+       delegate_to: "{{ physical_host }}"
+-      when: is_metal == false or is_metal == "False"
++      when: not is_metal | bool
+       tags:
+         - rsyslog-storage-dirs
+     - name: Flush net cache
+diff --git c/playbooks/utility-install.yml w/playbooks/utility-install.yml
+index 53555a2..c160d89 100644
+--- c/playbooks/utility-install.yml
++++ w/playbooks/utility-install.yml
+@@ -17,6 +17,16 @@
+   hosts: utility_all
+   max_fail_percentage: 20
+   user: root
++  pre_tasks:
++    - name: Use the lxc-openstack aa profile
++      lxc_container:
++        name: "{{ container_name }}"
++        container_config:
++          - "lxc.aa_profile=lxc-openstack"
++      delegate_to: "{{ physical_host }}"
++      when: not is_metal | bool
++      tags:
++        - lxc-aa-profile
+   roles:
+     - { role: "galera_client", tags: [ "utility-galera-client" ] }
+     - { role: "pip_lock_down", tags: [ "utility-pip-lock-down" ] }

--- a/rpcd/playbooks/roles/patcher/defaults/main.yml
+++ b/rpcd/playbooks/roles/patcher/defaults/main.yml
@@ -23,3 +23,4 @@ patcher_src_dir: "/opt/rpc-openstack/rpcd/patches"
 # The files we want to apply.
 patcher_files:
   - keystone-httpd-lp-bug-1481339.patch
+  - lxc-container-config-lp-bug-1487130.patch


### PR DESCRIPTION
This is a patch for the upstream bug
https://bugs.launchpad.net/openstack-ansible/+bug/1487130.

It is included here in order to have it available more quickly for
rpc-openstack. There were conflicting hunks removed from
os-cinder-install.yml, os-glance-install.yml, and os-nova-install.yml
since they were only style changes, but were problematic to apply via
`patch`.

In terms of impact, this change moves the container configuration to
each service's installation. This way, the container is not brought down
early on in the upgrade process and left to sit until late. The
interruption window is far shorter in this way.

(cherry picked from commit 14aefd38406214b4dde69ecc93605b16de5aa221)