### PR TITLE
Allow Kibana's Elasticsearch public URL to be configurable

### DIFF
--- a/rpcd/playbooks/roles/kibana/defaults/main.yml
+++ b/rpcd/playbooks/roles/kibana/defaults/main.yml
@@ -20,6 +20,7 @@ kibana_sha256sum: "480562733c2c941525bfa26326b6fae5faf83109b452a6c4e283a5c37e308
 
 elasticsearch_http_port: 9200
 elasticsearch_vip: "{{ internal_lb_vip_address }}"
+elasticsearch_public_url: "https://{{ external_lb_vip_address }}:8443/elasticsearch/"
 
 kibana_apt_packages:
   - apache2

--- a/rpcd/playbooks/roles/kibana/templates/config.js
+++ b/rpcd/playbooks/roles/kibana/templates/config.js
@@ -29,7 +29,7 @@ function (Settings) {
      *  +elasticsearch: {server: "http://localhost:9200", withCredentials: true}+
      *
      */
-    elasticsearch: "https://{{ external_lb_vip_address }}:8443/elasticsearch/",
+    elasticsearch: "{{ elasticsearch_public_url }}",
 
     /** @scratch /configuration/config.js/5
      *


### PR DESCRIPTION
This patch adds a new configuration variable in order to allow the
public elasticsearch URL that Kibana uses for its javascript bits to
be configurable directly without affecting any other services.

The variable, elasticsearch_public_url, may be set in any of the
/etc/openstack_deploy/user_*.yml files.

Closes-Issue: https://github.com/rcbops/rpc-openstack/issues/586