### PR TITLE
Set filter_plugins in ansible.cfg

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -30,5 +30,13 @@ roles_path = ../../openstack-ansible/playbooks/roles/
 # lookup plugins required
 lookup_plugins = ../../openstack-ansible/playbooks/plugins/lookups/
 
+# Set the path to the folder in openstack-ansible which holds the filter
+# plugins required
+filter_plugins = ../../openstack-ansible/playbooks/plugins/filters/
+
+# Set the path to the folder in openstack-ansible which holds the action
+# plugins required
+action_plugins = ../../openstack-ansible/playbooks/plugins/actions/
+
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
os-ansible-deployment's pip roles make use of a custom ansible filter.
This commit sets filter_plugins in ansible.cfg accordingly so that
custom filters can be found.

Closes issue #389