### PR TITLE
Add MaaS Alarms for swift replication time

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -275,12 +275,18 @@ net_tx_pct_crit: 60
 swift_object_quarantine_failed_percentage_threshold: 5.0
 swift_object_quarantine_average_threshold: 25.0
 swift_object_replication_failure_percentage_threshold: 5.0
+swift_object_replication_growth_rate_threshold: 10.0
+swift_object_replication_avg_time_threshold: 50.0
 swift_account_quarantine_failed_percentage_threshold: 5.0
 swift_account_quarantine_average_threshold: 25.0
 swift_account_replication_failure_percentage_threshold: 5.0
+swift_account_replication_growth_rate_threshold: 10.0
+swift_account_replication_avg_time_threshold: 50.0
 swift_container_quarantine_failed_percentage_threshold: 5.0
 swift_container_quarantine_average_threshold: 25.0
 swift_container_replication_failure_percentage_threshold: 5.0
+swift_container_replication_growth_rate_threshold: 10.0
+swift_container_replication_avg_time_threshold: 50.0
 swift_async_pending_failure_percentage_threshold: 5.0
 swift_async_pending_average_threshold: 25.0
 

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
@@ -7,11 +7,27 @@ details     :
     file    : swift-recon.py
     args    : ["--ring-type", "account", "replication"]
 alarms      :
-    swift_account_replication_check :
-        label                   : swift_account_replication_check--{{ ansible_hostname }}
+    swift_account_replication_failure_check :
+        label                   : swift_account_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_account_replication_failure_percentage_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Swift Account Replication Failure Percentage Above Threshold");
+            }
+    swift_account_replication_rate_check :
+        label                   : swift_account_replication_rate_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["time_avg"]) > {{ swift_account_replication_growth_rate_threshold / maas_check_period}}) {
+                return new AlarmStatus(CRITICAL, "Swift Account Replication time growth rate is above configured threshold. Currently above {{ swift_account_replication_growth_rate_threshold }}");
+            }
+    swift_account_replication_avg_time_check :
+        label                   : swift_account_replication_avg_time_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["time_avg"] > {{ swift_account_replication_avg_time_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Swift Account Replication average time is above configured threshold. Currently above {{ swift_account_replication_avg_time_threshold }}");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
@@ -7,11 +7,27 @@ details     :
     file    : swift-recon.py
     args    : ["--ring-type", "container", "replication"]
 alarms      :
-    swift_container_replication_check :
-        label                   : swift_container_replication_check--{{ ansible_hostname }}
+    swift_container_replication_failure_check :
+        label                   : swift_container_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_container_replication_failure_percentage_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Swift Container Replication Failure Percentage Above Threshold");
+            }
+    swift_container_replication_rate_check :
+        label                   : swift_container_replication_rate_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["time_avg"]) > {{ swift_container_replication_growth_rate_threshold / maas_check_period}}) {
+                return new AlarmStatus(CRITICAL, "Swift Container Replication time growth rate is above configured threshold. Currently above {{ swift_container_replication_growth_rate_threshold }}");
+            }
+    swift_container_replication_avg_time_check :
+        label                   : swift_container_replication_avg_time_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["time_avg"] > {{ swift_container_replication_avg_time_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Swift Container Replication average time is above configured threshold. Currently above {{ swift_container_replication_avg_time_threshold }}");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
@@ -7,11 +7,27 @@ details     :
     file    : swift-recon.py
     args    : ["--ring-type", "object", "replication"]
 alarms      :
-    swift_object_replication_check :
-        label                   : swift_object_replication_check--{{ ansible_hostname }}
+    swift_object_replication_failure_check :
+        label                   : swift_object_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_object_replication_failure_percentage_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Swift Object Replication Failure Percentage Above Threshold");
+            }
+    swift_object_replication_rate_check :
+        label                   : swift_object_replication_rate_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["time_avg"]) > {{ swift_object_replication_growth_rate_threshold / maas_check_period}}) {
+                return new AlarmStatus(CRITICAL, "Swift Object Replication time growth rate is above configured threshold. Currently above {{ swift_object_replication_growth_rate_threshold }}");
+            }
+    swift_object_replication_avg_time_check :
+        label                   : swift_object_replication_avg_time_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["time_avg"] > {{ swift_object_replication_avg_time_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Swift Object Replication average time is above configured threshold. Currently above {{ swift_object_replication_avg_time_threshold }}");
             }


### PR DESCRIPTION
Add a rate increase alarm for object/container/account replication
Add an average time threshold alarm for object/container/account
replication.

Closes-Issue: #655
(cherry picked from commit 108b00f7e2dcc5d1241f0b44b640e063c8da47a9)
Signed-off-by: Matthew Thode <mthode@mthode.org>