### PR TITLE
Enable MAAS on AIOs

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,8 +31,6 @@ cd ${OA_DIR}
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   # force the deployment of haproxy for an AIO
   export DEPLOY_HAPROXY="yes"
-  # disable the deployment of MAAS for an AIO
-  export DEPLOY_MAAS="no"
   if [[ ! -d /etc/openstack_deploy/ ]]; then
     ./scripts/bootstrap-aio.sh
     pushd ${RPCD_DIR}


### PR DESCRIPTION
Removed a line that explicitly disables MAAS deployment on AIOs
regardless of the value of DEPLOY_MAAS. This line wasn't necessary as
DEPLOY_MAAS defaults to no.

AIO + MAAS is useful for the RPC AIO gate check, otherwise it won't be
possible to test maas.

Related: #695