### PR TITLE
 Adding new default values for neutron/nova/keystone DB/RPC pools

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -13,18 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Nova overrides
+# SQLAlchemy/Olso Thread Pool Settings
+rpc_conn_pool_size: 180
+rpc_response_timeout: 180
+rpc_thread_pool_size: 180
+
+keystone_database_max_pool_size: 120
+keystone_database_pool_timeout: 60
+
+neutron_api_workers: 64
+neutron_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
+neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
+neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
+neutron_db_max_overflow: 60
+neutron_db_max_pool_size: 120
+neutron_db_pool_timeout: 60
+
+nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
+nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
+nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
+
+# Nova config overrides
 nova_cross_az_attach: False
-nova_rpc_conn_pool_size: 180
-nova_rpc_response_timeout: 180
-nova_rpc_thread_pool_size: 180
 
-# Neutron overrides
-neutron_rpc_conn_pool_size: 180
-neutron_rpc_response_timeout: 180
-neutron_rpc_thread_pool_size: 180
-
-#RabbitMQ overrides
+# RabbitMQ overrides
 rabbitmq_ulimit: 65535
 
 ## Apache SSL Settings


### PR DESCRIPTION
Adding new default values for neutron/nova/keystone SQLAlchemy/Olso Thread Pool Settings for bug #724