### PR TITLE
Fix issues with Network Utilisation MaaS Checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -34,6 +34,8 @@
     inventory_hostname in groups['hosts']
 
 - include: network.yml
+  when: >
+    inventory_hostname in groups['hosts']
 
 - include: kernel.yml
 
@@ -67,3 +69,5 @@
 - include: maas_exclude.yml
 
 - include: restart_raxmon.yml
+  when: >
+    inventory_hostname in groups['hosts']

--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Test that network interfaces exist
+  fail:
+    msg: "The specified network interfaces {{ item.name }} doesn't exist, consider setting the 'network_checks_list' variable to override these interfaces"
+  with_items:
+    - "{{ network_checks_list }}"
+  when:
+    - hostvars[inventory_hostname]["{{'ansible_' + item.name | replace('-', '_')}}"] is not defined
+
 - name: Discover NIC speed
   command: "cat /sys/class/net/{{ item.name }}/speed"
   ignore_errors: true
@@ -31,5 +39,12 @@
     - discover_nic_speed.results
   when:
     - inventory_hostname in groups["{{ item.0.group }}"]
-    - item.name not in maas_excluded_checks
-  delegate_to: "{{ physical_host }}"
+    - "'network_throughput-{{ item.0.name }}' not in maas_excluded_checks"
+
+- name: Remove checks that are excluded
+  file:
+    path: "/etc/rackspace-monitoring-agent.conf.d/network_throughput-{{ item.name }}-{{ inventory_hostname }}.yaml"
+    state: absent
+  with_items: network_checks_list
+  when:
+    - "'network_throughput-{{ item.name }}' in maas_excluded_checks"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/restart_raxmon.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/restart_raxmon.yml
@@ -17,7 +17,6 @@
   service:
     name: rackspace-monitoring-agent
     state: restarted
-  delegate_to: "{{ physical_host }}"
   tags:
     - maas-setup
     - rackspace-monitoring-agent-setup


### PR DESCRIPTION
This PR fixes the following issues:

* The network tasks were run against ALL containers, this should only be
run against physical hosts.
* Adds a test to see if an interface exists on a host, and errors with a
message to indicate what to do if the interface does not exist.
* Fixes the logic around adding/removing MaaS checks based on check
name.
* Fixes agent restart task to only run against physical hosts.

TODO: Fix maas check exclude list logic, currently it will perform this
per check type, and that doesn't work particularly well. Will be fixed
in a separate PR/issue.

Fixes-Issue: #677
(cherry picked from commit cfd3712e2ebd847f57a6fbdc90e7b636b7f22810)