### PR TITLE
Add plugin and check/alarm to monitor volume group usage

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -177,6 +177,21 @@ Hostname or IP address of service to test
     ...
 
 ***
+#### vg_check.py
+
+##### Description:
+Checks the free/used/total space on an lvm volume group and reports as metrics
+##### Mandatory Arguments:
+Name of volume group to check
+##### Example Output:
+
+    status okay
+    metric cinder-volumes_vg_total_space int64 107369 Megabytes
+    metric cinder-volumes_vg_free_space int64 107369 Megabytes
+    metric cinder-volumes_vg_used_space int64 0 Megabytes
+    ...
+
+***
 #### neutron_service_check.py
 
 ##### Description:

--- a/maas/plugins/vg_check.py
+++ b/maas/plugins/vg_check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import shlex
+import subprocess
+
+
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+
+def run_command(arg):
+    proc = subprocess.Popen(shlex.split(arg),
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=False)
+
+    out, err = proc.communicate()
+    ret = proc.returncode
+    return ret, out, err
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Check space in a volume group')
+    parser.add_argument('vgname',
+                        help='Name of volume group to query')
+    return parser.parse_args()
+
+
+def print_metrics(sizes, vgname):
+    status_ok()
+    metric('%s_vg_total_space' % vgname, 'int64',
+           sizes['totalsize'], 'Megabytes')
+    metric('%s_vg_free_space' % vgname, 'int64',
+           sizes['free'], 'Megabytes')
+    metric('%s_vg_used_space' % vgname, 'int64',
+           sizes['used'], 'Megabytes')
+
+
+def main():
+    args = parse_args()
+    vgname = args.vgname
+    command = ('vgs %s --noheadings --units M '
+               '--nosuffix -o vg_size,vg_free') % (vgname)
+    retcode, output, err = run_command(command)
+
+    if retcode > 0:
+        status_err(err)
+
+    if not output:
+        status_err('No output received from vgs command. '
+                   'Cannot gather metrics.')
+
+    totalsize, free = [int(float(x)) for x in output.split()]
+    used = totalsize - free
+    sizes = {}
+    sizes['totalsize'] = totalsize
+    sizes['free'] = free
+    sizes['used'] = used
+    print_metrics(sizes, vgname)
+
+
+if __name__ == '__main__':
+    with print_output():
+        main()

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -236,6 +236,11 @@ maas_filesystem_critical_threshold: 90.0
 mysql_connection_warning_threshold: 80
 mysql_connection_critical_threshold: 90
 
+# cinder-volumes volume group thresholds
+cinder_volumes_vg_warning_threshold: 80.0
+cinder_volumes_vg_critical_threshold: 90.0
+cinder_vg_name: "{{ cinder_backends['lvm']['volume_group'] }}"
+
 # MaaS CPU idle threshold
 cpu_idle_percent_avg_threshold: 10.0
 
@@ -323,6 +328,9 @@ openstack_service_local_checks_list:
   - { name: "nova_scheduler_check", group: "nova_scheduler" }
   - { name: "nova_consoleauth_check", group: "nova_console" }
   - { name: "nova_spice_console_check", group: "nova_console" }
+
+cinder_vg_checks_list:
+  - { name: "cinder_vg_check", group: "cinder_volume", cinder_vg_name: "{{ cinder_vg_name }}" }
 
 swift_checks_list:
   - { name: "swift_object_server_check", group: "swift_obj" }

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -45,6 +45,12 @@
   when: >
     remote_check == true
 
+- include: ensure_local_checks.yml
+  vars:
+    checks: "{{ cinder_vg_checks_list }}"
+  when: >
+    cinder_backends['lvm'] is defined
+
 - include: swift.yml
   vars:
     external_vip_address: "{{ external_lb_vip_address }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
@@ -1,0 +1,20 @@
+type: agent.plugin
+label: cinder_vg_check--{{ ansible_hostname }}
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : vg_check.py
+    args    : ["{{ item.cinder_vg_name }}"]
+alarms      :
+    cinder_vg_space_status :
+        label                   : cinder_vg_space_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["{{ item.cinder_vg_name }}_vg_used_space"], metric["{{ item.cinder_vg_name }}_vg_total_space"]) > {{ cinder_volumes_vg_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "space in the {{ item.cinder_vg_name }} vg on this host is more than {{ cinder_volumes_vg_critical_threshold }}% used");
+            }
+            if (percentage(metric["{{ item.cinder_vg_name }}_vg_used_space"], metric["{{ item.cinder_vg_name }}_vg_total_space"]) > {{ cinder_volumes_vg_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "space in the {{ item.cinder_vg_name }} vg on this host is more than {{ cinder_volumes_vg_warning_threshold }}% used");
+            }


### PR DESCRIPTION
Plugin:
Takes vg name as an argument (defaults to cinder-volumes) and
reports the following metrics:

vg_total_space (Mb)
vg_free_space (Mb)
vg_used_space (Mb)

Also included is a config file to set up the check, and
warning/critical alarms on (default) 80/90% used.

The playbooks are run in such a way that the check should only be added
on a cinder_volume host where the cinder backend is lvm.

Partial: #615 