### PR TITLE
Fix status error output

### DIFF
--- a/maas/plugins/rabbitmq_status.py
+++ b/maas/plugins/rabbitmq_status.py
@@ -145,7 +145,7 @@ def main():
         # Check that all other queues are equal to it
         if not all(first == q for q in queues):
             # If they're not, the queues are not synchronized
-            print("status err cluster not replicated across all nodes")
+            status_err('Cluster not replicated across all nodes')
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))


### PR DESCRIPTION
There is currently a print statement in the rabbitmq_status.py script
that prints out a line starting with 'status err '. This is a special
type of status line that causes a metric called legacy_state to be
created. This metric should not be created. The status_err function
should be used instead of using print directly.

This commit updates the line to use status_err. This will prevent the
metric legacy_state from being created. It will also cause the script
to exit with a return code of 1.

(cherry picked from commit 92ee46c526a54692c0f2c9e95a4461a4f7f99087)