### PR TITLE
Don't monitor Cinder Volume LVs for disk util.

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
@@ -17,10 +17,11 @@
   vars:
     checks: "{{ cpu_memory_checks_list }}"
 
+
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ disk_utilisation_checks_list }}"
-    devices: "[{% for device in ansible_devices.keys()%}{% if device not in maas_excluded_devices|default([]) %}'{{ device }}',{% endif %}{% endfor %}]"
+    devices: "[{% for device in ansible_devices.keys() %}{% if (device not in maas_excluded_devices|default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') %}'{{ device }}',{% endif %}{% endfor %}]"
 
 - name: Gathering facts for mounted drives
   set_fact:


### PR DESCRIPTION
The disk utilisation monitoring will monitor cinder volumes if they are
attached to an instance and you run the MaaS play again.

We need to avoid this by ensuring that the model of moniitored disks is
not 'VIRTUAL-DISK'.

Closes-Issues: #38
(cherry picked from commit 57493ffb7ac11633635680dcaf772fbbde565ba2)