### PR TITLE
Add check validation step to maas role

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -345,6 +345,7 @@ infra_service_local_checks_list:
   - { name: "memcached_status", group: "memcached" }
 
 raxmon_repo_url: "http://stable.packages.cloudmonitoring.rackspace.com/ubuntu-14.04-x86_64"
+
 maas_apt_keys:
   - { url: "https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc", state: "present" }
 
@@ -378,6 +379,7 @@ maas_pip_dependencies:
 
 maas_plugin_dir: /opt/rpc-openstack/maas/plugins/
 
+maas_rpc_dir: /opt/rpc-openstack/
 #
 # maas_excluded_checks: List of checks and alarms to exclude from this deploy
 #

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_auto_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_auto_checks.yml
@@ -16,7 +16,7 @@
 - name: Install fileystem auto checks
   template:
     src: "filesystem_auto.yaml.j2"
-    dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item|replace('/', '_') }}--{{ inventory_hostname }}.yaml"
+    dest: "/etc/rackspace-monitoring-agent.conf.d/filesystem_{{ item|replace('/', '.') }}--{{ inventory_hostname }}.yaml"
     owner: "root"
     group: "root"
     mode: "0644"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_checks.yml
@@ -16,7 +16,7 @@
 - name: Install fileystem auto checks
   template:
     src: "filesystem.yaml.j2"
-    dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item.filesystem|replace('/', '_') }}--{{ inventory_hostname }}.yaml"
+    dest: "/etc/rackspace-monitoring-agent.conf.d/filesystem_{{ item.filesystem|replace('/', '.') }}--{{ inventory_hostname }}.yaml"
     owner: "root"
     group: "root"
     mode: "0644"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -55,3 +55,7 @@
   when: >
     inventory_hostname in groups['ceph_all'] and
     groups['ceph_all'] is defined
+
+- meta: flush_handlers
+
+- include: validate_checks.yml

--- a/rpcd/playbooks/roles/rpc_maas/tasks/validate_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/validate_checks.yml
@@ -1,0 +1,59 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Raxmon client doesn't make it very easy to just get the full check names due
+# to limited choices in formatting of output
+- name: Enumerate all checks found
+  script: "{{ maas_rpc_dir }}/scripts/rpc-maas-tool.py --tab True --prefix {{ inventory_hostname }} checks"
+  when:
+    - inventory_hostname in groups['hosts']
+  register: maas_after_checks
+  changed_when: False
+  failed_when: maas_after_checks.rc != 0
+  tags:
+    - maas-install
+    - maas-verify
+
+- name: Enumerate expected checks
+  shell: ls -1 /etc/rackspace-monitoring-agent.conf.d/ | sed -e 's/\.yaml$//'
+  when:
+    - maas_after_checks is defined
+  register: expected_checks
+  changed_when: False
+  tags:
+    - maas-install
+    - maas-verify
+
+- name: Verify presence of expected checks
+  fail: msg="Expected check ({{ item|replace('.', '/') }}) not found"
+  with_items:
+    - "{{ expected_checks.stdout_lines }}"
+  when:
+    - maas_after_checks is defined
+    - maas_after_checks.stdout.find("{{ item|replace('.', '/') }}") == -1
+  tags:
+    - maas-install
+    - maas-verify
+
+- name: Verify absence of excluded checks
+  fail: msg="Excluded check ({{ item|replace('.', '/') }}) found"
+  with_items:
+    - "{{ maas_excluded_checks }}"
+  when:
+    - maas_after_checks is defined
+    - maas_after_checks.stdout.find("{{ item|replace('.', '/') }}") != -1
+  tags:
+    - maas-install
+    - maas-verify

--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -38,6 +38,8 @@ def main(args):
         alarms(args, conn)
     elif args.command == 'check':
         check(args, conn)
+    elif args.command == 'checks':
+        checks(args, conn)
     elif args.command == 'delete':
         delete(args, conn)
     elif args.command == 'remove-defunct-checks':
@@ -50,9 +52,14 @@ def alarms(args, conn):
     for entity in _get_entities(args, conn):
         alarms = conn.list_alarms(entity)
         if alarms:
-            print('Entity %s (%s):' % (entity.id, entity.label))
-            for alarm in alarms:
-                print(' - %s' % alarm.label)
+            _write(args, entity, alarms)
+
+
+def checks(args, conn):
+    for entity in _get_entities(args, conn):
+        checks = conn.list_checks(entity)
+        if checks:
+            _write(args, entity, checks)
 
 
 def check(args, conn):
@@ -161,11 +168,20 @@ def _get_entities(args, conn):
     return entities
 
 
+def _write(args, entity, objects):
+    if args.tab:
+        for o in objects:
+            print("\t".join([entity.id, entity.label, o.label, o.id]))
+    else:
+        print('Entity %s (%s):' % (entity.id, entity.label))
+        for o in objects:
+            print(' - %s' % o.label)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Test MaaS checks')
     parser.add_argument('command',
                         type=str,
-                        choices=['alarms', 'check', 'delete',
+                        choices=['alarms', 'check', 'checks', 'delete',
                                  'remove-defunct-checks',
                                  'remove-defunct-alarms'],
                         help='Command to execute')
@@ -177,6 +193,11 @@ if __name__ == "__main__":
                         help='Limit testing to checks on entities labelled w/ '
                              'this prefix',
                         default=None)
+    parser.add_argument('--tab',
+                        type=bool,
+                        help='Output in tab-separated format, applies only to '
+                             'alarms and checks commands',
+                        default=False)
     args = parser.parse_args()
 
     main(args)


### PR DESCRIPTION
Validation is meant to verify that for each check file applied there
is a check generated. It must rely on each host having the correct
check files applied as the alternative to this would mean duplicating
significant logic.

For filesystem checks, the file on the filesystem will use a '.'
instead of a '/' but otherwise each check file in the filesystem
shall have a name that matches the label of the check as recorded
server-side.

The rpc-maas-tool has added a checks mode and a --tabs boolean option
to enable this validation