### PR TITLE
Do not create RabbitMQ monitoring user if RabbitMQ is not installed.

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - include: rabbitmq_user.yml
   when: >
-    inventory_hostname == groups['rabbitmq_all'][0]
+    groups['rabbitmq_all']|length > 0 and inventory_hostname == groups['rabbitmq_all'][0]
 
 - include: create_my_cnf.yml
   when: >


### PR DESCRIPTION
This is needed when deploying stand alone Swift, and the RabbitMQ
affinity is set to 0 to prevent its installation.