### PR TITLE
Fix expires_at vs expires mismatch in v2 auth token

### DIFF
--- a/maas/plugins/maas_common.py
+++ b/maas/plugins/maas_common.py
@@ -342,7 +342,8 @@ class MaaSException(Exception):
 def is_token_expired(token):
     for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%fZ'):
         try:
-            expires = datetime.datetime.strptime(token['expires_at'], fmt)
+            expire_expr = token.get('expires_at', token.get('expires'))
+            expires = datetime.datetime.strptime(expire_expr, fmt)
             break
         except ValueError as e:
             pass


### PR DESCRIPTION
Just checking for either label on the key works as a solution
for both versions. Just tested by pulling down a patched
maas_commons.py and in the interpreter running get_auth_ref()
against devstack (Auth v2) and an OSA master instance (Auth v3).

Addresses: #668