### PR TITLE
Add check/alarm for monitoring network throughput

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -249,6 +249,13 @@ disk_utilisation_threshold: 90
 # nf_conntrack threshold
 nf_conntrack_threshold: 90
 
+# net_max_speed has units of Mb/s, set to null for auto discovery
+net_max_speed: null
+net_rx_pct_warn: 40
+net_rx_pct_crit: 60
+net_tx_pct_warn: 40
+net_tx_pct_crit: 60
+
 # Swift MaaS thresholds
 swift_object_quarantine_failed_percentage_threshold: 5.0
 swift_object_quarantine_average_threshold: 25.0
@@ -286,6 +293,12 @@ ceph_checks_list:
   - { name: "ceph_cluster_stats", group: "mons" }
 
 network_checks_list:
+  - { name: "eth0", group: "hosts", max_speed: "{{ net_max_speed }}", rx_pct_warn: "{{ net_rx_pct_warn }}", rx_pct_crit: "{{ net_rx_pct_crit }}", tx_pct_warn: "{{ net_tx_pct_warn }}", tx_pct_crit: "{{ net_tx_pct_crit }}"}
+  - { name: "eth1", group: "hosts", max_speed: "{{ net_max_speed }}", rx_pct_warn: "{{ net_rx_pct_warn }}", rx_pct_crit: "{{ net_rx_pct_crit }}", tx_pct_warn: "{{ net_tx_pct_warn }}", tx_pct_crit: "{{ net_tx_pct_crit }}"}
+  - { name: "eth2", group: "hosts", max_speed: "{{ net_max_speed }}", rx_pct_warn: "{{ net_rx_pct_warn }}", rx_pct_crit: "{{ net_rx_pct_crit }}", tx_pct_warn: "{{ net_tx_pct_warn }}", tx_pct_crit: "{{ net_tx_pct_crit }}"}
+  - { name: "eth3", group: "hosts", max_speed: "{{ net_max_speed }}", rx_pct_warn: "{{ net_rx_pct_warn }}", rx_pct_crit: "{{ net_rx_pct_crit }}", tx_pct_warn: "{{ net_tx_pct_warn }}", tx_pct_crit: "{{ net_tx_pct_crit }}"}
+
+kernel_checks_list:
   - { name: "conntrack_count", group: "hosts" }
 
 openstack_service_local_checks_list:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/kernel.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/kernel.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: ensure_local_checks.yml
+  vars:
+    checks: "{{ kernel_checks_list }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -35,6 +35,8 @@
 
 - include: network.yml
 
+- include: kernel.yml
+
 - include: local.yml
   vars:
     internal_vip_address: "{{ internal_lb_vip_address }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: ensure_local_checks.yml
-  vars:
-    checks: "{{ network_checks_list }}"
+- name: Discover NIC speed
+  command: "cat /sys/class/net/{{ item.name }}/speed"
+  ignore_errors: true
+  register: discover_nic_speed
+  with_items: network_checks_list
+
+- name: Install network throughput checks
+  template:
+    src: "network_throughput.yaml.j2"
+    dest: "/etc/rackspace-monitoring-agent.conf.d/network_throughput-{{ item.0.name }}-{{ inventory_hostname }}.yaml"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  with_together:
+    - network_checks_list
+    - discover_nic_speed.results
+  when:
+    - inventory_hostname in groups["{{ item.0.group }}"]
+    - item.name not in maas_excluded_checks
+  delegate_to: "{{ physical_host }}"
+
+- name: Remove checks that are excluded
+  file:
+    path: "/etc/rackspace-monitoring-agent.conf.d/network_throughput-{{ item.name }}-{{ inventory_hostname }}.yaml"
+    state: absent
+  with_items: network_checks_list
+  when:
+    - item.name in maas_excluded_checks
+  delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
@@ -1,0 +1,38 @@
+{% set max_speed = (item.0.max_speed | default(0, boolean=true) or item.1.stdout) | int * 10 ** 6 / 8 %}
+{% set rx_warn = (max_speed | int * item.0.rx_pct_warn | float / 100) | int %}
+{% set rx_crit = (max_speed | int * item.0.rx_pct_crit | float / 100) | int %}
+{% set tx_warn = (max_speed | int * item.0.tx_pct_warn | float / 100) | int %}
+{% set tx_crit = (max_speed | int * item.0.tx_pct_crit | float / 100) | int -%}
+
+type: agent.network
+label: network_throughput_{{ item.0.name }}--{{ inventory_hostname|quote }}
+disabled: false
+period: {{ maas_check_period| default(60) }}
+timeout: {{ maas_check_timeout| default(30) }}
+details:
+  target: {{ item.0.name }}
+alarms:
+    alarm-network-receive:
+        label: Network receive rate on {{ item.0.name }}
+        notification_plan_id: "{{ maas_notification_plan }}"
+        criteria: |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric['rx_bytes']) > {{ rx_crit }}) {
+              return new AlarmStatus(CRITICAL, "Network receive rate on {{ item.0.name }} is above your critical threshold of {{ item.0.rx_pct_crit }}% utilisation.");
+            }
+            if (rate(metric['rx_bytes']) > {{ rx_warn }}) {
+              return new AlarmStatus(WARNING, "Network receive rate on {{ item.0.name }} is above your warning threshold of {{ item.0.rx_pct_warn }}% utilisation.");
+            }
+            return new AlarmStatus(OK, "Network receive rate on {{ item.0.name }} is below your warning threshold of {{ item.0.rx_pct_warn }}% utilisation.");
+    alarm-network-transmit:
+        label: Network transmit rate on {{ item.0.name }}
+        notification_plan_id: "{{ maas_notification_plan }}"
+        criteria: |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric['tx_bytes']) > {{ tx_crit }}) {
+              return new AlarmStatus(CRITICAL, "Network transmit rate on {{ item.0.name }} is above your critical threshold of {{ item.0.tx_pct_crit }}% utilisation.");
+            }
+            if (rate(metric['tx_bytes']) > {{ tx_warn }}) {
+              return new AlarmStatus(WARNING, "Network transmit rate on {{ item.0.name }} is above your warning threshold of {{ item.0.tx_pct_warn }}% utilisation.");
+            }
+            return new AlarmStatus(OK, "Network transmit rate on {{ item.0.name }} is below your warning threshold of {{ item.0.tx_pct_warn }}% utilisation.");


### PR DESCRIPTION
The new MaaS template is used to create a set of checks and alarms, one
per specified NIC, for monitoring network throughput.

As part of this commit, the conntrack monitor is moved to 'kernel'
monitors, so that the network monitors can be for actual network things.

Partial: #712 

Co-Authored-By: git-harry <git-harry@live.co.uk>
(cherry picked from commit 54267b5ed6e608594c2d8bd2ceed373e15f8e3f5)