### PR TITLE
Correct syntactically invalid when conditions

### DIFF
--- a/rpcd/playbooks/maas-20151013-1-requirements.yml
+++ b/rpcd/playbooks/maas-20151013-1-requirements.yml
@@ -28,16 +28,15 @@
       changed_when: False
     - name: Stop if migration has been run
       fail: msg="MaaS has been previously run migration 20151013"
-      when:
-        - maas_upgraded_result is defined
-        - maas_upgraded_result.stat.exists | bool
+      when: >
+        maas_upgraded_result is defined and
+          maas_upgraded_result.stat.exists | bool
     - name: Locate existing Rackspace monitoring agent
       stat: path=/etc/rackspace-monitoring-agent.cfg
       register: raxmon
       changed_when: False
     - name: Halt if monitoring agent not found
       fail: msg="MaaS is not installed and configured already"
-      when:
-       - raxmon is defined
-       - not raxmon.stat.exists
+      when: >
+       raxmon is defined and not raxmon.stat.exists
 


### PR DESCRIPTION
It turns out that when you pass a list to when, you get some interesting
errors from Ansible. Using the normal syntax fixes this problem for us.

Addresses #538