### PR TITLE
remove neutron_metadata_agent_proxy_check from checks list

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -309,7 +309,6 @@ openstack_service_local_checks_list:
   - { name: "neutron_l3_agent_check", group: "neutron_l3_agent" }
   - { name: "neutron_linuxbridge_agent_check", group: "neutron_linuxbridge_agent" }
   - { name: "neutron_metadata_agent_check", group: "neutron_metadata_agent" }
-  - { name: "neutron_metadata_agent_proxy_check", group: "neutron_metadata_agent" }
   - { name: "neutron_metering_agent_check", group: "neutron_metering_agent" }
   - { name: "nova_api_metadata_local_check", group: "nova_api_metadata" }
   - { name: "nova_api_local_check", group: "nova_api_os_compute" }


### PR DESCRIPTION
commit https://github.com/rcbops/rpc-openstack/commit/a859736660355111c8eef26a2f079c40b9a98734 removed the yaml template for deploying the
metadata_agent_proxy_check, but we left the check name in the list of
templates to deploy. Therefore, deployments are failing because they
can't find the template file.

This commit removes the name from the list of templates to deploy

Addresses: #569 