### PR TITLE
Adjust permission of /etc/ceph to allow Cinder to create Ceph Volumes

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -25,3 +25,6 @@ openstack_repo_url: "http://{{ internal_lb_vip_address }}:{{ repo_server_port }}
 
 # Location to store a catalog of migrations completed
 migrations_dir: /etc/openstack_deploy/migrations
+
+# Ceph Conf Directory Mode
+conf_directory_mode: 755


### PR DESCRIPTION
Cinder Volume needs access to /etc/ceph to create Ceph Volumes. This
change passes and `conf_directory_mode` as a role parameter to adjust
permissions accordingly.

Note: This depends on an upstream pull request for the ceph-common role

https://github.com/ceph/ceph-ansible/pull/485

Fixes: #747
(cherry picked from commit a314356c58b55c7ec472abc53bbefb0e88afef38)