### PR TITLE
Ensure raxmon-agent's conf directory exists

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -87,6 +87,15 @@
     group: root
   notify: Restart raxmon agent
 
+- name: Ensure raspace-monitoring-agent config directory exists
+  file:
+    name: /etc/rackspace-monitoring-agent.conf.d
+    state: directory
+    group: root
+    owner: root
+  tags:
+    - rackspace-monitoring-agent-setup
+
 - name: Start raxmon agent
   service:
     name: rackspace-monitoring-agent


### PR DESCRIPTION
When we're setting up the rackspace-monitoring-agent we should ensure
the conf.d directory exists. This should be created as part of the
package install but we found this was an issue on a torn down lab and
prevented a complete upgrade test. This could be an issue on other
environments too during upgrades.

Addresses #544
Supersedes #547