### PR TITLE
Prepare the repository for r11.0.4

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
 # rpc-openstack version
-rpc_release: r11.0.1
+rpc_release: r11.0.4
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment


### PR DESCRIPTION
This pulls in OSA 11.2.5 and updates the rpc_release variable.