### PR TITLE
Fix for loop syntax for updating Ansible config

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,11 +36,11 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   if [[ ! -d /etc/openstack_deploy/ ]]; then
     ./scripts/bootstrap-aio.sh
     pushd ${RPCD_DIR}
-      for filename in $(find etc/openstack_deploy/ -type f -iname '*.yml');
+      for filename in $(find etc/openstack_deploy/ -type f -iname '*.yml'); do
         if [[ ! -a "/${filename}" ]]; then
           cp "${filename}" "/${filename}";
         fi
-        do ../scripts/update-yaml.py "/${filename}" "${filename}";
+        ../scripts/update-yaml.py "/${filename}" "${filename}";
       done
     popd
     # ensure that the elasticsearch JVM heap size is limited


### PR DESCRIPTION
37cc4fbda1551b71b572037f4b6519fc2b512d77 has introduced a bug because
the for-loop syntax is incorrect. This patch moves the 'do' so that the
loop will run.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/583