### PR TITLE
Configure pip.conf prior to running the rpc-support playbook

### DIFF
--- a/rpcd/playbooks/rpc-support.yml
+++ b/rpcd/playbooks/rpc-support.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: repo-pip-setup.yml
+
 - name: Setup hosts for rpc-support
   hosts: hosts:all_containers
   user: root


### PR DESCRIPTION
This fix makes sure that a proper pip.conf is in place so it can
pull down pip packages from the local repo clones rather than
upstream. Usually rpc-support is executed after the repo-pip-setup.yml
playbook but this fix will include repo-pip-setup.yml as a safety
precaution

Cherry-Picked 551f7c1db7a1dbb8bcecd265981485f4063c6481
Closes-Bug: #634