### PR TITLE
Allow for empty `network_checks_list`.

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - include: network.yml
   when: >
-    inventory_hostname in groups['hosts']
+    network_checks_list|length > 0 and inventory_hostname in groups['hosts']
 
 - include: kernel.yml
 


### PR DESCRIPTION
Partial Fix: #742

(cherry picked from commit 9d25b4335df3758e603121e033c23b2164285ff6)
Signed-off-by: Matthew Thode <mthode@mthode.org>