### PR TITLE
bump osa sha and consume run-upgrade-old.sh script

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -36,7 +36,7 @@ openstack-ansible -i "localhost," patcher.yml
 
 # Do the upgrade for openstack-ansible components
 cd ${OA_DIR}
-echo 'YES' | ${OA_DIR}/scripts/run-upgrade.sh
+echo 'YES' | ${OA_DIR}/scripts/run-upgrade-old.sh
 
 # Prevent the deployment script from re-running the OA playbooks
 export DEPLOY_OA="no"


### PR DESCRIPTION
openstack-ansible has moved the original run-upgrade.sh script to
run-upgrade-old.sh. In order to continue to consume the QE tested path,
we should consume this instead of run-upgrade.sh, which now points at a
new, un(QE)tested upgrade path.

Partial: #504 

(cherry picked from commit 304a63d8b69f33410ffc05d1c7f2286433a790eb)