### PR TITLE
Reify linting for multi-portion gating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: python
 
-script: ./scripts/linting.sh
+before_script:
+- pip install tox
+
+script: tox
 
 notifications:
     email: false
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=flake8
+    - python: 2.7
+      env: TOXENV=ansible-lint
+
+sudo: false

--- a/scripts/linting-ansible.sh
+++ b/scripts/linting-ansible.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -euo pipefail
+
+## Main ----------------------------------------------------------------------
+if [[ -z "$VIRTUAL_ENV" ]] ; then
+    echo "WARNING: Not running hacking inside a virtual environment."
+fi
+
+# Put local inventory in a var so we're not polluting the file system too much
+LOCAL_INVENTORY='[all]\nlocalhost ansible_connection=local'
+
+pushd rpcd/playbooks/
+  echo "Running ansible-playbook syntax check"
+  # Do a basic syntax check on all playbooks and roles.
+  ansible-playbook -i <(echo $LOCAL_INVENTORY) --syntax-check *.yml --list-tasks
+  # Perform a lint check on all playbooks and roles.
+  ansible-lint --version
+  # Skip ceph roles because they're submodules and not ours to lint
+  # NOTE(sigmavirus24): If
+  # https://github.com/willthames/ansible-lint/issues/80 is accepted and
+  # merged, get rid of these awful hacks around removing directories and
+  # re-placing them.
+  rm -r roles/ceph-common
+  rm -r roles/ceph-mon
+  rm -r roles/ceph-osd
+  echo "Running ansible-lint"
+  # Lint playbooks and roles
+  ansible-lint *.yml
+  # Revert changes to deleting submodules
+  git checkout .
+  # Re-clone the submodules for the next run
+  git submodule update >/dev/null
+popd

--- a/scripts/linting-pep8.sh
+++ b/scripts/linting-pep8.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,11 @@
 ## Shell Opts ----------------------------------------------------------------
 set -euo pipefail
 
-python -m tox
+## Main ----------------------------------------------------------------------
+if [[ -z "$VIRTUAL_ENV" ]] ; then
+    echo "WARNING: Not running hacking inside a virtual environment."
+fi
+
+flake8 $(grep -rln -e '^#!/usr/bin/env python' \
+                   -e '^#!/bin/python' \
+                   -e '^#!/usr/bin/python' * )

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,21 @@
+[tox]
+minversion = 2.0
+skipsdist = True
+envlist = flake8,ansible-lint
+
+[testenv]
+basepython = python2.7
+deps =
+    -ropenstack-ansible/dev-requirements.txt
+
+[testenv:flake8]
+commands =
+    {toxinidir}/scripts/linting-pep8.sh
+
+[testenv:ansible-lint]
+commands =
+    {toxinidir}/scripts/linting-ansible.sh
+
 [flake8]
 # Ignores the following rules due to how ansible modules work in general
 #     F403 'from ansible.module_utils.basic import *' used; unable to detect undefined names


### PR DESCRIPTION
Fixes-bug: #595 

--

This splits the gating out into two linting scripts:

- `scripts/linting-pep8.sh`
- `scripts/linting-ansible.sh`

And it changes `scripts/linting.sh` to use `tox` to isolate those dependencies and run them in virtual environments for us.

This also updates our Travis-CI configuration to run tox for each of the two checks. One check may fail while another may pass and the output from both will be easily readable from both. Travis will report "one check" to GitHub, but it has two "sub-checks" that it runs - one for hacking/flake8, one for ansible-lint.