### PR TITLE
Update fail messages for MaaS entity discovery

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -42,9 +42,14 @@
   shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
   register: entity_count
 
+- name: Zero entities with label {{ entity_name }} exist
+  fail:
+    msg: "Zero entities with the label {{ entity_name }} exist. Entities should be created as part of the hardware provisioning process, if missing, please consult the internal documentation for associating one with the device."
+  when: entity_count.stdout|int == 0
+
 - name: At most one {{ entity_name }} entity exists
   fail:
-    msg: "Entity count of {{ entity_count.stdout }} != 1 for entity with the label {{ entity_name }}"
+    msg: "Entity count of {{ entity_count.stdout }} != 1 for entity with the label {{ entity_name }}. Reduce the entity count to one by deleting or re-labelling the duplicate entities."
   when: entity_count.stdout|int != 1
 
 - name: Get entity {{ entity_name }}


### PR DESCRIPTION
Entities should alway exist for the customers hardware and are created
when it is assigned to the account. This commit updates the error
messages generated to be clearer about the action support should take.

The use of entites is not RPC specific and so no additional
documentation should be required.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/155