### PR TITLE
Update openstack-ansible name references.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "os-ansible-deployment"]
-	path = os-ansible-deployment
-	url = https://git.openstack.org/stackforge/os-ansible-deployment
+[submodule "openstack-ansible"]
+	path = openstack-ansible
+	url = https://git.openstack.org/openstack/openstack-ansible

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # rpc-openstack
 Optional add-ons for Rackspace Private Cloud
 
-# os-ansible-deployment integration
+# openstack-ansible integration
 
 The rpc-openstack repo includes add-ons for the Rackspace Private Cloud product
 that integrate with the 
-[os-ansible-deployment](https://github.com/stackforge/os-ansible-deployment)
+[openstack-ansible](https://github.com/openstack/openstack-ansible)
 set of Ansible playbooks and roles.
 These add-ons extend the 'vanilla' OpenStack environment with value-added
 features that Rackspace has found useful, but are not core to deploying an
@@ -17,14 +17,14 @@ In Juno, the MaaS plugins code is contained in a separate repo,
 [rpc-maas](https://github.com/rcbops/rpc-maas), and the Ansible code to deploy
 and configure the checks and alarms using these plugins is contained in tree
 with the
-[os-ansible-deployment](http://git.openstack.org/cgit/stackforge/os-ansible-deployment/tree/?h=juno)
+[openstack-ansible](http://git.openstack.org/cgit/openstack/openstack-ansible/tree/?h=juno)
 repo with the Juno branch.
 
 As of Kilo, both the Maas plugins, and the Ansible code to deploy and
 configure the checks and alarms, are contained in the
 [rpc-openstack](https://github.com/rcbops/rpc-openstack) repo.
 
-The Kilo branch of os-ansible-deployment does not include any rpc-maas
+The Kilo branch of openstack-ansible does not include any rpc-maas
 support directly any longer.
 
 # Ansible Playbooks
@@ -40,7 +40,7 @@ Heat templates for commonly deployed applications.
 * `kibana.yml` - Setup Kibana on the Kibana hosts for the logging dashboard.
 * `logstash.yml` - deploys a logstash host. If this play is used, be sure to
 uncomment the related block in user_extra_variables.yml before this play is
-run and then rerun the appropriate plays in os-ansible-deployment after this
+run and then rerun the appropriate plays in openstack-ansible after this
 play to ensure that rsyslog ships logs to logstash. See steps 11 - 13 below
 for more.
 * `repo-build.yml` - scans throug the YAML files in the source tree and builds
@@ -64,9 +64,9 @@ above.
 
 1. Clone the RPC repository:
    `cd /opt && git clone --recursive https://github.com/rcbops/rpc-openstack`
-2. Unless doing an AIO build, prepare the os-ansible-deployment configuration.
+2. Unless doing an AIO build, prepare the openstack-ansible configuration.
   1. recursively copy the openstack-ansible-deployment configuration files:
-     `cp -R os-ansible-deployment/etc/openstack_deploy /etc/openstack_deploy`
+     `cp -R openstack-ansible/etc/openstack_deploy /etc/openstack_deploy`
   2. merge /etc/openstack_deploy/user_variables.yml with rpcd/etc/openstack_deploy/user_variables.yml:
 
      ```
@@ -93,7 +93,7 @@ above.
 
 # Upgrading
 
-To run an upgrade of an existing os-ansible-deployment installation:
+To run an upgrade of an existing openstack-ansible installation:
 
 1. Run`scripts/upgrade.sh`.
 

--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -33,8 +33,8 @@ maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_notification_plan: npManaged
 
-# Where is the os-ansible deployment repo?
-rpc_repo_path: /opt/rpc-openstack/os-ansible-deployment
+# Where is the openstack-ansible repo?
+rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
 # By default we will create an agent token for each entity, however if you'd
 # prefer to use the same agent token for all entities then specify it here
@@ -85,7 +85,7 @@ maas_filesystem_critical_threshold: 90.0
 
 # Enumerate any apt packages that the deployer would like to pin to a particular version.
 #
-# This relies on the apt_package_pinning role from os-ansible-deployment.
+# This relies on the apt_package_pinning role from openstack-ansible.
 #
 # Pinning happens in the 'apt_pinned_packages' variable.
 #

--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -10,25 +10,25 @@ forks = 15
 # SSH timeout
 timeout = 120
 
-# Set the path to the folder in os-ansible-deployment which holds the dynamic
+# Set the path to the folder in openstack-ansible which holds the dynamic
 # inventory script - new config setting for ansible v1.9 and above
-inventory = ../../os-ansible-deployment/playbooks/inventory/
+inventory = ../../openstack-ansible/playbooks/inventory/
 
-# Set the path to the folder in os-ansible-deployment which holds the dynamic
+# Set the path to the folder in openstack-ansible which holds the dynamic
 # inventory script - uncomment if using ansible below v1.9
-#hostfile = ../../os-ansible-deployment/playbooks/inventory/
+#hostfile = ../../openstack-ansible/playbooks/inventory/
 
-# Set the path to the folder in os-ansible-deployment which holds the
+# Set the path to the folder in openstack-ansible which holds the
 # libraries required
-library = ../../os-ansible-deployment/playbooks/library/
+library = ../../openstack-ansible/playbooks/library/
 
-# Set the path to the folder in os-ansible-deployment which holds the roles
+# Set the path to the folder in openstack-ansible which holds the roles
 # that are depended on by the rpc-openstack roles
-roles_path = ../../os-ansible-deployment/playbooks/roles/
+roles_path = ../../openstack-ansible/playbooks/roles/
 
-# Set the path to the folder in os-ansible-deployment which holds the
+# Set the path to the folder in openstack-ansible which holds the
 # lookup plugins required
-lookup_plugins = ../../os-ansible-deployment/playbooks/plugins/lookups/
+lookup_plugins = ../../openstack-ansible/playbooks/plugins/lookups/
 
 [ssh_connection]
 pipelining = True

--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # This is the location where the rpc repository was checked out
-rpc_repo_path: /opt/rpc-openstack/os-ansible-deployment
+rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
-# RPC Extras version
-rpc_release: 11.0.0rc17
+# rpc-openstack version
+rpc_release: 11.0.0rc18
 
-# Definitions for the repo server, these should match your OSAD
+# Definitions for the repo server, these should match your openstack-ansible
 # deployment
 repo_server_port: 8181
 openstack_repo_url: "http://{{ internal_lb_vip_address }}:{{ repo_server_port }}"

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -17,7 +17,7 @@
 #   1) This needs to happen pre-run of the ansible playbooks.
 #   2) Since it's a pre-run, the inventory won't necessarily be
 #      available or accurate
-- name: Patch OSAD files
+- name: Patch upstream files
   hosts: 127.0.0.1
   connection: local
   gather_facts: No

--- a/rpcd/playbooks/roles/patcher/defaults/main.yml
+++ b/rpcd/playbooks/roles/patcher/defaults/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # The directory we want to apply patches to.
-patcher_dest_dir: "/opt/rpc-openstack/os-ansible-deployment"
+patcher_dest_dir: "/opt/rpc-openstack/openstack-ansible"
 
 # The directory we want to apply patches from
 patcher_src_dir: "/opt/rpc-openstack/rpcd/patches"

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -243,7 +243,7 @@ maas_apt_packages:
   - mariadb-client
 
 #
-# maas_pip_packages: Packages we need but are not built by os-ansible-deployment
+# maas_pip_packages: Packages we need but are not built by openstack-ansible
 #
 maas_pip_packages:
   - rackspace-monitoring-cli
@@ -251,7 +251,7 @@ maas_pip_packages:
 
 #
 # maas_pip_dependencies: These are pip packages we depend on, but should already be built in
-#                        os-ansible-deployment
+#                        openstack-ansible
 maas_pip_dependencies:
   - requests
   - lxml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,19 +6,19 @@ set -o pipefail
 export ADMIN_PASSWORD=${ADMIN_PASSWORD:-"secrete"}
 export DEPLOY_AIO=${DEPLOY_AIO:-"no"}
 export DEPLOY_HAPROXY=${DEPLOY_HAPROXY:-"no"}
-export DEPLOY_OSAD=${DEPLOY_OSAD:-"yes"}
+export DEPLOY_OA=${DEPLOY_OA:-"yes"}
 export DEPLOY_ELK=${DEPLOY_ELK:-"yes"}
 export DEPLOY_MAAS=${DEPLOY_MAAS:-"no"}
 export DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"no"}
 export DEPLOY_CEILOMETER=${DEPLOY_CEILOMETER:-"no"}
 export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 
-source /opt/rpc-openstack/os-ansible-deployment/scripts/scripts-library.sh
-OSAD_DIR='/opt/rpc-openstack/os-ansible-deployment'
+source /opt/rpc-openstack/openstack-ansible/scripts/scripts-library.sh
+OA_DIR='/opt/rpc-openstack/openstack-ansible'
 RPCD_DIR='/opt/rpc-openstack/rpcd'
 
 # begin the bootstrap process
-cd ${OSAD_DIR}
+cd ${OA_DIR}
 
 # bootstrap the AIO
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
@@ -56,8 +56,8 @@ cd ${RPCD_DIR}/playbooks
 openstack-ansible -i "localhost," patcher.yml
 
 # begin the openstack installation
-if [[ "${DEPLOY_OSAD}" == "yes" ]]; then
-  cd ${OSAD_DIR}/playbooks/
+if [[ "${DEPLOY_OA}" == "yes" ]]; then
+  cd ${OA_DIR}/playbooks/
 
   # ensure that the ELK containers aren't created if they're not
   # going to be used

--- a/scripts/linting.sh
+++ b/scripts/linting.sh
@@ -26,8 +26,8 @@ echo "Running Basic Ansible Lint Check"
 
 
 # Install the development requirements.
-if [[ -f "os-ansible-deployment/dev-requirements.txt" ]]; then
-  pip2 install -r os-ansible-deployment/dev-requirements.txt || pip install -r os-ansible-deployment/dev-requirements.txt
+if [[ -f "openstack-ansible/dev-requirements.txt" ]]; then
+  pip2 install -r openstack-ansible/dev-requirements.txt || pip install -r openstack-ansible/dev-requirements.txt
 else
   pip2 install ansible-lint || pip install ansible-lint
 fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -17,7 +17,7 @@
 set -eux pipefail
 
 BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
-OSAD_DIR="$BASE_DIR/os-ansible-deployment"
+OA_DIR="$BASE_DIR/openstack-ansible"
 RPCD_DIR="$BASE_DIR/rpcd"
 
 # Merge new overrides into existing user_variables before upgrade
@@ -27,22 +27,22 @@ ${BASE_DIR}/scripts/update-yaml.py /tmp/upgrade_user_variables.yml /etc/rpc_depl
 mv /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 
 # Upgrade Ansible in-place so we have access to the patch module.
-cd ${OSAD_DIR}
-${OSAD_DIR}/scripts/bootstrap-ansible.sh
+cd ${OA_DIR}
+${OA_DIR}/scripts/bootstrap-ansible.sh
 
 # Apply any patched files.
 cd ${RPCD_DIR}/playbooks
 openstack-ansible -i "localhost," patcher.yml
 
-# Do the upgrade for os-ansible-deployment components
-cd ${OSAD_DIR}
-echo 'YES' | ${OSAD_DIR}/scripts/run-upgrade.sh
+# Do the upgrade for openstack-ansible components
+cd ${OA_DIR}
+echo 'YES' | ${OA_DIR}/scripts/run-upgrade.sh
 
-# Prevent the deployment script from re-running the OSAD playbooks
-export DEPLOY_OSAD="no"
+# Prevent the deployment script from re-running the OA playbooks
+export DEPLOY_OA="no"
 
 # Do the upgrade for the RPC components
-source ${OSAD_DIR}/scripts/scripts-library.sh
+source ${OA_DIR}/scripts/scripts-library.sh
 cd ${BASE_DIR}
 ${BASE_DIR}/scripts/deploy.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,4 @@
 #     H303  No wildcard (*) import.
 # Excluding our upstream submodule, and our vendored f5 configuration script.
 ignore=F403,H303
-exclude=os-ansible-deployment/*,f5-config.py
+exclude=openstack-ansible/*,f5-config.py


### PR DESCRIPTION
This change is to account for the name change happening upstream. All
references in trtee to `os-ansible-deployment` are changed to
`openstack-ansible`, and `OSAD` is changed to `OA`, mostly for variable
names.

Address #381