### PR TITLE
Disable neutron metadata proxy check/alarm

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -195,21 +195,6 @@
 
 - include: local_setup.yml
   vars:
-    check_name: neutron_metadata_agent_proxy_check
-    check_details: file=neutron_metadata_local_check.py,args={{ internal_vip_address }}
-    check_period: "{{ maas_check_period }}"
-    check_timeout: "{{ maas_check_timeout }}"
-    alarms:
-      - { 'name': 'neutron_metadata_agent_proxy_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["neutron-metadata-agent-proxy_status"] != 1) { return new AlarmStatus(CRITICAL, "neutron-metadata-agent-proxy non-responsive"); }' }
-  user: root
-  vars_files:
-    - "{{ rpc_repo_path }}/playbooks/roles/os_neutron/defaults/main.yml"
-  when: >
-    inventory_hostname in groups['neutron_metadata_agent']
-
-
-- include: local_setup.yml
-  vars:
     check_name: neutron_metering_agent_check
     check_details: file=neutron_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"


### PR DESCRIPTION
This maas check does not work in our common configuration and the
strategy being used is ill-fit for the varied networks it needs to
test.

Functional Backport of: #639
Addresses: #569