### PR TITLE
Upgrade the upgrade script

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -36,7 +36,7 @@ openstack-ansible -i "localhost," patcher.yml
 
 # Do the upgrade for openstack-ansible components
 cd ${OA_DIR}
-echo 'YES' | ${OA_DIR}/scripts/run-upgrade-old.sh
+echo 'YES' | ${OA_DIR}/scripts/run-upgrade.sh
 
 # Prevent the deployment script from re-running the OA playbooks
 export DEPLOY_OA="no"


### PR DESCRIPTION
This change removes the old upgrade script in favor of the new upgrade
script. This should prove to be more stable and supportable for all
future upgrades.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>