### PR TITLE
Adds a task to remove the previous rpc-release file

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/rpc_release.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/rpc_release.yml
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Remove previous rpc-release file
+  file:
+    path: "/etc/rpc-release"
+    state: absent
+  tags:
+    - rpc-release
+
 - name: Drop rpc-release file
   template:
     src: "rpc-release.j2"


### PR DESCRIPTION
Since there is already an existing `/etc/rpc-release` file a new file will never be dropped on upgrade.  This adds a task to remove the existing file if it exists, if no file exists the task will simply pass and a new `rpc-release` will be created.

Closes-Bug: #533