### PR TITLE
Add Ansible linting under Ansible 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,7 @@ matrix:
       env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=ansible-lint
+    - python: 2.7
+      env: TOXENV=ansible2-lint
 
 sudo: false

--- a/scripts/linting-ansible.sh
+++ b/scripts/linting-ansible.sh
@@ -21,13 +21,10 @@ if [[ -z "$VIRTUAL_ENV" ]] ; then
     echo "WARNING: Not running hacking inside a virtual environment."
 fi
 
-# Put local inventory in a var so we're not polluting the file system too much
-LOCAL_INVENTORY='[all]\nlocalhost ansible_connection=local'
-
 pushd rpcd/playbooks/
   echo "Running ansible-playbook syntax check"
   # Do a basic syntax check on all playbooks and roles.
-  ansible-playbook -i <(echo $LOCAL_INVENTORY) --syntax-check *.yml --list-tasks
+  ansible-playbook -i 'localhost,' --syntax-check *.yml --list-tasks
   # Perform a lint check on all playbooks and roles.
   ansible-lint --version
   # Skip ceph roles because they're submodules and not ours to lint

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist = flake8,ansible-lint
 basepython = python2.7
 deps =
     -ropenstack-ansible/dev-requirements.txt
-    ansible>=1.9.1,<2.0.0
 
 [testenv:flake8]
 commands =
@@ -16,6 +15,16 @@ commands =
 [testenv:ansible-lint]
 commands =
     {toxinidir}/scripts/linting-ansible.sh
+deps=
+    -ropenstack-ansible/dev-requirements.txt
+    ansible>=1.9.1,<2.0.0
+
+[testenv:ansible2-lint]
+commands =
+    {toxinidir}/scripts/linting-ansible.sh
+deps=
+    -ropenstack-ansible/dev-requirements.txt
+    ansible>=2.0.0
 
 [flake8]
 # Ignores the following rules due to how ansible modules work in general


### PR DESCRIPTION
This commit adds a new tox environment for linting playbooks and roles
against Ansible 2.x. It also modifies the linting-ansible.sh script so
that it is compatible with both the 1.x and 2.x series.

This commit is not intended to provide full Ansible 2.x support. Rather,
it is to serve as an early warning system so that the playbooks and
roles aren't written in an incompatible manner prior to actually
switching.

Fixes: #754