### PR TITLE
Add Metadata iptables rule for AIOs

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -114,6 +114,19 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   # setup the infrastructure
   run_ansible setup-infrastructure.yml
 
+  # This section is duplicated from OSA/run-playbooks as RPC doesn't currently
+  # make use of run-playbooks. (TODO: hughsaunders)
+  # When running in an AIO, we need to drop the following iptables rule in any neutron_agent containers
+  # to ensure that instances can communicate with the neutron metadata service.
+  # This is necessary because in an AIO environment there are no physical interfaces involved in
+  # instance -> metadata requests, and this results in the checksums being incorrect.
+  if [ "${DEPLOY_AIO}" == "yes" ]; then
+    ansible neutron_agent -m command \
+                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
+    ansible neutron_agent -m shell \
+                          -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
+  fi
+
   # setup openstack
   run_ansible setup-openstack.yml
 


### PR DESCRIPTION
Needed to ensure that instance --> neuton metadata agent http requests
work. When an OSA AIO is deployed, this rule is added in run-playbooks. However the rpc deploy scripts do not make use of run-playbooks so the rule doesn't get added. 

This patch copies the code to created the iptables rule from OSA/scripts/run-playbooks to RPC/scripts/deploy

Related: #689