### PR TITLE
Add Ansible linting under Ansible 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
       env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=ansible-lint
+    - python: 2.7
+      env: TOXENV=ansible-lint ANSIBLE_VERSION='>=2.0'
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -134,3 +134,13 @@ To run an upgrade of an existing openstack-ansible installation:
 Please note the following behaviors that are **destructive**:
     * `/etc/rpc_deploy` will be deprecated and the file structure moved to 
       `/etc/openstack_deploy`.
+
+# Linting
+
+If you would like to lint against a version of ansible that is not the
+default, set the `ANSIBLE_VERSION` environment variable to the proper pip
+version specification:
+
+```
+ANSIBLE_VERSION='>=2.0' tox -e ansible-lint
+```

--- a/scripts/linting-ansible.sh
+++ b/scripts/linting-ansible.sh
@@ -21,13 +21,10 @@ if [[ -z "$VIRTUAL_ENV" ]] ; then
     echo "WARNING: Not running hacking inside a virtual environment."
 fi
 
-# Put local inventory in a var so we're not polluting the file system too much
-LOCAL_INVENTORY='[all]\nlocalhost ansible_connection=local'
-
 pushd rpcd/playbooks/
   echo "Running ansible-playbook syntax check"
   # Do a basic syntax check on all playbooks and roles.
-  ansible-playbook -i <(echo $LOCAL_INVENTORY) --syntax-check *.yml --list-tasks
+  ansible-playbook -i 'localhost,' --syntax-check *.yml --list-tasks
   # Perform a lint check on all playbooks and roles.
   ansible-lint --version
   echo "Running ansible-lint"

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ skipsdist = True
 envlist = flake8,ansible-lint
 
 [testenv]
+passenv = ANSIBLE_VERSION
 basepython = python2.7
 deps =
-    ansible>=1.9.1,<2.0.0
     -rtest-requirements.txt
+    ansible{env:ANSIBLE_VERSION:>=1.9.1,<2.0.0}
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
This commit adds a new tox environment for linting playbooks and roles
against Ansible 2.x. It also modifies the linting-ansible.sh script so
that it is compatible with both the 1.x and 2.x series.

This commit is not intended to provide full Ansible 2.x support. Rather,
it is to serve as an early warning system so that the playbooks and
roles aren't written in an incompatible manner prior to actually
switching.

Fixes: #754