### PR TITLE
Remove unrequired vars file include

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -127,6 +127,7 @@ maas_horizon_scheme: https
 # maas_heat_cloudwatch_scheme: https
 # maas_swift_proxy_scheme: https
 
+cinder_service_port: 8776
 #
 # maas_keystone_user: The keystone user to use/create to allow monitoring plugins to query
 #                     OpenStack APIs.

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -26,5 +26,3 @@
   user: root
   roles:
     - { role: "rpc_maas", tags: [ "maas-setup" ] }
-  vars_files:
-    - "{{ rpc_repo_path }}/playbooks/roles/os_cinder/defaults/main.yml"


### PR DESCRIPTION
Move the cinder_service_port to maas defaults and remove the vars file
include for cinder default vars.

Fixes: #534