### PR TITLE
Add filter for policy.d missing messages

### DIFF
--- a/rpcd/playbooks/roles/logstash/templates/02-general.conf
+++ b/rpcd/playbooks/roles/logstash/templates/02-general.conf
@@ -1,5 +1,8 @@
 filter {
   if "oslofmt" in [tags] {
+    if "Can not find policy directory: policy.d" in [message] {
+      drop{}
+    }
     grok {
       match => { "message" => "^%{TIMESTAMP_ISO8601:logdate}%{SPACE}%{NUMBER:pid}?%{SPACE}?(?<loglevel>AUDIT|CRITICAL|DEBUG|INFO|TRACE|WARNING|ERROR) \[?\b%{NOTSPACE:module}\b\]?%{SPACE}?%{GREEDYDATA:logmessage}?" }
       add_field => { "received_at" => "%{@timestamp}" }


### PR DESCRIPTION
Add a filter in logstash 02-general.conf file to filter policy.d missing message from any source. Right now this is a problem at least for Heat and Glance, but there could be other services that will or do produce this error.