### PR TITLE
Add required parameters to ES curator and fix typo

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
@@ -69,7 +69,7 @@
     minute: 0
     hour: 0
     user: "root"
-    job: "/usr/local/bin/curator --host {{ hostvars[inventory_hostname]['container_address'] }} delete --older_than {{ elasticsearch_prune_days }}"
+    job: "/usr/local/bin/curator --host {{ hostvars[inventory_hostname]['container_address'] }} delete indices --older-than {{ elasticsearch_prune_days }} --time-unit 'days' --timestring '%Y.%m.%d' --prefix 'logstash'"
     cron_file: "elasticsearch_curator"
   tags:
     - elasticsearch-post-install


### PR DESCRIPTION
This adds the following required parameters to ElasticSearch curator
* `--time-unit days`
* `--timestring %Y.%m.%d`
* `--prefix logstash`
* `indices`

And changes the flag `--older_than` to `--older-than`.

Closes-Bug: #630