### PR TITLE
Bump rpc-openstack for RC4

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
 # rpc-openstack version
-rpc_release: r11.1.0rc2
+rpc_release: r11.1.0rc4
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment


### PR DESCRIPTION
This updates the `rpc_release` variable to RC4

Fixes-Issue: #597 