### PR TITLE
change the default config_drive_format to vfat

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -33,6 +33,10 @@ nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 
+nova_nova_conf_overrides:
+  DEFAULT:
+    config_drive_format: "vfat"
+
 # Nova config overrides
 nova_cross_az_attach: False
 


### PR DESCRIPTION
this will allow migrations to work
https://github.com/openstack/nova/blob/c9c0b1b4b5acc1ea3c2bbb694aa79d7e4a7087e3/nova/virt/libvirt/driver.py#L6237-L6251

Connects #783