### PR TITLE
Allow for empty `network_checks_list`.

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - include: network.yml
   when: >
-    inventory_hostname in groups['hosts']
+    network_checks_list|length > 0 and inventory_hostname in groups['hosts']
 
 - include: kernel.yml
 


### PR DESCRIPTION
Partial Fix: #742