### PR TITLE
Prevent race creating Holland DB user

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_config.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_config.yml
@@ -31,6 +31,7 @@
       password: "{{ rpc_support_holland_password }}"
       priv: "*.*:ALL"
       state: present
+  run_once: true
   tags:
     - holland_sql_user
     - holland_all


### PR DESCRIPTION
Bypasses race by limiting creation to the first Galera node.

Fixes #556

(cherry picked from commit 607c284a21d3f128c0d1eba0debaf99e7951c377)