### PR TITLE
 Upgrade maas to use template configuration

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -22,3 +22,6 @@ rpc_release: master
 # deployment
 repo_server_port: 8181
 openstack_repo_url: "http://{{ internal_lb_vip_address }}:{{ repo_server_port }}"
+
+# Location to store a catalog of migrations completed
+migrations_dir: /etc/openstack_deploy/migrations

--- a/rpcd/playbooks/maas-20151013-1-requirements.yml
+++ b/rpcd/playbooks/maas-20151013-1-requirements.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Part of MaaS Migration: maas-20151013.yml
+- name: Ensure MaaS Migration Requirements
+  hosts: hosts
+  user: root
+  tasks:
+    - name: Ensure migrations index exists
+      local_action: file path={{ migrations_dir }} state=directory
+      when: inventory_hostname == groups['hosts'][0]
+    - name: Locate evidence of prior MaaS migration
+      local_action: stat path={{ migrations_dir }}/maas-20151013
+      when: inventory_hostname == groups['hosts'][0]
+      register: maas_upgraded_result
+      changed_when: False
+    - name: Stop if migration has been run
+      fail: msg="MaaS has been previously run migration 20151013"
+      when:
+        - maas_upgraded_result is defined
+        - maas_upgraded_result.stat.exists | bool
+    - name: Locate existing Rackspace monitoring agent
+      stat: path=/etc/rackspace-monitoring-agent.cfg
+      register: raxmon
+      changed_when: False
+    - name: Halt if monitoring agent not found
+      fail: msg="MaaS is not installed and configured already"
+      when:
+       - raxmon is defined
+       - not raxmon.stat.exists
+

--- a/rpcd/playbooks/maas-20151013-2-pre-migrate.yml
+++ b/rpcd/playbooks/maas-20151013-2-pre-migrate.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Part of MaaS Migration: maas-20151013.yml
+- name: Record Prior Checks before MaaS Migration
+  hosts: hosts[0]
+  user: root
+  tasks:
+    - name: Inspect existing checks - all entities
+      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py --tab True checks"
+      register: maas_prior_checks
+      changed_when: False
+    - name: Record report of existing checks - all entities
+      local_action: lineinfile create=yes line="{{ item }}" dest=/tmp/maas_20151013_prior_checks.tab
+      with_items: "{{ maas_prior_checks.stdout_lines | sort }}"
+  vars_files:
+    - "roles/rpc_maas/defaults/main.yml"

--- a/rpcd/playbooks/maas-20151013-3-purge-checks.yml
+++ b/rpcd/playbooks/maas-20151013-3-purge-checks.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Migrate MaaS checks and alarms to template-driven configuration
+  hosts: hosts
+  user: root
+  pre_tasks:
+    - meta: flush_handlers
+  tasks:
+    - name: Lookup Entity ID for physical_host
+      shell: raxmon-entities-list | grep "label={{ physical_host|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+      register: entity_id
+      changed_when: False
+    - name: Identify checks to purge
+      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py --prefix {{ inventory_hostname }} --tab True checks"
+      register: checks_purge_list
+      changed_when: False
+    - name: Delete existing checks and alarms
+      shell: raxmon-checks-delete --entity-id={{ entity_id.stdout }} --id=$(echo '{{ item }}'| awk '{print $3}') --why="MaaS Migration 20151013"
+      when: inventory_hostname in "{{ item }}"
+      with_items: checks_purge_list.stdout_lines
+  post_tasks:
+    - name: Record migration in index
+      local_action: file path={{ migrations_dir }}/maas-20151013 state=touch
+      when: inventory_hostname == groups['hosts'][0]
+  vars_files:
+    - "roles/rpc_maas/defaults/main.yml"

--- a/rpcd/playbooks/maas-20151013-6-post-migrate.yml
+++ b/rpcd/playbooks/maas-20151013-6-post-migrate.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Part of MaaS Migration: maas-20151013.yml
+- name: Record Checks after MaaS Migration
+  hosts: hosts
+  user: root
+  tasks:
+    - name: Inspect existing checks - all entities
+      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py --tab True checks"
+      when: inventory_hostname == groups['hosts'][0]
+      register: maas_post_checks
+      changed_when: False
+    - name: Record report of existing checks - all entities
+      local_action: lineinfile create=yes line="{{ item }}" dest=/tmp/maas_20151013_post_checks.tab
+      with_items: "{{ maas_post_checks.stdout_lines | sort }}"
+      when: inventory_hostname == groups['hosts'][0]
+  vars_files:
+    - "roles/rpc_maas/defaults/main.yml"

--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -177,7 +177,7 @@ def _write(args, entity, objects):
                 keys = ast.literal_eval(o.confd_name)
             else:
                 keys = {"check": "default", "filename": ""}
-            print("\t".join([entity.id, entity.label, o.label, o.id,
+            print("\t".join([entity.id, entity.label, o.id, o.label,
                              keys["filename"]]))
     else:
         print('Entity %s (%s):' % (entity.id, entity.label))


### PR DESCRIPTION
 Adds a playbook to be run as a one-time operation to convert maas to
 use template based configuration. The playbook records a fingerprint
 of when it runs under /etc/openstack_deploy/migrations and will not
 run again if this file is present.

 The play will generate .tab files on the deploy host under /tmp for
 reporting the state of checks before and after upgrade.