### PR TITLE
Adding Keystone V3 settings into openrc-maas along with endpoint type selection

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/openrc
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openrc
@@ -4,3 +4,14 @@ export OS_PASSWORD={{ maas_keystone_password }}
 export OS_TENANT_NAME={{ keystone_admin_tenant_name }}
 export OS_AUTH_URL={{ keystone_service_internalurl_v3 }}
 export OS_NO_CACHE=1
+export OS_USER_DOMAIN_NAME={{ openrc_os_domain_name }}
+export OS_PROJECT_DOMAIN_NAME={{ openrc_os_domain_name }}
+
+# For openstackclient
+{% if openrc_os_auth_url.endswith('v3') %}
+export OS_IDENTITY_API_VERSION=3
+export OS_AUTH_VERSION=3
+{% else %}
+export OS_IDENTITY_API_VERSION=2.0
+export OS_AUTH_VERSION=2
+{% endif %}


### PR DESCRIPTION
Adding V3 settings into openrc-maas, similar to standard openrc.
Also adding endpoint type selection and a new setting for insecure API calls (OSA fix pending LP #1537117)
Also fixing nova_exc.Unauthorized error for nova to reauthenticate instead
of only expecting AttributeError

Closes-Bug: #763 
Closes-Bug: #765 