### PR TITLE
MaaS testing

### DIFF
--- a/maas/testing/requirements.txt
+++ b/maas/testing/requirements.txt
@@ -1,0 +1,3 @@
+rackspace-monitoring
+requests
+tabulate

--- a/maas/testing/tests/integration/maas_cdm
+++ b/maas/testing/tests/integration/maas_cdm
@@ -1,0 +1,1291 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {
+            "cpu--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "idle_percent_average--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"idle_percent_average\"] <= 10.0) { return new AlarmStatus(WARNING, \"CPU time spent idle has dropped to <= 10%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cpu_count": {
+                        "name": "cpu_count",
+                        "unit": "count"
+                    },
+                    "idle_percent_average": {
+                        "name": "idle_percent_average",
+                        "unit": "percent"
+                    },
+                    "irq_percent_average": {
+                        "name": "irq_percent_average",
+                        "unit": "percent"
+                    },
+                    "max_cpu_usage": {
+                        "name": "max_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "min_cpu_usage": {
+                        "name": "min_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "stolen_percent_average": {
+                        "name": "stolen_percent_average",
+                        "unit": "percent"
+                    },
+                    "sys_percent_average": {
+                        "name": "sys_percent_average",
+                        "unit": "percent"
+                    },
+                    "usage_average": {
+                        "name": "usage_average",
+                        "unit": "percent"
+                    },
+                    "user_percent_average": {
+                        "name": "user_percent_average",
+                        "unit": "percent"
+                    },
+                    "wait_percent_average": {
+                        "name": "wait_percent_average",
+                        "unit": "percent"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.cpu"
+            },
+            "filesystem_/--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/ filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/ filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "memory--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Memory used--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"actual_used\"], metric[\"total\"]) >= 95.0) { return new AlarmStatus(WARNING, \"Memory is 95%+ in use.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "actual_free": {
+                        "name": "actual_free",
+                        "unit": "bytes"
+                    },
+                    "actual_used": {
+                        "name": "actual_used",
+                        "unit": "bytes"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "bytes"
+                    },
+                    "ram": {
+                        "name": "ram",
+                        "unit": "megabytes"
+                    },
+                    "swap_free": {
+                        "name": "swap_free",
+                        "unit": "bytes"
+                    },
+                    "swap_page_in": {
+                        "name": "swap_page_in",
+                        "unit": "bytes"
+                    },
+                    "swap_page_out": {
+                        "name": "swap_page_out",
+                        "unit": "bytes"
+                    },
+                    "swap_total": {
+                        "name": "swap_total",
+                        "unit": "bytes"
+                    },
+                    "swap_used": {
+                        "name": "swap_used",
+                        "unit": "bytes"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "bytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "bytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.memory"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {
+            "cpu--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "idle_percent_average--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"idle_percent_average\"] <= 10.0) { return new AlarmStatus(WARNING, \"CPU time spent idle has dropped to <= 10%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cpu_count": {
+                        "name": "cpu_count",
+                        "unit": "count"
+                    },
+                    "idle_percent_average": {
+                        "name": "idle_percent_average",
+                        "unit": "percent"
+                    },
+                    "irq_percent_average": {
+                        "name": "irq_percent_average",
+                        "unit": "percent"
+                    },
+                    "max_cpu_usage": {
+                        "name": "max_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "min_cpu_usage": {
+                        "name": "min_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "stolen_percent_average": {
+                        "name": "stolen_percent_average",
+                        "unit": "percent"
+                    },
+                    "sys_percent_average": {
+                        "name": "sys_percent_average",
+                        "unit": "percent"
+                    },
+                    "usage_average": {
+                        "name": "usage_average",
+                        "unit": "percent"
+                    },
+                    "user_percent_average": {
+                        "name": "user_percent_average",
+                        "unit": "percent"
+                    },
+                    "wait_percent_average": {
+                        "name": "wait_percent_average",
+                        "unit": "percent"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.cpu"
+            },
+            "filesystem_/--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/ filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/ filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "memory--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Memory used--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"actual_used\"], metric[\"total\"]) >= 95.0) { return new AlarmStatus(WARNING, \"Memory is 95%+ in use.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "actual_free": {
+                        "name": "actual_free",
+                        "unit": "bytes"
+                    },
+                    "actual_used": {
+                        "name": "actual_used",
+                        "unit": "bytes"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "bytes"
+                    },
+                    "ram": {
+                        "name": "ram",
+                        "unit": "megabytes"
+                    },
+                    "swap_free": {
+                        "name": "swap_free",
+                        "unit": "bytes"
+                    },
+                    "swap_page_in": {
+                        "name": "swap_page_in",
+                        "unit": "bytes"
+                    },
+                    "swap_page_out": {
+                        "name": "swap_page_out",
+                        "unit": "bytes"
+                    },
+                    "swap_total": {
+                        "name": "swap_total",
+                        "unit": "bytes"
+                    },
+                    "swap_used": {
+                        "name": "swap_used",
+                        "unit": "bytes"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "bytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "bytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.memory"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {
+            "cpu--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "idle_percent_average--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"idle_percent_average\"] <= 10.0) { return new AlarmStatus(WARNING, \"CPU time spent idle has dropped to <= 10%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cpu_count": {
+                        "name": "cpu_count",
+                        "unit": "count"
+                    },
+                    "idle_percent_average": {
+                        "name": "idle_percent_average",
+                        "unit": "percent"
+                    },
+                    "irq_percent_average": {
+                        "name": "irq_percent_average",
+                        "unit": "percent"
+                    },
+                    "max_cpu_usage": {
+                        "name": "max_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "min_cpu_usage": {
+                        "name": "min_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "stolen_percent_average": {
+                        "name": "stolen_percent_average",
+                        "unit": "percent"
+                    },
+                    "sys_percent_average": {
+                        "name": "sys_percent_average",
+                        "unit": "percent"
+                    },
+                    "usage_average": {
+                        "name": "usage_average",
+                        "unit": "percent"
+                    },
+                    "user_percent_average": {
+                        "name": "user_percent_average",
+                        "unit": "percent"
+                    },
+                    "wait_percent_average": {
+                        "name": "wait_percent_average",
+                        "unit": "percent"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.cpu"
+            },
+            "filesystem_/--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/ filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/ filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "memory--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Memory used--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"actual_used\"], metric[\"total\"]) >= 95.0) { return new AlarmStatus(WARNING, \"Memory is 95%+ in use.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "actual_free": {
+                        "name": "actual_free",
+                        "unit": "bytes"
+                    },
+                    "actual_used": {
+                        "name": "actual_used",
+                        "unit": "bytes"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "bytes"
+                    },
+                    "ram": {
+                        "name": "ram",
+                        "unit": "megabytes"
+                    },
+                    "swap_free": {
+                        "name": "swap_free",
+                        "unit": "bytes"
+                    },
+                    "swap_page_in": {
+                        "name": "swap_page_in",
+                        "unit": "bytes"
+                    },
+                    "swap_page_out": {
+                        "name": "swap_page_out",
+                        "unit": "bytes"
+                    },
+                    "swap_total": {
+                        "name": "swap_total",
+                        "unit": "bytes"
+                    },
+                    "swap_used": {
+                        "name": "swap_used",
+                        "unit": "bytes"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "bytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "bytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.memory"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {
+            "cpu--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "idle_percent_average--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"idle_percent_average\"] <= 10.0) { return new AlarmStatus(WARNING, \"CPU time spent idle has dropped to <= 10%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cpu_count": {
+                        "name": "cpu_count",
+                        "unit": "count"
+                    },
+                    "idle_percent_average": {
+                        "name": "idle_percent_average",
+                        "unit": "percent"
+                    },
+                    "irq_percent_average": {
+                        "name": "irq_percent_average",
+                        "unit": "percent"
+                    },
+                    "max_cpu_usage": {
+                        "name": "max_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "min_cpu_usage": {
+                        "name": "min_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "stolen_percent_average": {
+                        "name": "stolen_percent_average",
+                        "unit": "percent"
+                    },
+                    "sys_percent_average": {
+                        "name": "sys_percent_average",
+                        "unit": "percent"
+                    },
+                    "usage_average": {
+                        "name": "usage_average",
+                        "unit": "percent"
+                    },
+                    "user_percent_average": {
+                        "name": "user_percent_average",
+                        "unit": "percent"
+                    },
+                    "wait_percent_average": {
+                        "name": "wait_percent_average",
+                        "unit": "percent"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.cpu"
+            },
+            "filesystem_/--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/ filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/ filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "memory--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Memory used--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"actual_used\"], metric[\"total\"]) >= 95.0) { return new AlarmStatus(WARNING, \"Memory is 95%+ in use.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "actual_free": {
+                        "name": "actual_free",
+                        "unit": "bytes"
+                    },
+                    "actual_used": {
+                        "name": "actual_used",
+                        "unit": "bytes"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "bytes"
+                    },
+                    "ram": {
+                        "name": "ram",
+                        "unit": "megabytes"
+                    },
+                    "swap_free": {
+                        "name": "swap_free",
+                        "unit": "bytes"
+                    },
+                    "swap_page_in": {
+                        "name": "swap_page_in",
+                        "unit": "bytes"
+                    },
+                    "swap_page_out": {
+                        "name": "swap_page_out",
+                        "unit": "bytes"
+                    },
+                    "swap_total": {
+                        "name": "swap_total",
+                        "unit": "bytes"
+                    },
+                    "swap_used": {
+                        "name": "swap_used",
+                        "unit": "bytes"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "bytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "bytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.memory"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {
+            "cpu--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "idle_percent_average--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"idle_percent_average\"] <= 10.0) { return new AlarmStatus(WARNING, \"CPU time spent idle has dropped to <= 10%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cpu_count": {
+                        "name": "cpu_count",
+                        "unit": "count"
+                    },
+                    "idle_percent_average": {
+                        "name": "idle_percent_average",
+                        "unit": "percent"
+                    },
+                    "irq_percent_average": {
+                        "name": "irq_percent_average",
+                        "unit": "percent"
+                    },
+                    "max_cpu_usage": {
+                        "name": "max_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "min_cpu_usage": {
+                        "name": "min_cpu_usage",
+                        "unit": "percent"
+                    },
+                    "stolen_percent_average": {
+                        "name": "stolen_percent_average",
+                        "unit": "percent"
+                    },
+                    "sys_percent_average": {
+                        "name": "sys_percent_average",
+                        "unit": "percent"
+                    },
+                    "usage_average": {
+                        "name": "usage_average",
+                        "unit": "percent"
+                    },
+                    "user_percent_average": {
+                        "name": "user_percent_average",
+                        "unit": "percent"
+                    },
+                    "wait_percent_average": {
+                        "name": "wait_percent_average",
+                        "unit": "percent"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.cpu"
+            },
+            "filesystem_/--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/ filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/ filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "filesystem_/srv/disk1--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /srv/disk1--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/srv/disk1 filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/srv/disk1 filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/srv/disk1"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "filesystem_/srv/disk2--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /srv/disk2--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/srv/disk2 filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/srv/disk2 filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/srv/disk2"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "filesystem_/srv/disk3--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Disk space used on /srv/disk3--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric['used'], metric['total']) >= 90.0) { return new AlarmStatus(CRITICAL, '/srv/disk3 filesystem is >= 90.0% full.'); } if (percentage(metric['used'], metric['total']) >= 80.0) { return new AlarmStatus(WARNING, '/srv/disk3 filesystem is >= 80.0% full.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "target": "/srv/disk3"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "avail": {
+                        "name": "avail",
+                        "unit": "kilobytes"
+                    },
+                    "files": {
+                        "name": "files",
+                        "unit": "files"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "kilobytes"
+                    },
+                    "free_files": {
+                        "name": "free_files",
+                        "unit": "free_files"
+                    },
+                    "options": {
+                        "name": "options",
+                        "unit": "options"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "kilobytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "kilobytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.filesystem"
+            },
+            "memory--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "Memory used--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"actual_used\"], metric[\"total\"]) >= 95.0) { return new AlarmStatus(WARNING, \"Memory is 95%+ in use.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {},
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "actual_free": {
+                        "name": "actual_free",
+                        "unit": "bytes"
+                    },
+                    "actual_used": {
+                        "name": "actual_used",
+                        "unit": "bytes"
+                    },
+                    "free": {
+                        "name": "free",
+                        "unit": "bytes"
+                    },
+                    "ram": {
+                        "name": "ram",
+                        "unit": "megabytes"
+                    },
+                    "swap_free": {
+                        "name": "swap_free",
+                        "unit": "bytes"
+                    },
+                    "swap_page_in": {
+                        "name": "swap_page_in",
+                        "unit": "bytes"
+                    },
+                    "swap_page_out": {
+                        "name": "swap_page_out",
+                        "unit": "bytes"
+                    },
+                    "swap_total": {
+                        "name": "swap_total",
+                        "unit": "bytes"
+                    },
+                    "swap_used": {
+                        "name": "swap_used",
+                        "unit": "bytes"
+                    },
+                    "total": {
+                        "name": "total",
+                        "unit": "bytes"
+                    },
+                    "used": {
+                        "name": "used",
+                        "unit": "bytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.memory"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/maas/testing/tests/integration/maas_hp_hardware
+++ b/maas/testing/tests/integration/maas_hp_hardware
@@ -1,0 +1,754 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {
+            "hp-disk--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_disk_status--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_disk_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Disk Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-memory--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_memory_status--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_memory_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Memory Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-processors--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_processors_status--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_processors_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Processor Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {
+            "hp-disk--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_disk_status--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_disk_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Disk Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-memory--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_memory_status--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_memory_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Memory Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-processors--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_processors_status--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_processors_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Processor Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {
+            "hp-disk--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_disk_status--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_disk_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Disk Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-memory--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_memory_status--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_memory_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Memory Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-processors--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_processors_status--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_processors_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Processor Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {
+            "hp-disk--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_disk_status--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_disk_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Disk Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-memory--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_memory_status--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_memory_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Memory Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-processors--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_processors_status--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_processors_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Processor Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {
+            "hp-disk--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_disk_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_disk_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Disk Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-memory--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_memory_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_memory_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Memory Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "hp-processors--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "hardware_processors_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"hardware_processors_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Physical Processor Error\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "hp_monitoring.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "hardware_disk_status": {
+                        "name": "hardware_disk_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_memory_status": {
+                        "name": "hardware_memory_status",
+                        "unit": "unknown"
+                    },
+                    "hardware_processors_status": {
+                        "name": "hardware_processors_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/maas/testing/tests/integration/maas_local
+++ b/maas/testing/tests/integration/maas_local
@@ -1,0 +1,1883 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {
+            "cinder_volume_check--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "cinder_volume_status--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"cinder-volume_status\"] != 1) { return new AlarmStatus(CRITICAL, \"cinder-volume down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "BLOCK_STORAGE",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "cinder_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cinder-volume_status": {
+                        "name": "cinder-volume_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "disk_utilisation--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "percentage_disk_utilisation_xvda--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvda\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvda >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvdd--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvdd\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvdd >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvde--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvde\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvde >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "disk_utilisation.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "disk_utilisation_xvda": {
+                        "name": "disk_utilisation_xvda",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvdd": {
+                        "name": "disk_utilisation_xvdd",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvde": {
+                        "name": "disk_utilisation_xvde",
+                        "unit": "%"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {
+            "disk_utilisation--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "percentage_disk_utilisation_xvda--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvda\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvda >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvdd--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvdd\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvdd >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvde--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvde\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvde >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "disk_utilisation.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "disk_utilisation_xvda": {
+                        "name": "disk_utilisation_xvda",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvdd": {
+                        "name": "disk_utilisation_xvdd",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvde": {
+                        "name": "disk_utilisation_xvde",
+                        "unit": "%"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_linuxbridge_agent_check--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_linuxbridge_agent_status--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-linuxbridge-agent_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-linuxbridge-agent down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "COMPUTE",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-linuxbridge-agent_status": {
+                        "name": "neutron-linuxbridge-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_compute_check--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_compute_status--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova-compute_status\"] != 1) { return new AlarmStatus(CRITICAL, \"nova-compute down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "COMPUTE",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova-compute_status": {
+                        "name": "nova-compute_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {
+            "cinder_api_local_check--CONTROLLER_cinder_api_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "cinder_api_local_status--CONTROLLER_cinder_api_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"cinder_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "cinder_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cinder_api_local_response_time": {
+                        "name": "cinder_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "cinder_api_local_status": {
+                        "name": "cinder_api_local_status",
+                        "unit": "unknown"
+                    },
+                    "cinder_available_snaps": {
+                        "name": "cinder_available_snaps",
+                        "unit": "snapshots"
+                    },
+                    "cinder_available_volumes": {
+                        "name": "cinder_available_volumes",
+                        "unit": "volumes"
+                    },
+                    "cinder_error_snaps": {
+                        "name": "cinder_error_snaps",
+                        "unit": "snapshots"
+                    },
+                    "cinder_error_volumes": {
+                        "name": "cinder_error_volumes",
+                        "unit": "volumes"
+                    },
+                    "cinder_in-use_snaps": {
+                        "name": "cinder_in-use_snaps",
+                        "unit": "snapshots"
+                    },
+                    "cinder_in-use_volumes": {
+                        "name": "cinder_in-use_volumes",
+                        "unit": "volumes"
+                    },
+                    "total_cinder_snapshots": {
+                        "name": "total_cinder_snapshots",
+                        "unit": "snapshots"
+                    },
+                    "total_cinder_volumes": {
+                        "name": "total_cinder_volumes",
+                        "unit": "volumes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "cinder_scheduler_check--CONTROLLER_cinder_scheduler_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "cinder_scheduler_status--CONTROLLER_cinder_scheduler_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"cinder-scheduler_status\"] != 1) { return new AlarmStatus(CRITICAL, \"cinder-scheduler down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_cinder_scheduler_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "cinder_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "cinder-scheduler_status": {
+                        "name": "cinder-scheduler_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "disk_utilisation--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "percentage_disk_utilisation_xvda--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvda\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvda >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvdd--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvdd\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvdd >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvde--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvde\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvde >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "disk_utilisation.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "disk_utilisation_xvda": {
+                        "name": "disk_utilisation_xvda",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvdd": {
+                        "name": "disk_utilisation_xvdd",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvde": {
+                        "name": "disk_utilisation_xvde",
+                        "unit": "%"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "galera_check--CONTROLLER_galera_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "wsrep_cluster_size--CONTROLLER_galera_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"wsrep_cluster_size\"] < 3) { return new AlarmStatus(CRITICAL, \"Galera cluster size less than expected\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "wsrep_local_state--CONTROLLER_galera_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"wsrep_local_state_comment\"] != \"Synced\" ) { return new AlarmStatus(CRITICAL, \"Galera cluster node not synced\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "-H",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "galera_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "queries_per_second": {
+                        "name": "queries_per_second",
+                        "unit": "qps"
+                    },
+                    "wsrep_cluster_size": {
+                        "name": "wsrep_cluster_size",
+                        "unit": "nodes"
+                    },
+                    "wsrep_cluster_state_uuid": {
+                        "name": "wsrep_cluster_state_uuid",
+                        "unit": "unknown"
+                    },
+                    "wsrep_cluster_status": {
+                        "name": "wsrep_cluster_status",
+                        "unit": "unknown"
+                    },
+                    "wsrep_commit_window_size": {
+                        "name": "wsrep_commit_window_size",
+                        "unit": "sequence_delta"
+                    },
+                    "wsrep_local_state_comment": {
+                        "name": "wsrep_local_state_comment",
+                        "unit": "unknown"
+                    },
+                    "wsrep_local_state_uuid": {
+                        "name": "wsrep_local_state_uuid",
+                        "unit": "unknown"
+                    },
+                    "wsrep_received_bytes": {
+                        "name": "wsrep_received_bytes",
+                        "unit": "bytes"
+                    },
+                    "wsrep_replicated_bytes": {
+                        "name": "wsrep_replicated_bytes",
+                        "unit": "bytes"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "glance_api_local_check--CONTROLLER_glance_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "glance_api_local_status--CONTROLLER_glance_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"glance_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "glance_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "glance_active_images": {
+                        "name": "glance_active_images",
+                        "unit": "images"
+                    },
+                    "glance_api_local_response_time": {
+                        "name": "glance_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "glance_api_local_status": {
+                        "name": "glance_api_local_status",
+                        "unit": "unknown"
+                    },
+                    "glance_killed_images": {
+                        "name": "glance_killed_images",
+                        "unit": "images"
+                    },
+                    "glance_queued_images": {
+                        "name": "glance_queued_images",
+                        "unit": "images"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "glance_registry_local_check--CONTROLLER_glance_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "glance_registry_local_status--CONTROLLER_glance_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"glance_registry_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "glance_registry_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "glance_registry_local_response_time": {
+                        "name": "glance_registry_local_response_time",
+                        "unit": "ms"
+                    },
+                    "glance_registry_local_status": {
+                        "name": "glance_registry_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "heat_api_local_check--CONTROLLER_heat_apis_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "heat_api_local_status--CONTROLLER_heat_apis_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"heat_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "heat_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "heat_api_local_response_time": {
+                        "name": "heat_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "heat_api_local_status": {
+                        "name": "heat_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "heat_cfn_api_check--CONTROLLER_heat_apis_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "heat_cfn_api_local_status--CONTROLLER_heat_apis_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"heat_cfn_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "heat_cfn",
+                        "IP_ADDRESS",
+                        "8000"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "heat_cfn_api_local_response_time": {
+                        "name": "heat_cfn_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "heat_cfn_api_local_status": {
+                        "name": "heat_cfn_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "heat_cw_api_check--CONTROLLER_heat_apis_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "heat_cw_api_local_status--CONTROLLER_heat_apis_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"heat_cw_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "heat_cw",
+                        "IP_ADDRESS",
+                        "8003"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "heat_cw_api_local_response_time": {
+                        "name": "heat_cw_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "heat_cw_api_local_status": {
+                        "name": "heat_cw_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "horizon_local_check--CONTROLLER_horizon_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "horizon_local_status--CONTROLLER_horizon_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"horizon_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"Horizon unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "horizon_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "horizon_local_status": {
+                        "name": "horizon_local_status",
+                        "unit": "unknown"
+                    },
+                    "login_milliseconds": {
+                        "name": "login_milliseconds",
+                        "unit": "ms"
+                    },
+                    "login_status_code": {
+                        "name": "login_status_code",
+                        "unit": "http_code"
+                    },
+                    "splash_milliseconds": {
+                        "name": "splash_milliseconds",
+                        "unit": "ms"
+                    },
+                    "splash_status_code": {
+                        "name": "splash_status_code",
+                        "unit": "http_code"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "keystone_api_local_check--CONTROLLER_keystone_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "keystone_api_local_status--CONTROLLER_keystone_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"keystone_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "keystone_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "keystone_api_local_response_time": {
+                        "name": "keystone_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "keystone_api_local_status": {
+                        "name": "keystone_api_local_status",
+                        "unit": "unknown"
+                    },
+                    "keystone_tenant_count": {
+                        "name": "keystone_tenant_count",
+                        "unit": "tenants"
+                    },
+                    "keystone_user_count": {
+                        "name": "keystone_user_count",
+                        "unit": "users"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "memcached_status--CONTROLLER_memcached_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "memcache_api_local_status--CONTROLLER_memcached_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"memcache_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"memcached unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "memcached_status.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "memcache_api_local_status": {
+                        "name": "memcache_api_local_status",
+                        "unit": "unknown"
+                    },
+                    "memcache_get_hits": {
+                        "name": "memcache_get_hits",
+                        "unit": "cache_hits"
+                    },
+                    "memcache_get_misses": {
+                        "name": "memcache_get_misses",
+                        "unit": "cache_misses"
+                    },
+                    "memcache_total_connections": {
+                        "name": "memcache_total_connections",
+                        "unit": "connections"
+                    },
+                    "memcache_total_items": {
+                        "name": "memcache_total_items",
+                        "unit": "items"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_api_local_check--CONTROLLER_nova_api_os_compute_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_api_local_status--CONTROLLER_nova_api_os_compute_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API (os-compute) unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova_api_local_response_time": {
+                        "name": "nova_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "nova_api_local_status": {
+                        "name": "nova_api_local_status",
+                        "unit": "unknown"
+                    },
+                    "nova_instances_in_state_ACTIVE": {
+                        "name": "nova_instances_in_state_ACTIVE",
+                        "unit": "instances"
+                    },
+                    "nova_instances_in_state_ERROR": {
+                        "name": "nova_instances_in_state_ERROR",
+                        "unit": "instances"
+                    },
+                    "nova_instances_in_state_STOPPED": {
+                        "name": "nova_instances_in_state_STOPPED",
+                        "unit": "instances"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_api_metadata_local_check--CONTROLLER_nova_api_metadata_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_api_metadata_local_status--CONTROLLER_nova_api_metadata_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova_api_metadata_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API (metadata) unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_api_metadata_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova_api_metadata_local_response_time": {
+                        "name": "nova_api_metadata_local_response_time",
+                        "unit": "ms"
+                    },
+                    "nova_api_metadata_local_status": {
+                        "name": "nova_api_metadata_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_cert_check--CONTROLLER_nova_cert_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_cert_status--CONTROLLER_nova_cert_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova-cert_status\"] != 1) { return new AlarmStatus(CRITICAL, \"nova-cert down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_nova_cert_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova-cert_status": {
+                        "name": "nova-cert_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_conductor_check--CONTROLLER_nova_conductor_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_conductor_status--CONTROLLER_nova_conductor_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova-conductor_status\"] != 1) { return new AlarmStatus(CRITICAL, \"nova-conductor down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_nova_conductor_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova-conductor_status": {
+                        "name": "nova-conductor_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_consoleauth_check--CONTROLLER_nova_console_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_consoleauth_status--CONTROLLER_nova_console_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova-consoleauth_status\"] != 1) { return new AlarmStatus(CRITICAL, \"nova-consoleauth down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_nova_console_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova-consoleauth_status": {
+                        "name": "nova-consoleauth_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_scheduler_check--CONTROLLER_nova_scheduler_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_scheduler_status--CONTROLLER_nova_scheduler_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova-scheduler_status\"] != 1) { return new AlarmStatus(CRITICAL, \"nova-scheduler down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_nova_scheduler_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "nova_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova-scheduler_status": {
+                        "name": "nova-scheduler_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "nova_spice_console_check--CONTROLLER_nova_console_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "nova_spice_api_local_status--CONTROLLER_nova_console_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"nova_spice_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "nova_spice",
+                        "IP_ADDRESS",
+                        "6082",
+                        "--path",
+                        "spice_auto.html"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nova_spice_api_local_response_time": {
+                        "name": "nova_spice_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "nova_spice_api_local_status": {
+                        "name": "nova_spice_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "rabbitmq_status--CONTROLLER_rabbit_mq_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "rabbitmq_disk_free_alarm_status--CONTROLLER_rabbit_mq_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"rabbitmq_disk_free_alarm_status\"] != 1) { return new AlarmStatus(CRITICAL, \"rabbitmq_disk_free_alarm_status triggered\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "rabbitmq_max_channels_per_conn--CONTROLLER_rabbit_mq_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"rabbitmq_max_channels_per_conn\"] > 10) { return new AlarmStatus(CRITICAL, \"Detected RabbitMQ connections with > 10 channels, check RabbitMQ and all Openstack consumers\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "rabbitmq_mem_alarm_status--CONTROLLER_rabbit_mq_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"rabbitmq_mem_alarm_status\"] != 1) { return new AlarmStatus(CRITICAL, \"rabbitmq_mem_alarm_status triggered\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "-H",
+                        "IP_ADDRESS",
+                        "-n",
+                        "CONTROLLER_rabbit_mq_container-UID"
+                    ],
+                    "file": "rabbitmq_status.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "rabbitmq_ack": {
+                        "name": "rabbitmq_ack",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_deliver": {
+                        "name": "rabbitmq_deliver",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_deliver_get": {
+                        "name": "rabbitmq_deliver_get",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_disk_free_alarm_status": {
+                        "name": "rabbitmq_disk_free_alarm_status",
+                        "unit": "unknown"
+                    },
+                    "rabbitmq_fd_total": {
+                        "name": "rabbitmq_fd_total",
+                        "unit": "fd"
+                    },
+                    "rabbitmq_fd_used": {
+                        "name": "rabbitmq_fd_used",
+                        "unit": "fd"
+                    },
+                    "rabbitmq_max_channels_per_conn": {
+                        "name": "rabbitmq_max_channels_per_conn",
+                        "unit": "channels"
+                    },
+                    "rabbitmq_mem_alarm_status": {
+                        "name": "rabbitmq_mem_alarm_status",
+                        "unit": "unknown"
+                    },
+                    "rabbitmq_mem_limit": {
+                        "name": "rabbitmq_mem_limit",
+                        "unit": "bytes"
+                    },
+                    "rabbitmq_mem_used": {
+                        "name": "rabbitmq_mem_used",
+                        "unit": "bytes"
+                    },
+                    "rabbitmq_messages": {
+                        "name": "rabbitmq_messages",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_messages_ready": {
+                        "name": "rabbitmq_messages_ready",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_messages_unacknowledged": {
+                        "name": "rabbitmq_messages_unacknowledged",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_proc_total": {
+                        "name": "rabbitmq_proc_total",
+                        "unit": "processes"
+                    },
+                    "rabbitmq_proc_used": {
+                        "name": "rabbitmq_proc_used",
+                        "unit": "processes"
+                    },
+                    "rabbitmq_publish": {
+                        "name": "rabbitmq_publish",
+                        "unit": "messages"
+                    },
+                    "rabbitmq_sockets_total": {
+                        "name": "rabbitmq_sockets_total",
+                        "unit": "fd"
+                    },
+                    "rabbitmq_sockets_used": {
+                        "name": "rabbitmq_sockets_used",
+                        "unit": "fd"
+                    },
+                    "rabbitmq_uptime": {
+                        "name": "rabbitmq_uptime",
+                        "unit": "ms"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_api_local_check--CONTROLLER_neutron_server_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_api_local_status--CONTROLLER_neutron_server_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron_agents": {
+                        "name": "neutron_agents",
+                        "unit": "agents"
+                    },
+                    "neutron_api_local_response_time": {
+                        "name": "neutron_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "neutron_api_local_status": {
+                        "name": "neutron_api_local_status",
+                        "unit": "unknown"
+                    },
+                    "neutron_networks": {
+                        "name": "neutron_networks",
+                        "unit": "networks"
+                    },
+                    "neutron_routers": {
+                        "name": "neutron_routers",
+                        "unit": "agents"
+                    },
+                    "neutron_subnets": {
+                        "name": "neutron_subnets",
+                        "unit": "subnets"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_dhcp_agent_check--CONTROLLER_neutron_agents_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_dhcp_agent_status--CONTROLLER_neutron_agents_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-dhcp-agent_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-dhcp-agent down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_neutron_agents_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-dhcp-agent_status": {
+                        "name": "neutron-dhcp-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-l3-agent_status": {
+                        "name": "neutron-l3-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-linuxbridge-agent_status": {
+                        "name": "neutron-linuxbridge-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metadata-agent_status": {
+                        "name": "neutron-metadata-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metering-agent_status": {
+                        "name": "neutron-metering-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_l3_agent_check--CONTROLLER_neutron_agents_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_l3_agent_status--CONTROLLER_neutron_agents_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-l3-agent_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-l3-agent down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_neutron_agents_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-dhcp-agent_status": {
+                        "name": "neutron-dhcp-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-l3-agent_status": {
+                        "name": "neutron-l3-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-linuxbridge-agent_status": {
+                        "name": "neutron-linuxbridge-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metadata-agent_status": {
+                        "name": "neutron-metadata-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metering-agent_status": {
+                        "name": "neutron-metering-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_linuxbridge_agent_check--CONTROLLER_neutron_agents_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_linuxbridge_agent_status--CONTROLLER_neutron_agents_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-linuxbridge-agent_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-linuxbridge-agent down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_neutron_agents_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-dhcp-agent_status": {
+                        "name": "neutron-dhcp-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-l3-agent_status": {
+                        "name": "neutron-l3-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-linuxbridge-agent_status": {
+                        "name": "neutron-linuxbridge-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metadata-agent_status": {
+                        "name": "neutron-metadata-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metering-agent_status": {
+                        "name": "neutron-metering-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_metadata_agent_check--CONTROLLER_neutron_agents_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_metadata_agent_status--CONTROLLER_neutron_agents_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-metadata-agent_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-metadata-agent down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_neutron_agents_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-dhcp-agent_status": {
+                        "name": "neutron-dhcp-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-l3-agent_status": {
+                        "name": "neutron-l3-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-linuxbridge-agent_status": {
+                        "name": "neutron-linuxbridge-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metadata-agent_status": {
+                        "name": "neutron-metadata-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metering-agent_status": {
+                        "name": "neutron-metering-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "neutron_metering_agent_check--CONTROLLER_neutron_agents_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "neutron_metering_agent_status--CONTROLLER_neutron_agents_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"neutron-metering-agent_status\"] != 1) { return new AlarmStatus(CRITICAL, \"neutron-metering-agent down\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--host",
+                        "CONTROLLER_neutron_agents_container-UID",
+                        "IP_ADDRESS"
+                    ],
+                    "file": "neutron_service_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "neutron-dhcp-agent_status": {
+                        "name": "neutron-dhcp-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-l3-agent_status": {
+                        "name": "neutron-l3-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-linuxbridge-agent_status": {
+                        "name": "neutron-linuxbridge-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metadata-agent_status": {
+                        "name": "neutron-metadata-agent_status",
+                        "unit": "unknown"
+                    },
+                    "neutron-metering-agent_status": {
+                        "name": "neutron-metering-agent_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {
+            "disk_utilisation--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "percentage_disk_utilisation_xvda--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvda\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvda >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvdd--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvdd\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvdd >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvde--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvde\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvde >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "disk_utilisation.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "disk_utilisation_xvda": {
+                        "name": "disk_utilisation_xvda",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvdd": {
+                        "name": "disk_utilisation_xvdd",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvde": {
+                        "name": "disk_utilisation_xvde",
+                        "unit": "%"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {
+            "disk_utilisation--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "percentage_disk_utilisation_xvda--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvda\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvda >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvdd--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvdd\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvdd >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "percentage_disk_utilisation_xvde--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"disk_utilisation_xvde\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for xvde >= 90%\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "disk_utilisation.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "disk_utilisation_xvda": {
+                        "name": "disk_utilisation_xvda",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvdd": {
+                        "name": "disk_utilisation_xvdd",
+                        "unit": "%"
+                    },
+                    "disk_utilisation_xvde": {
+                        "name": "disk_utilisation_xvde",
+                        "unit": "%"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/maas/testing/tests/integration/maas_remote
+++ b/maas/testing/tests/integration/maas_remote
@@ -1,0 +1,1665 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {
+            "lb_api_check_cinder": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_cinder": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:8776"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_glance": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_glance": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '300') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:9292"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_heat_api": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_heat_api": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '300') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:8004"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_heat_cfn": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_heat_cfn": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '300') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:8000"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_heat_cloudwatch": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_heat_cloudwatch": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '300') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:8003"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_horizon": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_horizon": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "https://IP_ADDRESS:443/auth/login/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.cert_end": {
+                        "name": "mzdfw.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzdfw.cert_end_in": {
+                        "name": "mzdfw.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzdfw.cert_error": {
+                        "name": "mzdfw.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.cert_issuer": {
+                        "name": "mzdfw.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.cert_start": {
+                        "name": "mzdfw.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzdfw.cert_subject": {
+                        "name": "mzdfw.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.cert_end": {
+                        "name": "mzhkg.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzhkg.cert_end_in": {
+                        "name": "mzhkg.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzhkg.cert_error": {
+                        "name": "mzhkg.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.cert_issuer": {
+                        "name": "mzhkg.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.cert_start": {
+                        "name": "mzhkg.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzhkg.cert_subject": {
+                        "name": "mzhkg.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.cert_end": {
+                        "name": "mziad.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mziad.cert_end_in": {
+                        "name": "mziad.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mziad.cert_error": {
+                        "name": "mziad.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mziad.cert_issuer": {
+                        "name": "mziad.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mziad.cert_start": {
+                        "name": "mziad.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mziad.cert_subject": {
+                        "name": "mziad.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.cert_end": {
+                        "name": "mzlon.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzlon.cert_end_in": {
+                        "name": "mzlon.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzlon.cert_error": {
+                        "name": "mzlon.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzlon.cert_issuer": {
+                        "name": "mzlon.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzlon.cert_start": {
+                        "name": "mzlon.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzlon.cert_subject": {
+                        "name": "mzlon.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.cert_end": {
+                        "name": "mzord.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzord.cert_end_in": {
+                        "name": "mzord.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzord.cert_error": {
+                        "name": "mzord.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzord.cert_issuer": {
+                        "name": "mzord.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzord.cert_start": {
+                        "name": "mzord.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzord.cert_subject": {
+                        "name": "mzord.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_keystone": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_keystone": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '300') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:5000"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_neutron": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_neutron": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:9696/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            },
+            "lb_api_check_nova": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_nova": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:8774"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/maas/testing/tests/integration/maas_ssl_check
+++ b/maas/testing/tests/integration/maas_ssl_check
@@ -1,0 +1,385 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {
+            "lb_ssl_cert_expiry_check": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_ssl_cert_expiry_alarm": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": "if (metric['cert_end_in'] < 604800) {return new AlarmStatus(CRITICAL, 'Cert expiring in less than 7 days.');}if (metric['cert_end_in'] < 2628288) {return new AlarmStatus(WARNING, 'Cert expiring in less than 30 days.');}return new AlarmStatus(OK, 'HTTP certificate does not expire soon.');",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "https://IP_ADDRESS:443/auth/login/"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.cert_end": {
+                        "name": "mzdfw.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzdfw.cert_end_in": {
+                        "name": "mzdfw.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzdfw.cert_error": {
+                        "name": "mzdfw.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.cert_issuer": {
+                        "name": "mzdfw.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.cert_start": {
+                        "name": "mzdfw.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzdfw.cert_subject": {
+                        "name": "mzdfw.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.cert_end": {
+                        "name": "mzhkg.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzhkg.cert_end_in": {
+                        "name": "mzhkg.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzhkg.cert_error": {
+                        "name": "mzhkg.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.cert_issuer": {
+                        "name": "mzhkg.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.cert_start": {
+                        "name": "mzhkg.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzhkg.cert_subject": {
+                        "name": "mzhkg.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.cert_end": {
+                        "name": "mziad.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mziad.cert_end_in": {
+                        "name": "mziad.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mziad.cert_error": {
+                        "name": "mziad.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mziad.cert_issuer": {
+                        "name": "mziad.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mziad.cert_start": {
+                        "name": "mziad.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mziad.cert_subject": {
+                        "name": "mziad.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.cert_end": {
+                        "name": "mzlon.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzlon.cert_end_in": {
+                        "name": "mzlon.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzlon.cert_error": {
+                        "name": "mzlon.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzlon.cert_issuer": {
+                        "name": "mzlon.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzlon.cert_start": {
+                        "name": "mzlon.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzlon.cert_subject": {
+                        "name": "mzlon.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.cert_end": {
+                        "name": "mzord.cert_end",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzord.cert_end_in": {
+                        "name": "mzord.cert_end_in",
+                        "unit": "seconds"
+                    },
+                    "mzord.cert_error": {
+                        "name": "mzord.cert_error",
+                        "unit": "unknown"
+                    },
+                    "mzord.cert_issuer": {
+                        "name": "mzord.cert_issuer",
+                        "unit": "unknown"
+                    },
+                    "mzord.cert_start": {
+                        "name": "mzord.cert_start",
+                        "unit": "timestamp_seconds"
+                    },
+                    "mzord.cert_subject": {
+                        "name": "mzord.cert_subject",
+                        "unit": "unknown"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/maas/testing/tests/integration/network
+++ b/maas/testing/tests/integration/network
@@ -1,0 +1,304 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {
+            "conntrack_count--BLOCK_STORAGE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "conntrack_count_status--BLOCK_STORAGE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"nf_conntrack_count\"], metric[\"nf_conntrack_max\"]) > 90) { return new AlarmStatus(CRITICAL, \"Connection count is > 90% of maximum allowed.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "conntrack_count.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nf_conntrack_count": {
+                        "name": "nf_conntrack_count",
+                        "unit": "unknown"
+                    },
+                    "nf_conntrack_max": {
+                        "name": "nf_conntrack_max",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {
+            "conntrack_count--COMPUTE": {
+                "active_suppressions": [],
+                "alarms": {
+                    "conntrack_count_status--COMPUTE": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"nf_conntrack_count\"], metric[\"nf_conntrack_max\"]) > 90) { return new AlarmStatus(CRITICAL, \"Connection count is > 90% of maximum allowed.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "conntrack_count.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nf_conntrack_count": {
+                        "name": "nf_conntrack_count",
+                        "unit": "unknown"
+                    },
+                    "nf_conntrack_max": {
+                        "name": "nf_conntrack_max",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {
+            "conntrack_count--CONTROLLER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "conntrack_count_status--CONTROLLER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"nf_conntrack_count\"], metric[\"nf_conntrack_max\"]) > 90) { return new AlarmStatus(CRITICAL, \"Connection count is > 90% of maximum allowed.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "conntrack_count.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nf_conntrack_count": {
+                        "name": "nf_conntrack_count",
+                        "unit": "unknown"
+                    },
+                    "nf_conntrack_max": {
+                        "name": "nf_conntrack_max",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {
+            "conntrack_count--LOGGER": {
+                "active_suppressions": [],
+                "alarms": {
+                    "conntrack_count_status--LOGGER": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"nf_conntrack_count\"], metric[\"nf_conntrack_max\"]) > 90) { return new AlarmStatus(CRITICAL, \"Connection count is > 90% of maximum allowed.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "conntrack_count.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nf_conntrack_count": {
+                        "name": "nf_conntrack_count",
+                        "unit": "unknown"
+                    },
+                    "nf_conntrack_max": {
+                        "name": "nf_conntrack_max",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {
+            "conntrack_count--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "conntrack_count_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (percentage(metric[\"nf_conntrack_count\"], metric[\"nf_conntrack_max\"]) > 90) { return new AlarmStatus(CRITICAL, \"Connection count is > 90% of maximum allowed.\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "file": "conntrack_count.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "nf_conntrack_count": {
+                        "name": "nf_conntrack_count",
+                        "unit": "unknown"
+                    },
+                    "nf_conntrack_max": {
+                        "name": "nf_conntrack_max",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/maas/testing/tests/integration/swift_maas
+++ b/maas/testing/tests/integration/swift_maas
@@ -1,0 +1,1112 @@
+{
+    "BLOCK_STORAGE": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "COMPUTE": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "CONTROLLER": {
+        "active_suppressions": [],
+        "checks": {
+            "swift_proxy_server_check--CONTROLLER_swift_proxy_container-UID": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_proxy_server_api_local_status--CONTROLLER_swift_proxy_container-UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"swift_proxy_server_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "swift_proxy_server",
+                        "--path",
+                        "/healthcheck",
+                        "IP_ADDRESS",
+                        "8080"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "swift_proxy_server_api_local_response_time": {
+                        "name": "swift_proxy_server_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "swift_proxy_server_api_local_status": {
+                        "name": "swift_proxy_server_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOADBALANCER": {
+        "active_suppressions": [],
+        "checks": {
+            "lb_api_check_swift_proxy": {
+                "active_suppressions": [],
+                "alarms": {
+                    "lb_api_alarm_swift_proxy": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=1 if (metric['code'] != '200') { return new AlarmStatus(CRITICAL, 'API unavailable.'); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "follow_redirects": true,
+                    "include_body": false,
+                    "method": "GET",
+                    "url": "http://IP_ADDRESS:8080/healthcheck"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "mzdfw.bytes": {
+                        "name": "mzdfw.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.code": {
+                        "name": "mzdfw.code",
+                        "unit": "unknown"
+                    },
+                    "mzdfw.duration": {
+                        "name": "mzdfw.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.truncated": {
+                        "name": "mzdfw.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzdfw.tt_connect": {
+                        "name": "mzdfw.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzdfw.tt_firstbyte": {
+                        "name": "mzdfw.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.bytes": {
+                        "name": "mzhkg.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.code": {
+                        "name": "mzhkg.code",
+                        "unit": "unknown"
+                    },
+                    "mzhkg.duration": {
+                        "name": "mzhkg.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.truncated": {
+                        "name": "mzhkg.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzhkg.tt_connect": {
+                        "name": "mzhkg.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzhkg.tt_firstbyte": {
+                        "name": "mzhkg.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.bytes": {
+                        "name": "mziad.bytes",
+                        "unit": "bytes"
+                    },
+                    "mziad.code": {
+                        "name": "mziad.code",
+                        "unit": "unknown"
+                    },
+                    "mziad.duration": {
+                        "name": "mziad.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.truncated": {
+                        "name": "mziad.truncated",
+                        "unit": "bytes"
+                    },
+                    "mziad.tt_connect": {
+                        "name": "mziad.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mziad.tt_firstbyte": {
+                        "name": "mziad.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.bytes": {
+                        "name": "mzlon.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzlon.code": {
+                        "name": "mzlon.code",
+                        "unit": "unknown"
+                    },
+                    "mzlon.duration": {
+                        "name": "mzlon.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.truncated": {
+                        "name": "mzlon.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzlon.tt_connect": {
+                        "name": "mzlon.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzlon.tt_firstbyte": {
+                        "name": "mzlon.tt_firstbyte",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.bytes": {
+                        "name": "mzord.bytes",
+                        "unit": "bytes"
+                    },
+                    "mzord.code": {
+                        "name": "mzord.code",
+                        "unit": "unknown"
+                    },
+                    "mzord.duration": {
+                        "name": "mzord.duration",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.truncated": {
+                        "name": "mzord.truncated",
+                        "unit": "bytes"
+                    },
+                    "mzord.tt_connect": {
+                        "name": "mzord.tt_connect",
+                        "unit": "milliseconds"
+                    },
+                    "mzord.tt_firstbyte": {
+                        "name": "mzord.tt_firstbyte",
+                        "unit": "milliseconds"
+                    }
+                },
+                "monitoring_zones_poll": [
+                    "mzdfw",
+                    "mziad",
+                    "mzord",
+                    "mzlon",
+                    "mzhkg"
+                ],
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": "access_ip0_v4",
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "remote.http"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "LOGGER": {
+        "active_suppressions": [],
+        "checks": {},
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    },
+    "SWIFT": {
+        "active_suppressions": [],
+        "checks": {
+            "swift_account_replication_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_account_replication_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"time_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Account Replication Failure Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--ring-type",
+                        "account",
+                        "replication"
+                    ],
+                    "file": "swift-recon.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "attempted_avg": {
+                        "name": "attempted_avg",
+                        "unit": "unknown"
+                    },
+                    "attempted_failed": {
+                        "name": "attempted_failed",
+                        "unit": "unknown"
+                    },
+                    "attempted_high": {
+                        "name": "attempted_high",
+                        "unit": "unknown"
+                    },
+                    "attempted_low": {
+                        "name": "attempted_low",
+                        "unit": "unknown"
+                    },
+                    "attempted_no_result": {
+                        "name": "attempted_no_result",
+                        "unit": "unknown"
+                    },
+                    "attempted_reported": {
+                        "name": "attempted_reported",
+                        "unit": "unknown"
+                    },
+                    "attempted_total": {
+                        "name": "attempted_total",
+                        "unit": "unknown"
+                    },
+                    "failure_avg": {
+                        "name": "failure_avg",
+                        "unit": "unknown"
+                    },
+                    "failure_failed": {
+                        "name": "failure_failed",
+                        "unit": "unknown"
+                    },
+                    "failure_high": {
+                        "name": "failure_high",
+                        "unit": "unknown"
+                    },
+                    "failure_low": {
+                        "name": "failure_low",
+                        "unit": "unknown"
+                    },
+                    "failure_no_result": {
+                        "name": "failure_no_result",
+                        "unit": "unknown"
+                    },
+                    "failure_reported": {
+                        "name": "failure_reported",
+                        "unit": "unknown"
+                    },
+                    "failure_total": {
+                        "name": "failure_total",
+                        "unit": "unknown"
+                    },
+                    "success_avg": {
+                        "name": "success_avg",
+                        "unit": "unknown"
+                    },
+                    "success_failed": {
+                        "name": "success_failed",
+                        "unit": "unknown"
+                    },
+                    "success_high": {
+                        "name": "success_high",
+                        "unit": "unknown"
+                    },
+                    "success_low": {
+                        "name": "success_low",
+                        "unit": "unknown"
+                    },
+                    "success_no_result": {
+                        "name": "success_no_result",
+                        "unit": "unknown"
+                    },
+                    "success_reported": {
+                        "name": "success_reported",
+                        "unit": "unknown"
+                    },
+                    "success_total": {
+                        "name": "success_total",
+                        "unit": "unknown"
+                    },
+                    "time_avg": {
+                        "name": "time_avg",
+                        "unit": "unknown"
+                    },
+                    "time_failed": {
+                        "name": "time_failed",
+                        "unit": "unknown"
+                    },
+                    "time_high": {
+                        "name": "time_high",
+                        "unit": "unknown"
+                    },
+                    "time_low": {
+                        "name": "time_low",
+                        "unit": "unknown"
+                    },
+                    "time_no_result": {
+                        "name": "time_no_result",
+                        "unit": "unknown"
+                    },
+                    "time_reported": {
+                        "name": "time_reported",
+                        "unit": "unknown"
+                    },
+                    "time_total": {
+                        "name": "time_total",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_account_server_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_account_server_api_local_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"swift_account_server_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "swift_account_server",
+                        "--path",
+                        "/healthcheck",
+                        "IP_ADDRESS",
+                        "6002"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "swift_account_server_api_local_response_time": {
+                        "name": "swift_account_server_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "swift_account_server_api_local_status": {
+                        "name": "swift_account_server_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_async_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_async_avg_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"async_avg\"] > 25.0) { return new AlarmStatus(CRITICAL, \"Swift Async Pending Average above threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_async_failure_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"async_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Async Pending Failure Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "async-pendings"
+                    ],
+                    "file": "swift-recon.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "async_avg": {
+                        "name": "async_avg",
+                        "unit": "unknown"
+                    },
+                    "async_failed": {
+                        "name": "async_failed",
+                        "unit": "unknown"
+                    },
+                    "async_high": {
+                        "name": "async_high",
+                        "unit": "unknown"
+                    },
+                    "async_low": {
+                        "name": "async_low",
+                        "unit": "unknown"
+                    },
+                    "async_no_result": {
+                        "name": "async_no_result",
+                        "unit": "unknown"
+                    },
+                    "async_reported": {
+                        "name": "async_reported",
+                        "unit": "unknown"
+                    },
+                    "async_total": {
+                        "name": "async_total",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_container_replication_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_container_replication_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"time_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Container Replication Failure Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--ring-type",
+                        "container",
+                        "replication"
+                    ],
+                    "file": "swift-recon.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "attempted_avg": {
+                        "name": "attempted_avg",
+                        "unit": "unknown"
+                    },
+                    "attempted_failed": {
+                        "name": "attempted_failed",
+                        "unit": "unknown"
+                    },
+                    "attempted_high": {
+                        "name": "attempted_high",
+                        "unit": "unknown"
+                    },
+                    "attempted_low": {
+                        "name": "attempted_low",
+                        "unit": "unknown"
+                    },
+                    "attempted_no_result": {
+                        "name": "attempted_no_result",
+                        "unit": "unknown"
+                    },
+                    "attempted_reported": {
+                        "name": "attempted_reported",
+                        "unit": "unknown"
+                    },
+                    "attempted_total": {
+                        "name": "attempted_total",
+                        "unit": "unknown"
+                    },
+                    "failure_avg": {
+                        "name": "failure_avg",
+                        "unit": "unknown"
+                    },
+                    "failure_failed": {
+                        "name": "failure_failed",
+                        "unit": "unknown"
+                    },
+                    "failure_high": {
+                        "name": "failure_high",
+                        "unit": "unknown"
+                    },
+                    "failure_low": {
+                        "name": "failure_low",
+                        "unit": "unknown"
+                    },
+                    "failure_no_result": {
+                        "name": "failure_no_result",
+                        "unit": "unknown"
+                    },
+                    "failure_reported": {
+                        "name": "failure_reported",
+                        "unit": "unknown"
+                    },
+                    "failure_total": {
+                        "name": "failure_total",
+                        "unit": "unknown"
+                    },
+                    "success_avg": {
+                        "name": "success_avg",
+                        "unit": "unknown"
+                    },
+                    "success_failed": {
+                        "name": "success_failed",
+                        "unit": "unknown"
+                    },
+                    "success_high": {
+                        "name": "success_high",
+                        "unit": "unknown"
+                    },
+                    "success_low": {
+                        "name": "success_low",
+                        "unit": "unknown"
+                    },
+                    "success_no_result": {
+                        "name": "success_no_result",
+                        "unit": "unknown"
+                    },
+                    "success_reported": {
+                        "name": "success_reported",
+                        "unit": "unknown"
+                    },
+                    "success_total": {
+                        "name": "success_total",
+                        "unit": "unknown"
+                    },
+                    "time_avg": {
+                        "name": "time_avg",
+                        "unit": "unknown"
+                    },
+                    "time_failed": {
+                        "name": "time_failed",
+                        "unit": "unknown"
+                    },
+                    "time_high": {
+                        "name": "time_high",
+                        "unit": "unknown"
+                    },
+                    "time_low": {
+                        "name": "time_low",
+                        "unit": "unknown"
+                    },
+                    "time_no_result": {
+                        "name": "time_no_result",
+                        "unit": "unknown"
+                    },
+                    "time_reported": {
+                        "name": "time_reported",
+                        "unit": "unknown"
+                    },
+                    "time_total": {
+                        "name": "time_total",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_container_server_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_container_server_api_local_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"swift_container_server_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "swift_container_server",
+                        "--path",
+                        "/healthcheck",
+                        "IP_ADDRESS",
+                        "6001"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "swift_container_server_api_local_response_time": {
+                        "name": "swift_container_server_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "swift_container_server_api_local_status": {
+                        "name": "swift_container_server_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_md5_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_conf_md5_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"swift_conf_errors\"] > 0) { return new AlarmStatus(CRITICAL, \"Swift conf md5sum inconsistent\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_ring_md5_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"ring_errors\"] > 0) { return new AlarmStatus(CRITICAL, \"Ring md5sum Inconsistent\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "md5"
+                    ],
+                    "file": "swift-recon.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "ring_errors": {
+                        "name": "ring_errors",
+                        "unit": "unknown"
+                    },
+                    "ring_success": {
+                        "name": "ring_success",
+                        "unit": "unknown"
+                    },
+                    "ring_total": {
+                        "name": "ring_total",
+                        "unit": "unknown"
+                    },
+                    "swift_conf_errors": {
+                        "name": "swift_conf_errors",
+                        "unit": "unknown"
+                    },
+                    "swift_conf_success": {
+                        "name": "swift_conf_success",
+                        "unit": "unknown"
+                    },
+                    "swift_conf_total": {
+                        "name": "swift_conf_total",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_object_replication_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_object_replication_check--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"time_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Object Replication Failure Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "--ring-type",
+                        "object",
+                        "replication"
+                    ],
+                    "file": "swift-recon.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "time_avg": {
+                        "name": "time_avg",
+                        "unit": "unknown"
+                    },
+                    "time_failed": {
+                        "name": "time_failed",
+                        "unit": "unknown"
+                    },
+                    "time_high": {
+                        "name": "time_high",
+                        "unit": "unknown"
+                    },
+                    "time_low": {
+                        "name": "time_low",
+                        "unit": "unknown"
+                    },
+                    "time_no_result": {
+                        "name": "time_no_result",
+                        "unit": "unknown"
+                    },
+                    "time_reported": {
+                        "name": "time_reported",
+                        "unit": "unknown"
+                    },
+                    "time_total": {
+                        "name": "time_total",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_object_server_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_object_server_api_local_status--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"swift_object_server_api_local_status\"] != 1) { return new AlarmStatus(CRITICAL, \"API unavailable\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "swift_object_server",
+                        "--path",
+                        "/healthcheck",
+                        "IP_ADDRESS",
+                        "6000"
+                    ],
+                    "file": "service_api_local_check.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "swift_object_server_api_local_response_time": {
+                        "name": "swift_object_server_api_local_response_time",
+                        "unit": "ms"
+                    },
+                    "swift_object_server_api_local_status": {
+                        "name": "swift_object_server_api_local_status",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            },
+            "swift_quarantine_check--SWIFT": {
+                "active_suppressions": [],
+                "alarms": {
+                    "swift_quarantine_account_avg--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"accounts_avg\"] > 25.0) { return new AlarmStatus(CRITICAL, \"Swift Account Quarantine Average Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_quarantine_account_failed--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"accounts_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Account Quarantine Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_quarantine_container_avg--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"containers_avg\"] > 25.0) { return new AlarmStatus(CRITICAL, \"Swift Container Quarantine Average Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_quarantine_container_failed--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"containers_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Container Quarantine Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_quarantine_object_avg--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"objects_avg\"] > 25.0) { return new AlarmStatus(CRITICAL, \"Swift Object Quarantine Average Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    },
+                    "swift_quarantine_object_failed--SWIFT": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"objects_failed\"] > 5.0) { return new AlarmStatus(CRITICAL, \"Swift Object Quarantine Percentage Above Threshold\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
+                    }
+                },
+                "confd_hash": null,
+                "confd_name": null,
+                "details": {
+                    "args": [
+                        "quarantine"
+                    ],
+                    "file": "swift-recon.py"
+                },
+                "disabled": false,
+                "metadata": null,
+                "metrics": {
+                    "accounts_avg": {
+                        "name": "accounts_avg",
+                        "unit": "unknown"
+                    },
+                    "accounts_failed": {
+                        "name": "accounts_failed",
+                        "unit": "unknown"
+                    },
+                    "accounts_high": {
+                        "name": "accounts_high",
+                        "unit": "unknown"
+                    },
+                    "accounts_low": {
+                        "name": "accounts_low",
+                        "unit": "unknown"
+                    },
+                    "accounts_no_result": {
+                        "name": "accounts_no_result",
+                        "unit": "unknown"
+                    },
+                    "accounts_reported": {
+                        "name": "accounts_reported",
+                        "unit": "unknown"
+                    },
+                    "accounts_total": {
+                        "name": "accounts_total",
+                        "unit": "unknown"
+                    },
+                    "containers_avg": {
+                        "name": "containers_avg",
+                        "unit": "unknown"
+                    },
+                    "containers_failed": {
+                        "name": "containers_failed",
+                        "unit": "unknown"
+                    },
+                    "containers_high": {
+                        "name": "containers_high",
+                        "unit": "unknown"
+                    },
+                    "containers_low": {
+                        "name": "containers_low",
+                        "unit": "unknown"
+                    },
+                    "containers_no_result": {
+                        "name": "containers_no_result",
+                        "unit": "unknown"
+                    },
+                    "containers_reported": {
+                        "name": "containers_reported",
+                        "unit": "unknown"
+                    },
+                    "containers_total": {
+                        "name": "containers_total",
+                        "unit": "unknown"
+                    },
+                    "objects_avg": {
+                        "name": "objects_avg",
+                        "unit": "unknown"
+                    },
+                    "objects_failed": {
+                        "name": "objects_failed",
+                        "unit": "unknown"
+                    },
+                    "objects_high": {
+                        "name": "objects_high",
+                        "unit": "unknown"
+                    },
+                    "objects_low": {
+                        "name": "objects_low",
+                        "unit": "unknown"
+                    },
+                    "objects_no_result": {
+                        "name": "objects_no_result",
+                        "unit": "unknown"
+                    },
+                    "objects_reported": {
+                        "name": "objects_reported",
+                        "unit": "unknown"
+                    },
+                    "objects_total": {
+                        "name": "objects_total",
+                        "unit": "unknown"
+                    }
+                },
+                "monitoring_zones_poll": null,
+                "period": 60,
+                "scheduled_suppressions": [],
+                "target_alias": null,
+                "target_hostname": null,
+                "target_resolver": null,
+                "timeout": 30,
+                "type": "agent.plugin"
+            }
+        },
+        "ip_addresses": {
+            "access_ip0_v4": "IP_ADDRESS",
+            "access_ip1_v6": "IP_ADDRESS",
+            "heat_mgmt_vxlan0_v4": "IP_ADDRESS",
+            "heat_storage0_v4": "IP_ADDRESS",
+            "heat_tunnel0_v4": "IP_ADDRESS",
+            "private0_v4": "IP_ADDRESS",
+            "public0_v4": "IP_ADDRESS",
+            "public1_v6": "IP_ADDRESS"
+        },
+        "managed": false,
+        "metadata": null,
+        "scheduled_suppressions": []
+    }
+}

--- a/rpcd/playbooks/test-maas.yml
+++ b/rpcd/playbooks/test-maas.yml
@@ -1,0 +1,75 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- hosts: hosts
+  tasks:
+    - name: Create fake hpasmcli
+      copy:
+        src: /opt/rpc-openstack/maas/testing/fake_hp_monitoring.py
+        dest: /usr/local/bin/hpasmcli
+        mode: 0755
+      tags:
+        - setup-fake-hp
+
+    - name: Create fake hpssacli
+      copy:
+        src: /opt/rpc-openstack/maas/testing/fake_hp_monitoring.py
+        dest: /usr/local/bin/hpssacli
+        mode: 0755
+      tags:
+        - setup-fake-hp
+
+    # This attempts to work around the frequent memory errors with the agent
+    - name: Check if raxmon agent connected
+      shell: sleep 300; raxmon-agent-connections-list --agent-id {{ inventory_hostname }}{{ maas_fqdn_extension | default('') }} | grep -qv '\[]'; if [ $? -eq 0 ]; then if [ "$(date '+%s')" -gt "$(sleep 5; date -r /var/log/rackspace-monitoring-agent.log '+%s')" ]; then restart rackspace-monitoring-agent; else echo okay; fi; else restart rackspace-monitoring-agent; fi;
+      register: agent_connected
+      until: agent_connected.stdout == "okay"
+      ignore_errors: yes
+      retries: 20
+      delay: 1
+      tags:
+        - test
+
+- hosts: 127.0.0.1
+  connection: local
+  tasks:
+    - pip: name=virtualenv
+      tags:
+        - setup
+
+    - name: Create virtualenv
+      pip:
+      args:
+        requirements: /opt/rpc-openstack/maas/testing/requirements.txt
+        extra_args: "--isolated"
+        virtualenv: /opt/rpc-openstack/maas/testing/venv
+      tags:
+        - setup
+
+    - name: Generate MaaS definitions file
+      shell: "export OS_USERNAME={{ rackspace_cloud_username }}; export OS_PASSWORD={{ rackspace_cloud_api_key }}; export OS_REGION_NAME=LON; ./venv/bin/python generate-definitions.py heat_multi_node {{ groups['hosts'] | join(' ') }}  --raw_output"
+      args:
+        chdir: /opt/rpc-openstack/maas/testing
+      tags:
+        - test
+        - generate-definitions
+
+    - name: Compare definitions
+      shell: "./venv/bin/python compare-definitions.py --definitions {{ maas_testing_task_files | join(' ') }} --directory tests/integration/ --test_file ../../heat_multi_node --mappings {{ maas_testing_mappings | join(' ') }}"
+      args:
+        chdir: /opt/rpc-openstack/maas/testing
+      tags:
+        - test
+        - compare-definitions


### PR DESCRIPTION
Currently there is no regular testing of the MaaS playbooks. This
commit attempts to address that.

generate-definitions.py is used to create files that define the MaaS
configuration for a set of specified entities.

The files in maas/testing/tests/integration are per-MaaS-playbook
reference definitions files and were created using
generate-definitions.py. These need updating when the MaaS configuration
is altered.

compare-definitions.py is used to compare the definitions defined in the
this repo with those generated for the deployment being tested.

generate-docs.py prints tables of the checks, alarms and metrics
defined in one or more definitions files. The format of the output is
reStructuredText. To print the tables for the definitions set:

  ./generate-docs.py tests/integration/*

The test-maas.yml playbook can be used to test a deployments against
the reference definitions files. It prepares the hosts for testing and
then uses generate-definitions.py and compare-definitions.py to test
the deployed MaaS configuration against the one found in
maas/testing/tests/integration. As part of the setup a script is copied
to the hosts to allow HP hardware testing to be configured. Obviously
this does not test that the plugin works with the HP binaries, but that
that checks/alarms are configured as expected.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/216
(cherry picked from commit 738440d3ea06968e9bd6c5f6cbe1a1e5422a8d95)