### PR TITLE
update rabbitmq monitoring (queue length metrics, checks and alarms)

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -275,6 +275,8 @@ connects to an individual member of a rabbit cluster and grabs statistics from t
     metric rabbitmq_proc_total int64 1048576 processes
     metric rabbitmq_proc_used int64 180 processes
     metric rabbitmq_messages int64 0 messages
+    metric rabbitmq_msgs_excl_notifications int64 0 messages
+    metric rabbitmq_notification_messages int64 200 messages
     metric rabbitmq_sockets_total int64 3594 fd
     metric rabbitmq_fd_used int64 24 fd
     metric rabbitmq_mem_used int64 41562432 bytes

--- a/maas/plugins/rabbitmq_status.py
+++ b/maas/plugins/rabbitmq_status.py
@@ -59,7 +59,16 @@ CONNECTIONS_METRICS = {"max_channels_per_conn": "channels"}
 
 def hostname():
     """Return the name of the current host/node."""
-    return subprocess.check_output(['hostname']).strip()
+    return subprocess.check_output(['hostname', '-s']).strip()
+
+
+def rabbit_version(node):
+    if ('applications' in node and 'rabbit' in node['applications']
+            and 'version' in node['applications']['rabbit']):
+        version_string = node['applications']['rabbit']['version']
+        return tuple(int(part) for part in version_string.split('.'))
+    else:
+        return tuple()
 
 
 def parse_args():
@@ -135,28 +144,36 @@ def main():
     is_cluster_member = False
     if r.ok:
         resp_json = r.json()
-        for k, v in NODES_METRICS.items():
-            metrics[k] = {'value': resp_json[0][k], 'unit': v}
-
         # Ensure this node is a member of the cluster
-        is_cluster_member = any(n['name'].endswith(name) for n in resp_json)
-        # Gather the queue lengths for all nodes in the cluster
-        queues = [n['run_queue'] for n in resp_json]
-        # Grab the first queue length
-        first = queues.pop()
-        # Check that all other queues are equal to it
-        if not all(first == q for q in queues):
-            # If they're not, the queues are not synchronized
-            status_err('Cluster not replicated across all nodes')
+        nodes_matching_name = [n for n in resp_json
+                               if n['name'].endswith(name)]
+        is_cluster_member = any(nodes_matching_name)
+
+        if CLUSTERED:
+            if len(r.json()) < CLUSTER_SIZE:
+                status_err('cluster too small')
+            if not is_cluster_member:
+                status_err('{0} not a member of the cluster'.format(name))
+
+        for k, v in NODES_METRICS.items():
+            metrics[k] = {'value': nodes_matching_name[0][k], 'unit': v}
+
+        # We don't know exactly which version introduces data for all
+        #   nodes in the cluster returned by the NODES_URL, but we know it is
+        #   in 3.5.x at least.
+        if rabbit_version(nodes_matching_name[0]) > (3, 5):
+            # Gather the queue lengths for all nodes in the cluster
+            queues = [n['run_queue'] for n in resp_json
+                      if n.get('run_queue', None)]
+            # Grab the first queue length
+            first = queues.pop()
+            # Check that all other queues are equal to it
+            if not all(first == q for q in queues):
+                # If they're not, the queues are not synchronized
+                status_err('Cluster not replicated across all nodes')
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))
-
-    if CLUSTERED:
-        if len(r.json()) < CLUSTER_SIZE:
-            status_err('cluster too small')
-        if not is_cluster_member:
-            status_err('{0} not a member of the cluster'.format(name))
 
     status_ok()
 

--- a/maas/plugins/rabbitmq_status.py
+++ b/maas/plugins/rabbitmq_status.py
@@ -28,6 +28,7 @@ import requests
 OVERVIEW_URL = "http://%s:%s/api/overview"
 NODES_URL = "http://%s:%s/api/nodes"
 CONNECTIONS_URL = "http://%s:%s/api/connections?columns=channels"
+QUEUES_URL = "http://%s:%s/api/queues"
 
 CLUSTERED = True
 CLUSTER_SIZE = 3
@@ -94,86 +95,102 @@ def parse_args():
     return parser.parse_args()
 
 
-def main():
-    (options, _) = parse_args()
-    metrics = {}
-    s = requests.Session()  # Make a Session to store the authenticate creds
-    s.auth = (options.username, options.password)
-
+def _get_rabbit_json(session, url):
     try:
-        r = s.get(CONNECTIONS_URL % (options.host, options.port))
+        response = session.get(url)
     except requests.exceptions.ConnectionError as e:
         status_err(str(e))
 
-    if r.ok:
-        resp_json = r.json()  # Parse the JSON once
-        if resp_json:
-            max_chans = max(connection['channels'] for connection in resp_json
-                            if 'channels' in connection)
-            for k in CONNECTIONS_METRICS:
-                metrics[k] = {'value': max_chans,
-                              'unit': CONNECTIONS_METRICS[k]}
+    if response.ok:
+        return response.json()
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
-            r.status_code))
+            response.status_code))
 
-    try:
-        r = s.get(OVERVIEW_URL % (options.host, options.port))
-    except requests.exceptions.ConnectionError as e:
-        status_err(str(e))
 
-    if r.ok:
-        resp_json = r.json()  # Parse the JSON once
-        for k in OVERVIEW_METRICS:
-            if k in resp_json:
-                for a, b in OVERVIEW_METRICS[k].items():
-                    if a in resp_json[k]:
-                        metrics[a] = {'value': resp_json[k][a], 'unit': b}
-    else:
-        status_err('Received status {0} from RabbitMQ API'.format(
-            r.status_code))
+def _get_connection_metrics(session, metrics, host, port):
 
-    try:
-        r = s.get(NODES_URL % (options.host, options.port))
-    except requests.exceptions.ConnectionError as e:
-        status_err(str(e))
+    response = _get_rabbit_json(session, CONNECTIONS_URL % (host, port))
+
+    max_chans = max(connection['channels'] for connection in response
+                    if 'channels' in connection)
+    for k in CONNECTIONS_METRICS:
+        metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
+
+
+def _get_overview_metrics(session, metrics, host, port):
+    response = _get_rabbit_json(session, OVERVIEW_URL % (host, port))
+
+    for k in OVERVIEW_METRICS:
+        if k in response:
+            for a, b in OVERVIEW_METRICS[k].items():
+                if a in response[k]:
+                    metrics[a] = {'value': response[k][a], 'unit': b}
+
+
+def _get_node_metrics(session, metrics, host, port, name):
+    response = _get_rabbit_json(session, NODES_URL % (host, port))
 
     # Either use the option provided by the commandline flag or the current
     # hostname
-    name = '@' + (options.name or hostname())
+    name = '@' + (name or hostname())
     is_cluster_member = False
-    if r.ok:
-        resp_json = r.json()
-        # Ensure this node is a member of the cluster
-        nodes_matching_name = [n for n in resp_json
-                               if n['name'].endswith(name)]
-        is_cluster_member = any(nodes_matching_name)
 
-        if CLUSTERED:
-            if len(r.json()) < CLUSTER_SIZE:
-                status_err('cluster too small')
-            if not is_cluster_member:
-                status_err('{0} not a member of the cluster'.format(name))
+    # Ensure this node is a member of the cluster
+    nodes_matching_name = [n for n in response
+                           if n['name'].endswith(name)]
+    is_cluster_member = any(nodes_matching_name)
 
-        for k, v in NODES_METRICS.items():
-            metrics[k] = {'value': nodes_matching_name[0][k], 'unit': v}
+    if CLUSTERED:
+        if len(response) < CLUSTER_SIZE:
+            status_err('cluster too small')
+        if not is_cluster_member:
+            status_err('{0} not a member of the cluster'.format(name))
 
-        # We don't know exactly which version introduces data for all
-        #   nodes in the cluster returned by the NODES_URL, but we know it is
-        #   in 3.5.x at least.
-        if rabbit_version(nodes_matching_name[0]) > (3, 5):
-            # Gather the queue lengths for all nodes in the cluster
-            queues = [n['run_queue'] for n in resp_json
-                      if n.get('run_queue', None)]
-            # Grab the first queue length
-            first = queues.pop()
-            # Check that all other queues are equal to it
-            if not all(first == q for q in queues):
-                # If they're not, the queues are not synchronized
-                status_err('Cluster not replicated across all nodes')
-    else:
-        status_err('Received status {0} from RabbitMQ API'.format(
-            r.status_code))
+    for k, v in NODES_METRICS.items():
+        metrics[k] = {'value': nodes_matching_name[0][k], 'unit': v}
+
+    # We don't know exactly which version introduces data for all
+    #   nodes in the cluster returned by the NODES_URL, but we know it is
+    #   in 3.5.x at least.
+    if rabbit_version(nodes_matching_name[0]) > (3, 5):
+        # Gather the queue lengths for all nodes in the cluster
+        queues = [n['run_queue'] for n in response
+                  if n.get('run_queue', None)]
+        # Grab the first queue length
+        first = queues.pop()
+        # Check that all other queues are equal to it
+        if not all(first == q for q in queues):
+            # If they're not, the queues are not synchronized
+            status_err('Cluster not replicated across all nodes')
+
+
+def _get_queue_metrics(session, metrics, host, port):
+    response = _get_rabbit_json(session, QUEUES_URL % (host, port))
+    notification_messages = sum([q['messages'] for q in response
+                                if q['name'].startswith('notifications.')])
+
+    metrics['notification_messages'] = {
+        'value': notification_messages,
+        'unit': 'messages'
+    }
+    metrics['msgs_excl_notifications'] = {
+        'value': metrics['messages']['value'] - notification_messages,
+        'unit': 'messages'
+    }
+
+
+def main():
+    (options, _) = parse_args()
+    metrics = {}
+    session = requests.Session()  # Make a Session to store the auth creds
+    session.auth = (options.username, options.password)
+
+    _get_connection_metrics(session, metrics, options.host, options.port)
+    _get_overview_metrics(session, metrics, options.host, options.port)
+    _get_node_metrics(session, metrics, options.host, options.port,
+                      options.name)
+    _get_queue_metrics(session, metrics, options.host, options.port)
 
     status_ok()
 

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -242,6 +242,11 @@ rabbitmq_max_channels_per_con_threshold: 10
 rabbitmq_fd_used_threshold: 90
 rabbitmq_proc_used_threshold: 90
 rabbitmq_socket_used_threshold: 90
+rabbitmq_queued_messages_excluding_notifications_threshold: 100
+
+# queued messages per check period (default = 60s)
+rabbitmq_queue_growth_rate_threshold: 15
+
 
 # Set the threshold for the "Disk utilisation" MaaS alarms
 disk_utilisation_threshold: 90

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -60,3 +60,19 @@ alarms      :
             if (percentage(metric["rabbitmq_sockets_used"],metric["rabbitmq_sockets_total"]) >= {{ rabbitmq_socket_used_threshold }}) {
                 return new AlarmStatus(CRITICAL, "RabbitMQ sockets is reaching configured limit. Currently above {{ rabbitmq_socket_used_threshold }} % used");
             }
+    rabbitmq_msgs_excl_notifications :
+        label                   : rabbitmq_msgs_excl_notifications--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["rabbitmq_msgs_excl_notifications"] > {{ rabbitmq_queued_messages_excluding_notifications_threshold }} ) {
+                return new AlarmStatus(CRITICAL, "RabbitMQ sum of queued messages excluding notifications queues is reaching configured limit. Currently above {{ rabbitmq_queued_messages_excluding_notifications_threshold }}");
+            }
+    rabbitmq_qgrowth_excl_notifications :
+        label                   : rabbitmq_qgrowth_excl_notifications--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{rabbitmq_queue_growth_rate_threshold / maas_check_period}}) {
+                return new AlarmStatus(CRITICAL, "RabbitMQ Queue growth rate is above configured threshold. Currently above {{ rabbitmq_queue_growth_rate_threshold }}");
+            }


### PR DESCRIPTION
This backport PR necessarily has 2 commits as they depend on each other.  See individual commits for details, but essentially they:

- update the way we search for a particular rabbit node in the output from the api
- add a check to monitor for growing queue lengths, as requested by support

Partial: #644 
Partial: #633