### PR TITLE
Flush handlers to ensure the raxmon agent restarts

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/handlers/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/handlers/main.yml
@@ -12,9 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-- name: Restart raxmon agent
-  service:
-    name: rackspace-monitoring-agent
-    state: restarted
-  delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_checks.yml
@@ -24,4 +24,3 @@
     - "{{ drives }}"
   when: inventory_hostname in groups["hosts"]
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
@@ -26,7 +26,6 @@
     - inventory_hostname in groups["{{ item.group }}"]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent
 
 - name: Remove checks that are excluded
   file:
@@ -37,4 +36,3 @@
   when:
     - item.name in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
@@ -28,7 +28,6 @@
     - inventory_hostname != groups["{{ item.group }}"][0]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent
 
 - name: Remove checks that are excluded
   file:
@@ -39,4 +38,3 @@
   when:
     - item.name in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
@@ -27,7 +27,6 @@
     - inventory_hostname == groups["{{ item.group }}"][0]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent
 
 - name: Remove checks that are excluded
   file:
@@ -38,4 +37,3 @@
   when:
     - item.name in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-  notify: Restart raxmon agent

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -55,3 +55,5 @@
   when: >
     inventory_hostname in groups['ceph_all'] and
     groups['ceph_all'] is defined
+
+- include: restart_raxmon.yml

--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -85,7 +85,6 @@
     mode: 0600
     owner: root
     group: root
-  notify: Restart raxmon agent
 
 - name: Ensure raspace-monitoring-agent config directory exists
   file:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/restart_raxmon.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/restart_raxmon.yml
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install fileystem auto checks
-  template:
-    src: "filesystem_auto.yaml.j2"
-    dest: "/etc/rackspace-monitoring-agent.conf.d/filesystem_{{ item|replace('/', '.') }}--{{ inventory_hostname }}.yaml"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  with_items:
-    - "{{ drives }}"
-  when: inventory_hostname in groups["hosts"]
-  delegate_to: "{{ physical_host }}"
+- name: Restart rackspace-monitoring-agent service
+  service:
+    name: rackspace-monitoring-agent
+    state: restarted
+  tags:
+    - maas-setup
+    - rackspace-monitoring-agent-setup
+    - rackspace-monitoring-agent-restart


### PR DESCRIPTION
During upgrade testing we noticed that the handler which restarts the
rackspace-monitoring-agent service does not always seem to trigger, even
when it should. After reading http://wherenow.org/ansible-handlers/, we
decided to use flush_handlers.

Addresses #571