### PR TITLE
Update ansible.cfg

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -30,5 +30,13 @@ roles_path = ../../openstack-ansible/playbooks/roles/
 # lookup plugins required
 lookup_plugins = ../../openstack-ansible/playbooks/plugins/lookups/
 
+# Set the path to the folder in openstack-ansible which holds the filter
+# plugins required
+filter_plugins = ../../openstack-ansible/playbooks/plugins/filters/
+
+# Set the path to the folder in openstack-ansible which holds the action
+# plugins required
+action_plugins = ../../openstack-ansible/playbooks/plugins/actions/
+
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
openstack-ansible's pip roles now make use of custom ansible action
and filter plugins.  This commit updates rpcd's ansible.cfg
accordingly so that these custom plugins can be found.

Closes issue #389

(cherry picked from commit 1dcbdd868a8bbbe4074a955d0d5012b50a7c1236)