### PR TITLE
Put maas_excluded_checks removal into its own task

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
@@ -28,13 +28,3 @@
     - inventory_hostname != groups["{{ item.group }}"][0]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-
-- name: Remove checks that are excluded
-  file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}.yaml"
-    state: absent
-  with_items:
-    - "{{ checks }}"
-  when:
-    - item.name in maas_excluded_checks
-  delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
@@ -27,13 +27,3 @@
     - inventory_hostname == groups["{{ item.group }}"][0]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-
-- name: Remove checks that are excluded
-  file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}.yaml"
-    state: absent
-  with_items:
-    - "{{ checks }}"
-  when:
-    - item.name in maas_excluded_checks
-  delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/maas_exclude.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/maas_exclude.yml
@@ -13,16 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install local checks
-  template:
-    src: "{{ item.name }}.yaml.j2"
-    dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}--{{ inventory_hostname }}.yaml"
-    owner: "root"
-    group: "root"
-    mode: "0644"
+- name: Ensure local checks are removed
+  file:
+    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}-{{ inventory_hostname }}.yaml"
+    state: absent
   with_items:
-    - "{{ checks }}"
-  when:
-    - inventory_hostname in groups["{{ item.group }}"]
-    - item.name not in maas_excluded_checks
+    - "{{ maas_excluded_checks }}"
+  delegate_to: "{{ physical_host }}"
+
+- name: Ensure remote checks are removed
+  file:
+    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}.yaml"
+    state: absent
+  with_items:
+    - "{{ maas_excluded_checks }}"
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -64,4 +64,6 @@
     inventory_hostname in groups['ceph_all'] and
     groups['ceph_all'] is defined
 
+- include: maas_exclude.yml
+
 - include: restart_raxmon.yml

--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -33,12 +33,3 @@
     - inventory_hostname in groups["{{ item.0.group }}"]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"
-
-- name: Remove checks that are excluded
-  file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/network_throughput-{{ item.name }}-{{ inventory_hostname }}.yaml"
-    state: absent
-  with_items: network_checks_list
-  when:
-    - item.name in maas_excluded_checks
-  delegate_to: "{{ physical_host }}"


### PR DESCRIPTION
The logic around removing maas checks based on the maas_excluded_checks
list is flawed in that it runs after every "check/alarm" setup task, and
removes checks based on the checks it's setting up.

We need to remove checks in the list if they exist at all, regardless of
whether they are being set up or not.

This PR moves the removal task into its own included task file and will
remove any checks that exist with the listed checkname (for remote
checks) or checkname-inventory_hostname (for local checks).

Fixes-Issue: #681
(cherry picked from commit 477012bc8f309edcb26a1aeb239c0eb118c546ea)
Signed-off-by: Matthew Thode <mthode@mthode.org>