### PR TITLE
Update monitoring checks to pass

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -292,7 +292,7 @@
 - include: local_setup.yml
   vars:
     check_name: nova_spice_console_check
-    check_details: file=service_api_local_check.py,args=nova_spice,args={{ ansible_ssh_host }},args=6082
+    check_details: file=service_api_local_check.py,args=nova_spice,args={{ ansible_ssh_host }},args=6082,args=--path,args=spice_auto.html
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ssl_check.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ssl_check.yml
@@ -26,7 +26,7 @@
     scheme: "https"
     ip_address: "{{ external_vip_address }}"
     port: "443"
-    path: ""
+    path: "/auth/login/"
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
     alarm_name: lb_ssl_cert_expiry_alarm
     criteria: "if (metric['cert_end_in'] < 604800) {return new AlarmStatus(CRITICAL, 'Cert expiring in less than 7 days.');}if (metric['cert_end_in'] < 2628288) {return new AlarmStatus(WARNING, 'Cert expiring in less than 30 days.');}return new AlarmStatus(OK, 'HTTP certificate does not expire soon.');"


### PR DESCRIPTION
The commit updates the paths for the following checks to prevent alerts
being created when the services are functioning correctly:

lb_api_check_horizon
lb_ssl_cert_expiry_check
nova_spice_console_check

(cherry picked from commit d8f42e5d4d8924bd4ac1e1ffd8c54a9cc0c11ee3)