### PR TITLE
Updated common vars to mirror the repo location change.

### DIFF
--- a/rpc_deployment/vars/common.yml
+++ b/rpc_deployment/vars/common.yml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # This is the location where the rpc repository was checked out
-rpc_repo_path: /opt/os-ansible-deployment
+rpc_repo_path: /opt/openstack-ansible


### PR DESCRIPTION
Due to the recent location change for openstack-ansible the common
vars for the juno rpc-openstack needed to be updated to mirror the
upstream change. This was causing the dynamic inventory script to
fail due to a unkown file location

This fixes issue #404 