### PR TITLE
cinder_service_check.py not using --host option

### DIFF
--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -77,8 +77,7 @@ def check(auth_ref, args):
         if service['status'] == 'enabled' and service['state'] != 'up':
             service_is_up = False
 
-        # We need to match against a host of X and X@lvm (or whatever backend)
-        if args.host and args.host in service['host']:
+        if args.host:
             name = '%s_status' % service['binary']
         else:
             name = '%s_on_host_%s' % (service['binary'], service['host'])


### PR DESCRIPTION
The script cinder_service_check.py defines an optional host parameter
that is designed to filter the results, returned by the cinder API, so
that only services on the specified host are returned. The MaaS setup
role, that configures the checks that use this script, uses '--host'.
The script does not use the host argument if supplied.

This patch fixes the script so that the results returned are filtered
by host, where host includes any backends/pools on that host.

Closes-bug: https://github.com/rcbops/rpc-openstack/issues/200
(cherry picked from commit 6c4d898591bdf2cfdeed5c8d564dda622252daf6)