### PR TITLE
Use script module instead of shell module to run verify-maas tasks.

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -18,7 +18,7 @@
   user: root
   tasks:
     - name: "Verify Checks & Alarms are registered"
-      shell: >
+      script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-created
         --entity {{ inventory_hostname }}
         {% for ec in maas_excluded_checks %} --excludedcheck {{ec}}
@@ -31,7 +31,7 @@
       delay: 60
 
     - name: "Verify Check & Alarm Status"
-      shell: >
+      script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status
         --entity {{ inventory_hostname }}
 


### PR DESCRIPTION
Fixes #769

(cherry picked from commit 42311f617d6a1e48277f379b501f54966c8946d2)
Signed-off-by: Matthew Thode <mthode@mthode.org>