### PR TITLE
Download of pccommon.sh should use raw URL

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
@@ -15,6 +15,6 @@
 
 - name: Download pccommon.sh
   get_url:
-    url: "https://github.com/rsoprivatecloud/pubscripts/blob/master/pccommon.sh"
+    url: "https://raw.githubusercontent.com/rsoprivatecloud/pubscripts/master/pccommon.sh"
     dest: /root/pccommon.sh
     mode: 0700


### PR DESCRIPTION
Download of pccommon.sh should use raw URL.
(cherry picked from commit db701371f7d974a7cea8146cc3220fcff3060854)