### PR TITLE
Update references to rcbops-extras

### DIFF
--- a/rpcd/playbooks/roles/beaver/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/beaver/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:

--- a/rpcd/playbooks/roles/elasticsearch/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/elasticsearch/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:

--- a/rpcd/playbooks/roles/haproxy_rpc/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/haproxy_rpc/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:

--- a/rpcd/playbooks/roles/kibana/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/kibana/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:

--- a/rpcd/playbooks/roles/logstash/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/logstash/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:

--- a/rpcd/playbooks/roles/rpc_maas/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/rpc_maas/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:

--- a/rpcd/playbooks/roles/rpc_support/CONTRIBUTING.rst
+++ b/rpcd/playbooks/roles/rpc_support/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ contributor guidelines
 Filing Bugs
 -----------
 
-Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+Bugs should be filed on GitHub: "https://github.com/rcbops/rpc-openstack"
 
 
 When submitting a bug, or working on a bug, please ensure the following criteria are met:


### PR DESCRIPTION
Update references from `https://github.com/rcbops/rcbops-extras` to `https://github.com/rcbops/rpc-openstack`.

Fixes-Bug: #473