### PR TITLE
Bump version for r11.0.1

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
 # rpc-openstack version
-rpc_release: r11.1.0rc1
+rpc_release: r11.0.1
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment


### PR DESCRIPTION
Bump the rpc_openstack version to r11.0.1 in preparation for tagging.