### PR TITLE
Add bash autocompletion to OpenStack clients

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -15,6 +15,7 @@
 
 # Packages required for support
 support_util_packages:
+  - bash-completion
   - bridge-utils
   - debootstrap
   - dstat

--- a/rpcd/playbooks/roles/rpc_support/files/autocompletion_source.sh.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/autocompletion_source.sh.j2
@@ -1,0 +1,29 @@
+#for cinderclient
+if [ -f "/etc/openstack_completions/cinder.bash_completion" ]; then
+  [[ $(which cinder) ]] && . /etc/openstack_completions/cinder.bash_completion
+fi
+
+#for glanceclient
+if [ -f "/etc/openstack_completions/glance.bash_completion" ]; then
+  [[ $(which glance) ]] && . /etc/openstack_completions/glance.bash_completion
+fi
+
+#for heatclient
+if [ -f "/etc/openstack_completions/heat.bash_completion" ]; then
+  [[ $(which heat) ]] && . /etc/openstack_completions/heat.bash_completion
+fi
+
+#for keystoneclient
+if [ -f "/etc/openstack_completions/keystone.bash_completion" ]; then
+  [[ $(which keystone) ]] && . /etc/openstack_completions/keystone.bash_completion
+fi
+
+#for neutronclient
+if [ -f "/etc/openstack_completions/neutron.bash_completion" ]; then
+  [[ $(which neutron) ]] && . /etc/openstack_completions/neutron.bash_completion
+fi
+
+# for novaclient
+if [ -f "/etc/openstack_completions/nova.bash_completion" ]; then
+  [[ $(which nova) ]] && . /etc/openstack_completions/nova.bash_completion
+fi

--- a/rpcd/playbooks/roles/rpc_support/files/cinder.bash_completion.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/cinder.bash_completion.j2
@@ -1,0 +1,27 @@
+_cinder_opts="" # lazy init
+_cinder_flags="" # lazy init
+_cinder_opts_exp="" # lazy init
+
+_cinder()
+{
+    local cur prev cbc cflags
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [ "x$_cinder_opts" == "x" ] ; then
+                cbc="`cinder bash-completion | sed -e "s/  *-h  */ /" -e "s/  *-i  */ /"`"
+                _cinder_opts="`echo "$cbc" | sed -e "s/--[a-z0-9_-]*//g" -e "s/  */ /g"`"
+                _cinder_flags="`echo " $cbc" | sed -e "s/ [^-][^-][a-z0-9_-]*//g" -e "s/  */ /g"`"
+     fi
+
+     if [[ "$prev" != "help" ]] ; then
+                COMPLETION_CACHE=~/.cinderclient/*/*-cache
+                cflags="$_cinder_flags $_cinder_opts "$(cat $COMPLETION_CACHE 2> /dev/null | tr '\n' ' ')
+                COMPREPLY=($(compgen -W "${cflags}" -- ${cur}))
+     else
+                COMPREPLY=($(compgen -W "${_cinder_opts}" -- ${cur}))
+     fi
+     return 0
+}
+complete -F _cinder cinder

--- a/rpcd/playbooks/roles/rpc_support/files/glance.bash_completion.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/glance.bash_completion.j2
@@ -1,0 +1,25 @@
+_glance_opts="" # lazy init
+_glance_flags="" # lazy init
+_glance_opts_exp="" # lazy init
+_glance()
+{
+    local cur prev nbc cflags
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [ "x$_glance_opts" == "x" ] ; then
+        nbc="`glance bash-completion | sed -e "s/  *-h  */ /" -e "s/  *-i  */ /"`"
+        _glance_opts="`echo "$nbc" | sed -e "s/--[a-z0-9_-]*//g" -e "s/  */ /g"`"
+        _glance_flags="`echo " $nbc" | sed -e "s/ [^-][^-][a-z0-9_-]*//g" -e "s/  */ /g"`"
+        _glance_opts_exp="`echo "$_glance_opts" | sed 's/^ *//' | tr ' ' '|'`"
+    fi
+
+    if [[ " ${COMP_WORDS[@]} " =~ " "($_glance_opts_exp)" " && "$prev" != "help" ]] ; then
+        COMPREPLY=($(compgen -W "${_glance_flags}" -- ${cur}))
+    else
+        COMPREPLY=($(compgen -W "${_glance_opts}" -- ${cur}))
+    fi
+    return 0
+}
+complete -F _glance glance

--- a/rpcd/playbooks/roles/rpc_support/files/heat.bash_completion.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/heat.bash_completion.j2
@@ -1,0 +1,27 @@
+# bash completion for openstack heat
+
+_heat_opts="" # lazy init
+_heat_flags="" # lazy init
+_heat_opts_exp="" # lazy init
+_heat()
+{
+    local cur prev kbc
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [ "x$_heat_opts" == "x" ] ; then
+        kbc="`heat bash-completion | sed -e "s/ -h / /"`"
+        _heat_opts="`echo "$kbc" | sed -e "s/--[a-z0-9_-]*//g" -e "s/[ ][ ]*/ /g"`"
+        _heat_flags="`echo " $kbc" | sed -e "s/ [^-][^-][a-z0-9_-]*//g" -e "s/[ ][ ]*/ /g"`"
+        _heat_opts_exp="`echo $_heat_opts | sed -e "s/[ ]/|/g"`"
+    fi
+
+    if [[ " ${COMP_WORDS[@]} " =~ " "($_heat_opts_exp)" " && "$prev" != "help" ]] ; then
+        COMPREPLY=($(compgen -W "${_heat_flags}" -- ${cur}))
+    else
+        COMPREPLY=($(compgen -W "${_heat_opts}" -- ${cur}))
+    fi
+    return 0
+}
+complete -o default -F _heat heat

--- a/rpcd/playbooks/roles/rpc_support/files/keystone.bash_completion.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/keystone.bash_completion.j2
@@ -1,0 +1,27 @@
+# bash completion for openstack keystone
+
+_keystone_opts="" # lazy init
+_keystone_flags="" # lazy init
+_keystone_opts_exp="" # lazy init
+_keystone()
+{
+	local cur prev kbc
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+	if [ "x$_keystone_opts" == "x" ] ; then
+		kbc="`keystone bash-completion | sed -e "s/ -h / /"`"
+		_keystone_opts="`echo "$kbc" | sed -e "s/--[a-z0-9_-]*//g" -e "s/[ ][ ]*/ /g"`"
+		_keystone_flags="`echo " $kbc" | sed -e "s/ [^-][^-][a-z0-9_-]*//g" -e "s/[ ][ ]*/ /g"`"
+		_keystone_opts_exp="`echo $_keystone_opts | sed -e "s/[ ]/|/g"`"
+	fi
+
+	if [[ " ${COMP_WORDS[@]} " =~ " "($_keystone_opts_exp)" " && "$prev" != "help" ]] ; then
+		COMPREPLY=($(compgen -W "${_keystone_flags}" -- ${cur}))
+	else
+		COMPREPLY=($(compgen -W "${_keystone_opts}" -- ${cur}))
+	fi
+	return 0
+}
+complete -F _keystone keystone

--- a/rpcd/playbooks/roles/rpc_support/files/neutron.bash_completion.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/neutron.bash_completion.j2
@@ -1,0 +1,27 @@
+_neutron_opts="" # lazy init
+_neutron_flags="" # lazy init
+_neutron_opts_exp="" # lazy init
+_neutron()
+{
+	local cur prev nbc cflags
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+	if [ "x$_neutron_opts" == "x" ] ; then
+		nbc="`neutron bash-completion`"
+		_neutron_opts="`echo "$nbc" | sed -e "s/--[a-z0-9_-]*//g" -e "s/\s\s*/ /g"`"
+		_neutron_flags="`echo " $nbc" | sed -e "s/ [^-][^-][a-z0-9_-]*//g" -e "s/\s\s*/ /g"`"
+		_neutron_opts_exp="`echo "$_neutron_opts" | sed -e "s/\s/|/g"`"
+	fi
+
+	if [[ " ${COMP_WORDS[@]} " =~ " "($_neutron_opts_exp)" " && "$prev" != "help" ]] ; then
+		COMPLETION_CACHE=~/.neutronclient/*/*-cache
+		cflags="$_neutron_flags "$(cat $COMPLETION_CACHE 2> /dev/null | tr '\n' ' ')
+		COMPREPLY=($(compgen -W "${cflags}" -- ${cur}))
+	else
+		COMPREPLY=($(compgen -W "${_neutron_opts}" -- ${cur}))
+	fi
+	return 0
+}
+complete -F _neutron neutron

--- a/rpcd/playbooks/roles/rpc_support/files/nova.bash_completion.j2
+++ b/rpcd/playbooks/roles/rpc_support/files/nova.bash_completion.j2
@@ -1,0 +1,28 @@
+
+_nova_opts="" # lazy init
+_nova_flags="" # lazy init
+_nova_opts_exp="" # lazy init
+_nova()
+{
+	local cur prev nbc cflags
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+	if [ "x$_nova_opts" == "x" ] ; then
+		nbc="`nova bash-completion | sed -e "s/  *-h  */ /" -e "s/  *-i  */ /"`"
+		_nova_opts="`echo "$nbc" | sed -e "s/--[a-z0-9_-]*//g" -e "s/  */ /g"`"
+		_nova_flags="`echo " $nbc" | sed -e "s/ [^-][^-][a-z0-9_-]*//g" -e "s/  */ /g"`"
+		_nova_opts_exp="`echo "$_nova_opts" | tr ' ' '|'`"
+	fi
+
+	if [[ " ${COMP_WORDS[@]} " =~ " "($_nova_opts_exp)" " && "$prev" != "help" ]] ; then
+		COMPLETION_CACHE=~/.novaclient/*/*-cache
+		cflags="$_nova_flags "$(cat $COMPLETION_CACHE 2> /dev/null | tr '\n' ' ')
+		COMPREPLY=($(compgen -W "${cflags}" -- ${cur}))
+	else
+		COMPREPLY=($(compgen -W "${_nova_opts}" -- ${cur}))
+	fi
+	return 0
+}
+complete -F _nova nova

--- a/rpcd/playbooks/roles/rpc_support/tasks/autocompletion.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/autocompletion.yml
@@ -1,0 +1,35 @@
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- name: Create Openstack Completion directory
+  file:
+    path: "/etc/openstack_completions"
+    state: "directory"
+    mode: "0755"
+
+- name: Add source script to bash_completion.d
+  copy:
+    dest: "/etc/bash_completion.d/autocompletion_source.sh"
+    src: "autocompletion_source.sh.j2"
+
+- name: Add bash completion to openstack clients
+  copy:
+    dest: "/etc/openstack_completions/{{ item }}"
+    src: "{{ item }}.j2"
+  with_items:
+    - cinder.bash_completion
+    - glance.bash_completion
+    - heat.bash_completion
+    - keystone.bash_completion
+    - neutron.bash_completion
+    - nova.bash_completion

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -70,3 +70,5 @@
 - include: neutron_debug.yml
   when: >
     inventory_hostname in groups['neutron_agent']
+
+- include: autocompletion.yml


### PR DESCRIPTION
This patch adds bash autocompletion to the following Openstack clients:

    Cinder
    Glance
    Heat
    Keystone
    Neutron
    Nova

Bash completion will be available in all enviroments where the OpenStack
clients are installed. The autocompletion scripts are placed into a new
directory, and are sourced only if their respective client is present in
the enviroment.

(cherry picked from commit 2b8b04f29d7212e4d0cf07d25c4e5e83c9cb176d)