### PR TITLE
Update rpc_release variable for r11.1.0

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -16,7 +16,7 @@
 rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
 # rpc-openstack version
-rpc_release: r11.1.0rc5
+rpc_release: r11.1.0
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment


### PR DESCRIPTION
Updates the `rpc_release` variable to r11.1.0 for release.

Fixes-Bug: #665