### PR TITLE
 Rename nova_console to nova_spice_console in the f5-config 

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -252,7 +252,7 @@ POOL_PARTS = {
         'make_public': True,
         'hosts': []
     },
-    'nova_console': {
+    'nova_spice_console': {
         'port': 6082,
         'backend_port': 6082,
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_SPICE_CONSOLE',


### PR DESCRIPTION
The config name changed in an earlier commit, we are fixing the script
so that the naming is consistent.

Closes-Bug: https://github.com/rcbops/rpc-extras/issues/46
(cherry picked from commit 02659163494670921876943b3205076dfaa1ba44)