### PR TITLE
Convert pip tasks to support pip_install_options

### DIFF
--- a/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
+++ b/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
@@ -17,6 +17,7 @@
   pip:
     name: "{{ item }}"
     state: present
+    extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success
   retries: 5

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -32,6 +32,7 @@
   pip:
     name: "{{ item }}"
     state: present
+    extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success
   retries: 5

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -41,6 +41,7 @@
 - name: Install python dependencies
   pip:
     requirements: "{{ horizon_extensions_pip_requirements_file }}"
+    extra_args: "{{ pip_install_options | default('') }}"
 
 - name: "Create /etc/rackspace if it doesn't exist"
   file:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -25,6 +25,7 @@
   pip:
     name: "{{ item }}"
     state: present
+    extra_args: "{{ pip_install_options | default('') }}"
   with_flattened:
     - maas_pip_packages
     - maas_pip_dependencies

--- a/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
@@ -27,6 +27,7 @@
   pip:
     name: "{{ item }}"
     state: present
+    extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success
   retries: 2

--- a/rpcd/playbooks/test-maas.yml
+++ b/rpcd/playbooks/test-maas.yml
@@ -45,7 +45,9 @@
 - hosts: 127.0.0.1
   connection: local
   tasks:
-    - pip: name=virtualenv
+    - pip:
+        name: virtualenv
+        extra_args: "{{ pip_install_options | default('') }}"
       tags:
         - setup
 
@@ -53,7 +55,7 @@
       pip:
       args:
         requirements: /opt/rpc-openstack/maas/testing/requirements.txt
-        extra_args: "--isolated"
+        extra_args: "{{ pip_install_options | default('--isolated') }}"
         virtualenv: /opt/rpc-openstack/maas/testing/venv
       tags:
         - setup


### PR DESCRIPTION
In testing an upgrade from 10.1.15 to r11.0.x, @toxick found that some
packages installed on the host for MaaS need to be forcibly reinstalled
to match requirement constraints on newer packages. The case that
spurred this fix and the original issue was oslo.utils. The exact
information is documented in an issue comment.

Addresses #549