### PR TITLE
Set `ssl_check` to `true` to match previous behavior of check getting…

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -88,7 +88,7 @@ maas_target_alias: public0_v4
 #
 # ssl_check: This flag indicates if the ssl-related checks and alarms should be deployed.
 #
-ssl_check: false
+ssl_check: true
 
 #
 # dell_check: This flag indicates if the Dell-related hardware monitoring checks and alarms should


### PR DESCRIPTION
… created by default.

(cherry picked from commit d45273095d48b6f8d6b362915a34a15033f0b750)