### PR TITLE
Change label for cpu check

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
@@ -1,5 +1,5 @@
 type              : agent.cpu
-label             : cpu--{{ inventory_hostname|quote }}
+label             : cpu_check--{{ inventory_hostname|quote }}
 disabled          : false
 period            : "{{ maas_check_period }}"
 timeout           : "{{ maas_check_timeout }}"


### PR DESCRIPTION
Name of cpu check did not conform to the filename or it's name
causing it to fail validations