### PR TITLE
Discover rpc-openstack version

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -15,8 +15,8 @@
 # This is the location where the rpc repository was checked out
 rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 
-# rpc-openstack version
-rpc_release: r11.1.0
+# rpc-openstack version, this should be discovered by git_repo_info
+rpc_release: "{{ rpc_openstack_repo is defined | ternary((rpc_openstack_repo | default({}))['version'], 'UNKNOWN_RELEASE') }}"
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment

--- a/rpcd/playbooks/library/git_repo_info
+++ b/rpcd/playbooks/library/git_repo_info
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = """
+---
+module: git_repo_info
+short_description:
+    - A module for gathering git repo facts.
+description:
+    - A module for gathering git repo facts.
+author: Rcbops
+options:
+  path:
+    description:
+      - The path to the repo.
+    required: true
+  name:
+    description:
+      - The name to use when referencing the repo.
+    required: false
+    default: The repo directory in path.
+  closest_tag:
+    description:
+      - By default it will cause the version returned to be the tag closest to
+        HEAD. If set to false the version will take the form
+        closest_tag-number_of_commits_from_closest_tag-current_SHA.
+    required: false
+    default: true
+"""
+
+EXAMPLES = """
+- name: Discover current rpc-openstack release
+  git_repo_info:
+    path: "/opt/rpc-openstack"
+  delegate_to: localhost
+  run_once: true
+
+In the above example a variable called 'rpc_openstack_repo' is added to the
+global ansible namespace and has the following form:
+
+rpc_openstack_repo:
+  name: rpc-openstack
+  sha: bbd50f3908e38acae3d96e12989394ace234c94d
+  version: 1.2.3
+
+name is the repo name unless supplied in the task definition
+sha is the current HEAD for the repo
+version is the most recent tag reached from HEAD
+"""
+
+import os.path
+import subprocess
+
+
+class GitRepoFacts(object):
+    def __init__(self, module):
+        self.state_change = False
+        self.module = module
+        self.params = self.module.params
+
+    def gather_facts(self):
+        """Get information about RPC release."""
+        repo = {}
+        repo['version'], repo['sha'] = self.get_repo_version()
+        repo['name'] = (self.params['name'] or
+                        os.path.split(self.params['path'])[-1])
+        name = '%s_repo' % (repo['name'].replace('-', '_'))
+        self.module.exit_json(
+            ansible_facts={name: repo})
+
+    def run_command(self, cmd, cwd):
+        try:
+            output = subprocess.check_output(cmd,
+                                             stderr=subprocess.STDOUT,
+                                             cwd=cwd)
+        except subprocess.CalledProcessError as e:
+            message = ('Repo fact collection failed: "%s".' %
+                       e.output.strip())
+            self.module.fail_json(msg=message)
+        else:
+            return output.strip()
+
+    def get_repo_version(self):
+        cmd = ['git', 'describe', '--tags', '--long', '--abbrev=40']
+        output = self.run_command(cmd, self.params['path'])
+        newest_tag, additional_commits, current_commit = output.rsplit('-', 2)
+        if self.params['closest_tag'] or additional_commits == '0':
+            tag = newest_tag
+        else:
+            tag = output
+        return tag, current_commit.lstrip('g')
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            'path': {'type': 'str', 'required': True},
+            'name': {'type': 'str', 'default': None, 'required': False},
+            'closest_tag': {'type': 'bool', 'default': True, 'required': False}
+        },
+        supports_check_mode=False
+    )
+    repo_facts = GitRepoFacts(module)
+    repo_facts.gather_facts()
+
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/rpcd/playbooks/repo-build.yml
+++ b/rpcd/playbooks/repo-build.yml
@@ -21,6 +21,16 @@
   max_fail_percentage: 20
   gather_facts: false
   user: root
+  pre_tasks:
+    - name: Discover rpc-openstack version
+      git_repo_info:
+        path: "/opt/rpc-openstack"
+      delegate_to: localhost
+      run_once: true
+      tags:
+        - repo-create-report
+        - repo-build-requirements
+        - repo-build-git-sources
   tasks:
     - name: Create a build report for all known packages within a release
       shell: |

--- a/rpcd/playbooks/repo-pip-setup.yml
+++ b/rpcd/playbooks/repo-pip-setup.yml
@@ -21,6 +21,14 @@
   max_fail_percentage: 20
   gather_facts: true
   user: root
+  pre_tasks:
+    - name: Discover rpc-openstack version
+      git_repo_info:
+        path: "/opt/rpc-openstack"
+      delegate_to: localhost
+      run_once: true
+      tags:
+        - lock-pip-files
   roles:
     - pip_lock_down
   post_tasks:

--- a/rpcd/playbooks/roles/rpc_support/tasks/rpc_release.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/rpc_release.yml
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Discover rpc-openstack version
+  git_repo_info:
+    path: "/opt/rpc-openstack"
+  delegate_to: localhost
+  run_once: true
+  tags:
+    - rpc-release
+
 - name: Drop rpc-release file
   template:
     src: "rpc-release.j2"


### PR DESCRIPTION
Currently Ansible determines the version of rpc-openstack in use by
reading the variable rpc_release. This variable needs to be updated
whenever a new version is tagged. The have been a number of occasions
where this has been missed and so rpc_release does not match the version
of code being used.

Tags are being used to identify different releases within the project.
rpc_release is essentially duplicating that information. This commit
adds a new module called git_repo_info that is used to discover the
current tag and so remove the requirement for manual updates. If
required the dynamic value can be overridden.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/533
(cherry picked from commit 2c4e3c4821d591ead5e2826e7d27f156225d81ff)
Signed-off-by: Matthew Thode <mthode@mthode.org>