### PR TITLE
Standalone Swift Skip Key Distribute Retrieve Tasks

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -49,11 +49,11 @@
 
 - include: distribute_auth_key.yml
   when: >
-    inventory_hostname == groups['utility'][0]
+    groups['nova_api_os_compute']|length > 0 and inventory_hostname == groups['utility'][0]
 
 - include: retrieve_auth_key.yml
   when: >
-    inventory_hostname != groups['utility'][0] and (inventory_hostname in groups['utility'] or inventory_hostname in groups['neutron_all'])
+    groups['nova_api_os_compute']|length > 0 and inventory_hostname != groups['utility'][0] and (inventory_hostname in groups['utility'] or inventory_hostname in groups['neutron_all'])
 
 - include: holland_preinstall.yml
   when: >


### PR DESCRIPTION
Partial fix in PR #222 skips the keypair creation, and registering in Nova tasks. This PR adds the distribute and retrieve keypair tasks to the list of skipped tasks.

Partial fix for BUG #221

(cherry picked from commit b7cb8976d872b1670ebcc11efc223166166b9004)