### PR TITLE
Enable the Elasticsearch service during install

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -85,3 +85,8 @@
   tags:
     - elasticsearch-plugins
     - elasticsearch-install
+
+- name: Enable ElasticSearch Service
+  service:
+    name: elasticsearch
+    enabled: yes


### PR DESCRIPTION
Enable the Elasticsearch service in the install playbook, but defer starting until the service handler is triggered.

Relates to: #688 