### PR TITLE
Fix ceph_osd stats template file

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -5,7 +5,7 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : ceph_monitoring.py
-    args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') | quote }}"]
+    args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') }}"]
 alarms      :
 {% for osd_id in ceph_osd_host['osd_ids'] %}
     ceph_warn_osd.{{ osd_id }} :
@@ -13,7 +13,7 @@ alarms      :
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["osd.{{ osd_id }}"] == 0) {
+            if (metric["osd.{{ osd_id }}_up"] == 0) {
                 return new AlarmStatus(CRITICAL, "Ceph osd error.");
             }
 {% endfor %}


### PR DESCRIPTION
The ceph_osd checks/alarms were not returning metrics because of
additional quoting around the OSD number list.

Additionally, the metric requested should be "osd.x_up" rather than just
"osd.x".

This patch fixes both those issues.

Fixes-Issue: #675