### PR TITLE
Add MaaS compatibility with Keystone v2.0

### DIFF
--- a/maas/plugins/cinder_api_local_check.py
+++ b/maas/plugins/cinder_api_local_check.py
@@ -20,7 +20,6 @@ import collections
 import ipaddr
 # Technically maas_common isn't third-party but our own thing but hacking
 # consideres it third-party
-from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
 from maas_common import metric_bool
@@ -37,9 +36,9 @@ VOLUME_STATUSES = ['available', 'in-use', 'error']
 # cinderclient. Only way to test local is direct http. :sadface:
 
 
-def check(auth_ref, args):
+def check(args):
 
-    keystone = get_keystone_client(auth_ref)
+    keystone = get_keystone_client()
     auth_token = keystone.auth_token
     VOLUME_ENDPOINT = ('http://{ip}:8776/v1/{tenant}'.format
                        (ip=args.ip, tenant=keystone.tenant_id))
@@ -96,8 +95,7 @@ def check(auth_ref, args):
 
 
 def main(args):
-    auth_ref = get_auth_ref()
-    check(auth_ref, args)
+    check(args)
 
 if __name__ == "__main__":
     with print_output():

--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -18,7 +18,6 @@ import argparse
 
 # Technically maas_common isn't third-party but our own thing but hacking
 # consideres it third-party
-from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric_bool
 from maas_common import print_output
@@ -32,9 +31,8 @@ from requests import exceptions as exc
 # cinderclient. Only way to test local is direct http. :sadface:
 
 
-def check(auth_ref, args):
-
-    keystone = get_keystone_client(auth_ref)
+def check(args):
+    keystone = get_keystone_client()
     auth_token = keystone.auth_token
     VOLUME_ENDPOINT = (
         'http://{hostname}:8776/v1/{tenant}'.format(hostname=args.hostname,
@@ -86,8 +84,7 @@ def check(auth_ref, args):
 
 
 def main(args):
-    auth_ref = get_auth_ref()
-    check(auth_ref, args)
+    check(args)
 
 if __name__ == "__main__":
     with print_output():

--- a/maas/plugins/glance_api_local_check.py
+++ b/maas/plugins/glance_api_local_check.py
@@ -18,7 +18,6 @@ import argparse
 import collections
 
 import ipaddr
-from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
 from maas_common import metric_bool
@@ -31,10 +30,10 @@ from requests import exceptions as exc
 IMAGE_STATUSES = ['active', 'queued', 'killed']
 
 
-def check(auth_ref, args):
+def check(args):
     # We call get_keystone_client here as there is some logic within to get a
     # new token if previous one is bad.
-    keystone = get_keystone_client(auth_ref)
+    keystone = get_keystone_client()
     auth_token = keystone.auth_token
     api_endpoint = 'http://{ip}:9292/v1'.format(ip=args.ip)
 
@@ -83,8 +82,7 @@ def check(auth_ref, args):
 
 
 def main(args):
-    auth_ref = get_auth_ref()
-    check(auth_ref, args)
+    check(args)
 
 
 if __name__ == "__main__":

--- a/maas/plugins/glance_registry_local_check.py
+++ b/maas/plugins/glance_registry_local_check.py
@@ -17,7 +17,6 @@
 import argparse
 
 import ipaddr
-from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
 from maas_common import metric_bool
@@ -28,10 +27,10 @@ import requests
 from requests import exceptions as exc
 
 
-def check(auth_ref, args):
+def check(args):
     # We call get_keystone_client here as there is some logic within to get a
     # new token if previous one is bad.
-    keystone = get_keystone_client(auth_ref)
+    keystone = get_keystone_client()
     auth_token = keystone.auth_token
     registry_endpoint = 'http://{ip}:9191'.format(ip=args.ip)
 
@@ -60,8 +59,7 @@ def check(auth_ref, args):
 
 
 def main(args):
-    auth_ref = get_auth_ref()
-    check(auth_ref, args)
+    check(args)
 
 
 if __name__ == "__main__":

--- a/maas/plugins/service_api_local_check.py
+++ b/maas/plugins/service_api_local_check.py
@@ -17,7 +17,6 @@
 import argparse
 
 import ipaddr
-from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
 from maas_common import metric_bool
@@ -31,8 +30,7 @@ def check(args):
     headers = {'Content-type': 'application/json'}
     path_options = {}
     if args.auth:
-        auth_ref = get_auth_ref()
-        keystone = get_keystone_client(auth_ref)
+        keystone = get_keystone_client()
         auth_token = keystone.auth_token
         project_id = keystone.project_id
         headers['auth_token'] = auth_token


### PR DESCRIPTION
Currently the OpenStack MaaS plugins only support v3. The OSP project
requires that the plugins support Keystone v2.0.

This commit updates maas_common.py and the plugins so that both Keystone
v2.0 and v3 are supported.

Closes-Issue: https://github.com/rcbops/rpc-openstack/issues/668