### PR TITLE
Add /etc/ansible/roles to roles_path

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -24,7 +24,7 @@ library = ../../openstack-ansible/playbooks/library/
 
 # Set the path to the folder in openstack-ansible which holds the roles
 # that are depended on by the rpc-openstack roles
-roles_path = ../../openstack-ansible/playbooks/roles/
+roles_path = ../../openstack-ansible/playbooks/roles/:/etc/ansible/roles/
 
 # Set the path to the folder in openstack-ansible which holds the
 # lookup plugins required


### PR DESCRIPTION
Openstack Ansible now imports some externala roles to /etc/ansible/roles,
These must be in the roles path in rpc-openstack to be available to
rpc-openstack plays.

closes #659