### PR TITLE
Adjust disk utilisation devices variable

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
@@ -21,7 +21,7 @@
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ disk_utilisation_checks_list }}"
-    devices: "[{% for device in ansible_devices.keys() %}{% if (device not in maas_excluded_devices|default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') %}'{{ device }}',{% endif %}{% endfor %}]"
+    disk_util_devices: "[{% for device in ansible_devices.keys() %}{% if (device not in maas_excluded_devices|default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') %}'{{ device }}',{% endif %}{% endfor %}]"
 
 - name: Gathering facts for mounted drives
   set_fact:

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -7,7 +7,7 @@ details     :
     file    : disk_utilisation.py
     args    : ["{{ ansible_ssh_host }}"]
 alarms      :
-{% for device in devices %}
+{% for device in disk_util_devices %}
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"


### PR DESCRIPTION
The current variable "devices" overlaps with ceph, in that we need to
specify a list of "devices" for ceph to use, and this var is then taken
to be used by the disk utilisation monitoring.

This causes incorrect (and failing) disk utilisation MaaS
checks/alarms to be setup.

Fixes-Issue: #676