### PR TITLE
add some connection related monitors to galera_check plugin

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -307,6 +307,10 @@ connects to an individual member of a galera cluster and checks various statuses
     metric wsrep_cluster_status string primary
     metric wsrep_local_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
     metric wsrep_local_state_comment string synced
+    metric max_configured_connections int64 800 connections
+    metric current_connections int64 1 connections
+    metric max_seen_connections int64 2 connections
+    metric percentage_used_connections int64 0
 
 ***
 #### conntrack_count.py

--- a/maas/plugins/galera_check.py
+++ b/maas/plugins/galera_check.py
@@ -13,10 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import division
 
 import optparse
 import shlex
 import subprocess
+
 
 from maas_common import metric
 from maas_common import print_output
@@ -24,7 +26,7 @@ from maas_common import status_err
 from maas_common import status_ok
 
 
-def galera_status_check(arg):
+def galera_check(arg):
     proc = subprocess.Popen(shlex.split(arg),
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
@@ -35,7 +37,7 @@ def galera_status_check(arg):
     return ret, out, err
 
 
-def generate_query(host, port):
+def generate_query(host, port, type='status'):
     if host:
         host = ' -h %s' % host
     else:
@@ -45,10 +47,12 @@ def generate_query(host, port):
         port = ' -P %s' % port
     else:
         port = ''
-
-    return ('/usr/bin/mysql --defaults-file=/root/.my.cnf'
-            '%s%s -e "SHOW STATUS WHERE Variable_name REGEXP '
-            "'^(wsrep.*|queries)'\"") % (host, port)
+    if type == 'status':
+        return ('/usr/bin/mysql --defaults-file=/root/.my.cnf '
+                '%s%s -e "SHOW GLOBAL STATUS"') % (host, port)
+    elif type == 'variables':
+        return ('/usr/bin/mysql --defaults-file=/root/.my.cnf '
+                '%s%s -e "SHOW VARIABLES"') % (host, port)
 
 
 def parse_args():
@@ -82,25 +86,35 @@ def print_metrics(replica_status):
            replica_status['wsrep_local_state_uuid'])
     metric('wsrep_local_state_comment', 'string',
            replica_status['wsrep_local_state_comment'])
+    metric('max_configured_connections', 'int64',
+           replica_status['max_connections'], 'connections')
+    metric('current_connections', 'int64',
+           replica_status['Threads_connected'], 'connections')
+    metric('max_seen_connections', 'int64',
+           replica_status['Max_used_connections'], 'connections')
+    metric('percentage_used_connections', 'int64',
+           (int(int(replica_status['Threads_connected']) /
+            int(replica_status['max_connections'])) * 100))
 
 
 def main():
     options, _ = parse_args()
 
-    retcode, output, err = galera_status_check(
-        generate_query(options.host, options.port)
-    )
-
-    if retcode > 0:
-        status_err(err)
-
-    if not output:
-        status_err('No output received from mysql. Cannot gather metrics.')
-
-    show_status_list = output.split('\n')[1:-1]
     replica_status = {}
-    for i in show_status_list:
-        replica_status[i.split('\t')[0]] = i.split('\t')[1]
+    for i in ['status', 'variables']:
+        retcode, output, err = galera_check(
+            generate_query(options.host, options.port, type=i)
+        )
+
+        if retcode > 0:
+            status_err(err)
+
+        if not output:
+            status_err('No output received from mysql. Cannot gather metrics.')
+
+        show_list = output.split('\n')[1:-1]
+        for i in show_list:
+            replica_status[i.split('\t')[0]] = i.split('\t')[1]
 
     if replica_status['wsrep_cluster_status'] != "Primary":
         status_err("there is a partition in the cluster")


### PR DESCRIPTION
Up to now, we've been grabbing specific matching data from the output
of 'SHOW STATUS'. This commit adds the output from 'SHOW VARIABLES', so
that we can grab the configuration vars too.i Additionally, we no longer
limit the captured data from 'SHOW STATUS'.

Having all of the output from 'SHOW VARIABLES' and 'SHOW STATUS' will
make it easy to add any further metrics/alarms to this plugin in the
future.

Additionally, 'SHOW STATUS' was changed to 'SHOW GLOBAL STATUS' to
ensure we are gathering global stats as opposed to 'this session' stats.

Some new metrics are also added:

current_connections
max_configured_connections
max_seen_connections
percentage_used_connections

Partially-addresses: #550 

(cherry picked from commit 9bc48bef6fd73e042f49428f1da77f7a3d5d9d7f)