### PR TITLE
Update release to match tag.

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
 # rpc-openstack version
-rpc_release: 11.0.0
+rpc_release: r11.0.0
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment


### PR DESCRIPTION
The `rpc-release` variable is dropped into `/etc/rpc-release`, and thus should match the release's tag.