### PR TITLE
Only create support keypair is nova service is present. Only create s…

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -41,11 +41,11 @@
 
 - include: support_key_pair.yml
   when: >
-    inventory_hostname == groups['utility'][0]
+    groups['nova_api_os_compute']|length > 0 and inventory_hostname == groups['utility'][0]
 
 - include: support_sec_group.yml
   when: >
-    inventory_hostname == groups['utility'][0]
+    groups['neutron_server']|length > 0 and inventory_hostname == groups['utility'][0]
 
 - include: distribute_auth_key.yml
   when: >


### PR DESCRIPTION
…upport security group if neutron service is present.

(cherry picked from commit e739459a1cd1fc97de103fd92f390b514be61fdd)