### PR TITLE
Fixes formatting causing duplicate config entry

### DIFF
--- a/rpcd/patches/lxc-container-config-lp-bug-1487130.patch
+++ b/rpcd/patches/lxc-container-config-lp-bug-1487130.patch
@@ -145,8 +145,7 @@ index a05040b..92b8f38 100644
 -          - "lxc.aa_profile=unconfined"
 +          - "lxc.autodev=0"
            - "lxc.cgroup.devices.allow=a *:* rmw"
--          - "lxc.mount.entry = udev dev devtmpfs defaults 0 0"
-+          - "lxc.mount.entry=udev dev devtmpfs defaults 0 0"
+           - "lxc.mount.entry = udev dev devtmpfs defaults 0 0"
        delegate_to: "{{ physical_host }}"
 -      when: (is_metal == false or is_metal == "False") and inventory_hostname in groups['cinder_volume']
 +      when: >


### PR DESCRIPTION
The update to the formatting around the = sign was causing duplicate
entries in the lxc container config which causes containers to not
restart on upgrade.

Addresses #383