### PR TITLE
Re-template raxrc file hosts for MaaS upgrade

### DIFF
--- a/rpcd/playbooks/maas-20151013-1-requirements.yml
+++ b/rpcd/playbooks/maas-20151013-1-requirements.yml
@@ -40,3 +40,8 @@
       when: >
        raxmon is defined and not raxmon.stat.exists
 
+- name: Ensure MaaS token is updated on hosts
+  hosts: hosts
+  user: root
+  roles:
+    - { role: "rpc_maas", tags: [ "drop-raxrc-config" ] }

--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_cli_config.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_cli_config.yml
@@ -20,3 +20,7 @@
     mode: 0600
     owner: root
     group: root
+  tags:
+    - drop-raxrc-config
+    - setup-raxmon-cli
+    - setup-rpc-maas-tool-config


### PR DESCRIPTION
When users first deploy MaaS they have to place a token in the correct
variables file. Tokens expire quickly so when they go to upgrade the
MaaS checks, then they'll need to upgrade their MaaS token again. We
need to ensure the token in the variable file is then placed on the
hosts in /root/.raxrc. This allows rpc-maas-tool.py to work as expected
within the playbooks.

Addresses #543 
Supersedes #546