### PR TITLE
Use 169.254.169.254 for neutron metadata check

### DIFF
--- a/maas/plugins/neutron_metadata_local_check.py
+++ b/maas/plugins/neutron_metadata_local_check.py
@@ -27,7 +27,7 @@ from maas_common import status_ok
 # identify the first active neutron agents container on this host
 # network namespaces can only be accessed from within neutron agents container
 FIND_CONTAINER = shlex.split('lxc-ls -1 --running .*neutron_agents')
-SERVICE_CHECK = 'ip netns exec %s curl -fvs 127.0.0.1:80'
+SERVICE_CHECK = 'ip netns exec %s curl -fvs 169.254.169.254:80'
 
 
 def check(args):


### PR DESCRIPTION
The plugin uses the IP address 127.0.0.1 for monitoring the metadata
service availability, this is not the IP address used by nova instances
when accessing metadata and there have been reports of plugin failures
with this address.

This commit changes the IP address to 169.254.169.254 which should
increase the reliability of this plugin.

Closes-issue: #569