### PR TITLE
Add alarm verification step to maas role

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -58,4 +58,5 @@
 
 - meta: flush_handlers
 
-- include: validate_checks.yml
+- include: verify_checks.yml
+- include: verify_alarms.yml

--- a/rpcd/playbooks/roles/rpc_maas/tasks/verify_alarms.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/verify_alarms.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Raxmon client doesn't make it very easy to just get the full check names due
+# to limited choices in formatting of output
+- name: Enumerate all alarms found
+  script: "{{ maas_rpc_dir }}/scripts/rpc-maas-tool.py --tab True --prefix {{ inventory_hostname }} alarms"
+  when:
+    - inventory_hostname in groups['hosts']
+    - expected_checks is defined
+  register: maas_after_alarms
+  changed_when: False
+  failed_when: maas_after_alarms.rc != 0
+  tags:
+    - maas-install
+    - maas-verify
+
+- name: Verify presence of expected alarms
+  fail: msg="Expected alarm for check ({{ item }}) not found"
+  with_items:
+    - "{{ expected_checks.stdout_lines }}"
+  when:
+    - maas_after_alarms is defined
+    - maas_after_alarms.stdout.find("{{ item }}") == -1
+  tags:
+    - maas-install
+    - maas-verify

--- a/rpcd/playbooks/roles/rpc_maas/tasks/verify_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/verify_checks.yml
@@ -37,23 +37,23 @@
     - maas-verify
 
 - name: Verify presence of expected checks
-  fail: msg="Expected check ({{ item|replace('.', '/') }}) not found"
+  fail: msg="Expected check ({{ item }}) not found"
   with_items:
     - "{{ expected_checks.stdout_lines }}"
   when:
     - maas_after_checks is defined
-    - maas_after_checks.stdout.find("{{ item|replace('.', '/') }}") == -1
+    - maas_after_checks.stdout.find("{{ item }}") == -1
   tags:
     - maas-install
     - maas-verify
 
 - name: Verify absence of excluded checks
-  fail: msg="Excluded check ({{ item|replace('.', '/') }}) found"
+  fail: msg="Excluded check ({{ item }}) found"
   with_items:
     - "{{ maas_excluded_checks }}"
   when:
     - maas_after_checks is defined
-    - maas_after_checks.stdout.find("{{ item|replace('.', '/') }}") != -1
+    - maas_after_checks.stdout.find("{{ item }}") != -1
   tags:
     - maas-install
     - maas-verify

--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -171,11 +171,19 @@ def _get_entities(args, conn):
 def _write(args, entity, objects):
     if args.tab:
         for o in objects:
-            print("\t".join([entity.id, entity.label, o.label, o.id]))
+            if o.confd_name:
+                import ast
+
+                keys = ast.literal_eval(o.confd_name)
+            else:
+                keys = {"check": "default", "filename": ""}
+            print("\t".join([entity.id, entity.label, o.label, o.id,
+                             keys["filename"]]))
     else:
         print('Entity %s (%s):' % (entity.id, entity.label))
         for o in objects:
             print(' - %s' % o.label)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Test MaaS checks')


### PR DESCRIPTION
For every check, ensure that at least one alarm is attached to it.

This involves two primary changes:

- Add the verify tasks for alarms and invoke it after checks are
verified.

- Modify the tab format for checks and alarms to include the filename
the check originated from, if any. This simplifies the matching of
check labels listed from API against those on the filesystem and
eliminates some of the complexity with respect to needing to keep
these in sync resulting in a simpler system over all.

The term verify is used instead of validate as a secondary change.