### PR TITLE
Updated iRule addition to tmsh one-liner

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -541,9 +541,9 @@ def main():
 
     commands.extend([
         '### CREATE SECURITY iRULE ###',
-        'create ltm rule /' + PART + '/' + PREFIX_NAME + '_DISCARD_ALL',
-        '   --> Copy and Paste the following between pre-included curly brackets <--',
-        'when CLIENT_ACCEPTED { discard }\n',
+        'run util bash',
+        'tmsh create ltm rule /' + PART + '/' + PREFIX_NAME + '_DISCARD_ALL when CLIENT_ACCEPTED { discard }',
+        'exit',
         '### CREATE EXTERNAL MONITOR ###',
         '   --> Upload External monitor file to disk <--',
         '       run util bash',


### PR DESCRIPTION
Fixed the following error that kept the Nova spice pool from being generated: Inventory group "nova_console" not found, skipping.

Allows the F5 engineer to copy/paste the F5 configuration without having to interact with the text editor on the F5. If you want to abandon this commit, we can submit a new PR with additional changes.

This is one commit from previous pr https://github.com/rcbops/rpc-openstack/pull/266
  