### PR TITLE
Fix typo in alarm name for linuxbridge agent

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -8,7 +8,7 @@ details     :
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_linuxbridge_agent_status :
-        label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}
+        label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}


### PR DESCRIPTION
The linuxbridge-agent alarm was incorrectly labelled as "dhcp_agent".
This has been changed to correctly reflect "linuxbridge_agent"

Fixes Issue: #649