### PR TITLE
Fixing #495 which add the missing domain for a user list API request

### DIFF
--- a/maas/plugins/keystone_api_local_check.py
+++ b/maas/plugins/keystone_api_local_check.py
@@ -48,7 +48,7 @@ def check(args):
 
         # gather some vaguely interesting metrics to return
         project_count = len(keystone.projects.list())
-        user_count = len(keystone.users.list())
+        user_count = len(keystone.users.list(domain='Default'))
 
     status_ok()
     metric_bool('keystone_api_local_status', is_up)


### PR DESCRIPTION
This does only apply to v3 identity API which is already hard coded in this script.

Closes #495 
(Cherry picked from edc64ab)