### PR TITLE
Search for the current host in nodes

### DIFF
--- a/maas/plugins/rabbitmq_status.py
+++ b/maas/plugins/rabbitmq_status.py
@@ -59,7 +59,16 @@ CONNECTIONS_METRICS = {"max_channels_per_conn": "channels"}
 
 def hostname():
     """Return the name of the current host/node."""
-    return subprocess.check_output(['hostname']).strip()
+    return subprocess.check_output(['hostname', '-s']).strip()
+
+
+def rabbit_version(node):
+    if ('applications' in node and 'rabbit' in node['applications']
+            and 'version' in node['applications']['rabbit']):
+        version_string = node['applications']['rabbit']['version']
+        return tuple(int(part) for part in version_string.split('.'))
+    else:
+        return tuple()
 
 
 def parse_args():
@@ -135,28 +144,36 @@ def main():
     is_cluster_member = False
     if r.ok:
         resp_json = r.json()
-        for k, v in NODES_METRICS.items():
-            metrics[k] = {'value': resp_json[0][k], 'unit': v}
-
         # Ensure this node is a member of the cluster
-        is_cluster_member = any(n['name'].endswith(name) for n in resp_json)
-        # Gather the queue lengths for all nodes in the cluster
-        queues = [n['run_queue'] for n in resp_json]
-        # Grab the first queue length
-        first = queues.pop()
-        # Check that all other queues are equal to it
-        if not all(first == q for q in queues):
-            # If they're not, the queues are not synchronized
-            status_err('Cluster not replicated across all nodes')
+        nodes_matching_name = [n for n in resp_json
+                               if n['name'].endswith(name)]
+        is_cluster_member = any(nodes_matching_name)
+
+        if CLUSTERED:
+            if len(r.json()) < CLUSTER_SIZE:
+                status_err('cluster too small')
+            if not is_cluster_member:
+                status_err('{0} not a member of the cluster'.format(name))
+
+        for k, v in NODES_METRICS.items():
+            metrics[k] = {'value': nodes_matching_name[0][k], 'unit': v}
+
+        # We don't know exactly which version introduces data for all
+        #   nodes in the cluster returned by the NODES_URL, but we know it is
+        #   in 3.5.x at least.
+        if rabbit_version(nodes_matching_name[0]) > (3, 5):
+            # Gather the queue lengths for all nodes in the cluster
+            queues = [n['run_queue'] for n in resp_json
+                      if n.get('run_queue', None)]
+            # Grab the first queue length
+            first = queues.pop()
+            # Check that all other queues are equal to it
+            if not all(first == q for q in queues):
+                # If they're not, the queues are not synchronized
+                status_err('Cluster not replicated across all nodes')
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))
-
-    if CLUSTERED:
-        if len(r.json()) < CLUSTER_SIZE:
-            status_err('cluster too small')
-        if not is_cluster_member:
-            status_err('{0} not a member of the cluster'.format(name))
 
     status_ok()
 


### PR DESCRIPTION
To ensure we find the current host we should search for the hostname
without domain in the response array of nodes, and then proceed to
collect metrics from that dict.

We ensure we check that the RabbitMQ version is at least 3.5.x before
checking the lengths of queues on all nodes since we know that this
check is not valid in version 3.3.5 and further noodling into the
version where that feature becomes available can be deferred based on
need.

Addresses: #610
(cherry picked from commit 78bdd1d39cd845359ac62b5a837f57439cf62cc3)