### PR TITLE
Rename spice console check

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -291,8 +291,8 @@
 
 - include: local_setup.yml
   vars:
-    check_name: nova_spice_console_check
-    check_details: file=service_api_local_check.py,args=nova_spice,args={{ ansible_ssh_host }},args=6082
+    check_name: nova_console_check
+    check_details: file=service_api_local_check.py,args=nova_spice,args={{ ansible_ssh_host }},args=6082,args=--path,args=spice_auto.html
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:


### PR DESCRIPTION
Fix name of maas check created through playbook and related tests to
reflect the general purpose rather than the technology choice used for
nova consoles.

Related to #326

(cherry picked from commit 90060eea7528048b1f8fda63a55bf5f09ede1380)