### PR TITLE
Ignore hosts without stdout_lines in maas post-migrate

### DIFF
--- a/rpcd/playbooks/maas-20151013-6-post-migrate.yml
+++ b/rpcd/playbooks/maas-20151013-6-post-migrate.yml
@@ -25,7 +25,7 @@
       changed_when: False
     - name: Record report of existing checks - all entities
       local_action: lineinfile create=yes line="{{ item }}" dest=/tmp/maas_20151013_post_checks.tab
-      with_items: "{{ maas_post_checks.stdout_lines | sort }}"
+      with_items: "{{ maas_post_checks.stdout_lines | default([]) | sort }}"
       when: inventory_hostname == groups['hosts'][0]
   vars_files:
     - "roles/rpc_maas/defaults/main.yml"


### PR DESCRIPTION
If stdout_lines wasn't collected calling |sort on it will not produce
anything valuable for with_items (which expects a list or set). So we
need to make sure we default to an empty list in that case.

Addresses #545
Supersedes #548