### PR TITLE
Add a plugin and config to monitor 'whole cloud' level stats for nova

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -42,6 +42,26 @@ IP address of service to test
     metric nova_instances_in_state_ERROR uint32 0 instances
 
 ***
+#### nova_cloud_stats.py
+
+##### Description:
+Polls a nova API living on the specified IP. Checks statistics at the 'whole cloud' level and reports as metrics
+##### Mandatory Arguments:
+IP address of service to test
+##### Example Output:
+
+    status okay
+    metric cloud_resource_total_memory uint32 15704 Megabytes
+    metric cloud_resource_free_disk_space uint32 310 Gigabytes
+    metric cloud_resource_used_memory uint32 4096 Megabytes
+    metric cloud_resource_used_disk_space uint32 4 Gigabytes
+    metric cloud_resource_free_memory uint32 11608 Megabytes
+    metric cloud_resource_hypervisor_count uint32 2 hypervisors
+    metric cloud_resource_total_disk_space uint32 314 Gigabytes
+    metric cloud_resource_used_vcpus uint32 0 vcpu
+    metric cloud_resource_total_vcpus uint32 16 vcpu
+
+***
 #### cinder_api_local_check.py
 
 ##### Description:

--- a/maas/plugins/nova_cloud_stats.py
+++ b/maas/plugins/nova_cloud_stats.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import collections
+
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_nova_client
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+# The actual stat names from novaclient are nasty, so this mapping is used to
+# translate them to something more consistent and usable, as well as set the
+# units for each metric
+stats_mapping = {
+    'hypervisor_count': {
+        'stat_name': 'count', 'unit': 'hypervisors', 'type': 'uint32'
+    },
+    'total_disk_space': {
+        'stat_name': 'local_gb', 'unit': 'Gigabytes', 'type': 'uint32'
+    },
+    'used_disk_space': {
+        'stat_name': 'local_gb_used', 'unit': 'Gigabytes', 'type': 'uint32'
+    },
+    'free_disk_space': {
+        'stat_name': 'free_disk_gb', 'unit': 'Gigabytes', 'type': 'uint32'
+    },
+    'total_memory': {
+        'stat_name': 'memory_mb', 'unit': 'Megabytes', 'type': 'uint32'
+    },
+    'used_memory': {
+        'stat_name': 'memory_mb_used', 'unit': 'Megabytes', 'type': 'uint32'
+    },
+    'free_memory': {
+        'stat_name': 'free_ram_mb', 'unit': 'Megabytes', 'type': 'uint32'
+    },
+    'total_vcpus': {
+        'stat_name': 'vcpus', 'unit': 'vcpu', 'type': 'uint32'
+    },
+    'used_vcpus': {
+        'stat_name': 'vcpus_used', 'unit': 'vcpu', 'type': 'uint32'
+    }
+}
+
+
+def check(args):
+    auth_ref = get_auth_ref()
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
+
+    COMPUTE_ENDPOINT = (
+        'http://{ip}:8774/v2/{tenant_id}'.format(ip=args.ip,
+                                                 tenant_id=tenant_id)
+    )
+
+    try:
+        nova = get_nova_client(auth_token=auth_token,
+                               bypass_url=COMPUTE_ENDPOINT)
+    except Exception as e:
+        status_err(str(e))
+    else:
+        # get some cloud stats
+        stats = nova.hypervisor_stats.statistics()
+        cloud_stats = collections.defaultdict(dict)
+        for metric_name, vals in stats_mapping.iteritems():
+            cloud_stats[metric_name]['value'] = \
+                getattr(stats, vals['stat_name'])
+            cloud_stats[metric_name]['unit'] = \
+                vals['unit']
+            cloud_stats[metric_name]['type'] = \
+                vals['type']
+
+    status_ok()
+    for metric_name in cloud_stats.iterkeys():
+        metric('cloud_resource_%s' % metric_name,
+               cloud_stats[metric_name]['type'],
+               cloud_stats[metric_name]['value'],
+               cloud_stats[metric_name]['unit'])
+
+
+def main(args):
+    check(args)
+
+
+if __name__ == "__main__":
+    with print_output():
+        parser = argparse.ArgumentParser(
+            description='Check nova hypervisor stats')
+        parser.add_argument('ip',
+                            type=ipaddr.IPv4Address,
+                            help='nova API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -263,6 +263,14 @@ swift_container_replication_failure_percentage_threshold: 5.0
 swift_async_pending_failure_percentage_threshold: 5.0
 swift_async_pending_average_threshold: 25.0
 
+# cloud level resource thresholds
+cloud_resource_warning_memory: 80.0
+cloud_resource_critical_memory: 90.0
+cloud_resource_warning_vcpus: 80.0
+cloud_resource_critical_vcpus: 90.0
+cloud_resource_warning_disk_space: 80.0
+cloud_resource_critical_disk_space: 90.0
+
 # List of checks, by type - variable:
 hp_checks_list:
   - { name: "hp-memory", group: "hosts" }
@@ -315,6 +323,7 @@ openstack_service_local_checks_list:
   - { name: "nova_scheduler_check", group: "nova_scheduler" }
   - { name: "nova_consoleauth_check", group: "nova_console" }
   - { name: "nova_spice_console_check", group: "nova_console" }
+  - { name: "nova_cloud_stats_check", group: "nova_api_os_compute" }
 
 swift_checks_list:
   - { name: "swift_object_server_check", group: "swift_obj" }

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -1,0 +1,42 @@
+type: agent.plugin
+label: "nova_cloud_stats_check--{{ ansible_hostname }}"
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : nova_cloud_stats.py
+    args    : ["{{ ansible_ssh_host }}"]
+alarms      :
+    nova_cloud_memory_status :
+        label                   : nova_cloud_memory_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["cloud_resource_used_memory"], metric["cloud_resource_total_memory"]) > {{ cloud_resource_critical_memory }}) {
+                return new AlarmStatus(CRITICAL, "Total cloud memory usage exceeds critical threshold of {{ cloud_resource_critical_memory }}%");
+            }
+            if (percentage(metric["cloud_resource_used_memory"], metric["cloud_resource_total_memory"]) > {{ cloud_resource_warning_memory }}) {
+                return new AlarmStatus(WARNING, "Total cloud memory usage exceeds warning threshold of {{ cloud_resource_warning_memory }}%");
+            }
+    nova_cloud_disk_status :
+        label                   : nova_cloud_disk_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["cloud_resource_used_disk_space"], metric["cloud_resource_total_disk_space"]) > {{ cloud_resource_critical_disk_space }}) {
+                return new AlarmStatus(CRITICAL, "Total cloud disk_space usage exceeds critical threshold of {{ cloud_resource_critical_disk_space }}%");
+            }
+            if (percentage(metric["cloud_resource_used_disk_space"], metric["cloud_resource_total_disk_space"]) > {{ cloud_resource_warning_disk_space }}) {
+                return new AlarmStatus(WARNING, "Total cloud disk_space usage exceeds warning threshold of {{ cloud_resource_warning_disk_space }}%");
+            }
+    nova_cloud_vcpu_status :
+        label                   : nova_cloud_vcpu_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["cloud_resource_used_vcpus"], metric["cloud_resource_total_vcpus"]) > {{ cloud_resource_critical_vcpus }}) {
+                return new AlarmStatus(CRITICAL, "Total cloud vcpus usage exceeds critical threshold of {{ cloud_resource_critical_vcpus }}%");
+            }
+            if (percentage(metric["cloud_resource_used_vcpus"], metric["cloud_resource_total_vcpus"]) > {{ cloud_resource_warning_vcpus }}) {
+                return new AlarmStatus(WARNING, "Total cloud vcpus usage exceeds warning threshold of {{ cloud_resource_warning_vcpus }}%");
+            }


### PR DESCRIPTION
The new plugin will take all attributes from the 'nova
hypervisor-statistics' call and create metrics from them. This includes
information about vcpus, memory and disk, as well as hypervisor count.

Additionally, this commit adds a config template to create checks and
alert on threshold levels of each of these resources.

Partial: #593 