### PR TITLE
Lowering max_retries from 5 to 2 to catch build errors faster

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,6 +13,7 @@ export DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"no"}
 export DEPLOY_CEILOMETER=${DEPLOY_CEILOMETER:-"no"}
 export DEPLOY_CEPH=${DEPLOY_CEPH:-"no"}
 export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
+export MAX_RETRIES=${MAX_RETRIES:-"2"}
 
 source /opt/rpc-openstack/openstack-ansible/scripts/scripts-library.sh
 OA_DIR='/opt/rpc-openstack/openstack-ansible'


### PR DESCRIPTION
This change will cause OSA to fail more early in case repeating errors occur. It has been our experience if playbooks fail more than one, there's usually a issue we have to take care off. There is then no need to wait for 3 more failures before we even get a chance to fix and rerun the playbooks again.