### PR TITLE
add some connection related monitors to galera_check plugin

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -307,6 +307,9 @@ connects to an individual member of a galera cluster and checks various statuses
     metric wsrep_cluster_status string primary
     metric wsrep_local_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
     metric wsrep_local_state_comment string synced
+    metric mysql_max_configured_connections int64 800 connections
+    metric mysql_current_connections int64 1 connections
+    metric mysql_max_seen_connections int64 2 connections
 
 ***
 #### conntrack_count.py

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -232,6 +232,10 @@ maas_filesystem_critical_threshold: 90.0
 #    warning_threshold: 80.0
 #    critical_threshold: 90.0
 
+# Maas mysql connection thresholds
+mysql_connection_warning_threshold: 80
+mysql_connection_critical_threshold: 90
+
 # MaaS CPU idle threshold
 cpu_idle_percent_avg_threshold: 10.0
 

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -15,7 +15,6 @@ alarms      :
             if (metric["wsrep_cluster_size"] < {{ groups["galera"] | length }}) {
                 return new AlarmStatus(CRITICAL, "Galera cluster size less than expected");
             }
-
     wsrep_local_state :
         label                   : wsrep_local_state--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
@@ -23,4 +22,15 @@ alarms      :
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_local_state_comment"] != "Synced" ) {
                 return new AlarmStatus(CRITICAL, "Galera cluster node not synced");
+            }
+    percentage_used_mysql_connections :
+        label                   : percentage_used_mysql_connections--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["mysql_current_connections"], metric["mysql_max_configured_connections"]) > {{ mysql_connection_critical_threshold }} ) {
+                return new AlarmStatus(CRITICAL, "Mysql connectons has exceeded {{ mysql_connection_critical_threshold }}% of configured maximum");
+            }
+            if (percentage(metric["mysql_current_connections"], metric["mysql_max_configured_connections"]) > {{ mysql_connection_warning_threshold }} ) {
+                return new AlarmStatus(WARNING, "Mysql connectons has exceeded {{ mysql_connection_warning_threshold }}% of configured maximum");
             }


### PR DESCRIPTION
Up to now, we've been grabbing specific matching data from the output
of 'SHOW STATUS'. This commit adds the output from 'SHOW VARIABLES', so
that we can grab the configuration vars too.i Additionally, we no longer
limit the captured data from 'SHOW STATUS'.

Having all of the output from 'SHOW VARIABLES' and 'SHOW STATUS' will
make it easy to add any further metrics/alarms to this plugin in the
future.

Additionally, 'SHOW STATUS' was changed to 'SHOW GLOBAL STATUS' to
ensure we are gathering global stats as opposed to 'this session' stats.

Some new metrics are also added:

current_connections
max_configured_connections
max_seen_connections
percentage_used_connections

Partially-Addresses: #550 