### PR TITLE
Add script to run all maas plugins

### DIFF
--- a/scripts/run-maas-plugins.sh
+++ b/scripts/run-maas-plugins.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# This script is for exceuting rackspace monitoring agent plugins without
+# needing a connection to MAAS.
+
+# Usage: $0 [ -v ] FILTER_STRING
+# -v: print full plugin output even on success
+# FILTER_STRING: only config files including this string will be run.
+
+# Example:
+
+#  ./run-maas-plugins.sh rabbit
+#  rabbitmq_status--rpc_rabbit_mq_container-5079f706.yaml status okay
+#  rabbitmq_status--rpc_rabbit_mq_container-56acfe95.yaml status okay
+#  rabbitmq_status--rpc_rabbit_mq_container-58d015b1.yaml status okay
+
+NO_COLOUR="\033[0m"
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+
+run_plugin(){
+  config_file="$1"
+
+  # skip config files that don't define plugin checks
+  grep agent.plugin $config_file &>/dev/null ||\
+    { echo "Skipping as it doesn't define an agent.plugin check"; continue; }
+
+  # extract plugin filename from config file
+  plugin_file="$(awk '/^\s*file\s*:/{print $3}' <$config_file)"
+
+  # skip if no plugin is defined
+  [ -z $plugin_file ] &&\
+    { echo "Skipping as the 'file' field is empty"; continue; }
+
+  full_plugin_path="/usr/lib/rackspace-monitoring-agent/plugins/$plugin_file"
+
+  # skip if plugin not found
+  [ -f $full_plugin_path ] ||\
+    { echo "Skipping as plugin $full_plugin_path not found"; continue; }
+
+  # extract plugin args from config file
+  plugin_args="$(awk '/args/{gsub(/\s*args\s*:\s*/, ""); print}' <$config_file |tr -d "\",'][")"
+
+  $full_plugin_path $plugin_args
+
+}
+
+if [[ $1 == -v ]]
+then
+  VERBOSE=true
+  shift
+else
+  VERBOSE=false
+fi
+
+for path in /etc/rackspace-monitoring-agent.conf.d/*${1:-}*.yaml
+do
+  file=$(basename $path)
+  # run each plugin, prepending the file name to each line of output, store output in temp file
+  run_plugin "$path" 2>&1 |sed "s/^/$file /" >/tmp/maastesting
+
+  if [[ $VERBOSE == true ]]
+  then
+    cat /tmp/maastesting
+  else
+    #output status line if pass, otherwise log full output.
+    echo -en $GREEN; grep 'status okay' /tmp/maastesting || \
+      { echo -en $RED; cat /tmp/maastesting; }
+    echo -en $NO_COLOUR
+  fi
+done


### PR DESCRIPTION
Script does not rely on MAAS being reachable as the plugins are executed
locally and results reported on stdout. Useful for local testing of a
deployment or a new maas plugin.

For example:
Galera is having issues
```
root@rpcopenstack3:/opt/rpc-openstack# scripts/run-maas-plugins.sh galera
galera_check--rpcopenstack3_galera_container-0613dcd0.yaml status error ERROR 2003 (HY000): Can't connect to MySQL server on '172.29.238.23' (111)\n
galera_check--rpcopenstack3_galera_container-be62aff2.yaml status error ERROR 2003 (HY000): Can't connect to MySQL server on '172.29.239.90' (111)\n
galera_check--rpcopenstack3_galera_container-e83886e2.yaml status error there is a partition in the cluster
```

All fixed
```
root@rpcopenstack3:/opt/rpc-openstack# scripts/run-maas-plugins.sh  galera
galera_check--rpcopenstack3_galera_container-0613dcd0.yaml status okay
galera_check--rpcopenstack3_galera_container-be62aff2.yaml status okay
galera_check--rpcopenstack3_galera_container-e83886e2.yaml status okay
```

And now everything else works too :)
```
root@rpcopenstack3:/opt/rpc-openstack# scripts/run-maas-plugins.sh
cinder_api_local_check--rpcopenstack3_cinder_api_container-a963443f.yaml status okay
cinder_scheduler_check--rpcopenstack3_cinder_scheduler_container-4a1fd36f.yaml status okay
cinder_volume_check--rpcopenstack3.yaml status okay
conntrack_count--rpcopenstack3.yaml status okay
disk_utilisation--rpcopenstack3.yaml status okay
galera_check--rpcopenstack3_galera_container-0613dcd0.yaml status okay
galera_check--rpcopenstack3_galera_container-be62aff2.yaml status okay
galera_check--rpcopenstack3_galera_container-e83886e2.yaml status okay
glance_api_local_check--rpcopenstack3_glance_container-0d20536e.yaml status okay
glance_registry_local_check--rpcopenstack3_glance_container-0d20536e.yaml status okay
heat_api_local_check--rpcopenstack3_heat_apis_container-cae4eca4.yaml status okay
heat_cfn_api_check--rpcopenstack3_heat_apis_container-cae4eca4.yaml status okay
heat_cw_api_check--rpcopenstack3_heat_apis_container-cae4eca4.yaml status okay
horizon_local_check--rpcopenstack3_horizon_container-36c63ac8.yaml status okay
horizon_local_check--rpcopenstack3_horizon_container-9d3c7015.yaml status okay
keystone_api_local_check--rpcopenstack3_keystone_container-d41a28b3.yaml status okay
keystone_api_local_check--rpcopenstack3_keystone_container-f7d9f731.yaml status okay
memcached_status--rpcopenstack3_memcached_container-8188ca08.yaml status okay
neutron_api_local_check--rpcopenstack3_neutron_server_container-d2e5ac4e.yaml status okay
neutron_dhcp_agent_check--rpcopenstack3_neutron_agents_container-29f73ea7.yaml status okay
neutron_l3_agent_check--rpcopenstack3_neutron_agents_container-29f73ea7.yaml status okay
neutron_linuxbridge_agent_check--rpcopenstack3_neutron_agents_container-29f73ea7.yaml status okay
neutron_linuxbridge_agent_check--rpcopenstack3.yaml status okay
neutron_metadata_agent_check--rpcopenstack3_neutron_agents_container-29f73ea7.yaml status okay
neutron_metadata_agent_proxy_check--rpcopenstack3_neutron_agents_container-29f73ea7.yaml status okay
neutron_metering_agent_check--rpcopenstack3_neutron_agents_container-29f73ea7.yaml status okay
nova_api_local_check--rpcopenstack3_nova_api_os_compute_container-bd162ca9.yaml status okay
nova_api_metadata_local_check--rpcopenstack3_nova_api_metadata_container-8b7d1b2d.yaml status okay
nova_cert_check--rpcopenstack3_nova_cert_container-8ba19539.yaml status okay
nova_compute_check--rpcopenstack3.yaml status okay
nova_conductor_check--rpcopenstack3_nova_conductor_container-34443b29.yaml status okay
nova_consoleauth_check--rpcopenstack3_nova_console_container-1e056b4e.yaml status okay
nova_scheduler_check--rpcopenstack3_nova_scheduler_container-109a689a.yaml status okay
nova_spice_console_check--rpcopenstack3_nova_console_container-1e056b4e.yaml status okay
rabbitmq_status--rpcopenstack3_rabbit_mq_container-4261d3cf.yaml status okay
rabbitmq_status--rpcopenstack3_rabbit_mq_container-4da46299.yaml status okay
rabbitmq_status--rpcopenstack3_rabbit_mq_container-640bd794.yaml status okay
swift_account_replication_check--rpcopenstack3.yaml status okay
swift_account_server_check--rpcopenstack3.yaml status okay
swift_async_check--rpcopenstack3.yaml status okay
swift_container_replication_check--rpcopenstack3.yaml status okay
swift_container_server_check--rpcopenstack3.yaml status okay
swift_md5_check--rpcopenstack3.yaml status okay
swift_object_replication_check--rpcopenstack3.yaml status okay
swift_object_server_check--rpcopenstack3.yaml status okay
swift_proxy_server_check--rpcopenstack3_swift_proxy_container-b34c0a93.yaml status okay
swift_quarantine_check--rpcopenstack3.yaml status okay
```