### PR TITLE
Adding missing OS_ENDPOINT_TYPE inside rpc_maas

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -433,3 +433,10 @@ maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
 # maas_excluded_checks: List of checks and alarms to exclude from this deploy
 #
 maas_excluded_checks: []
+
+
+#
+# openrc definitions from OSA
+# This is necessary until LP #1537117 is implemented
+openrc_os_endpoint_type: internalURL
+openrc_insecure: "{{ (keystone_service_adminuri_insecure | bool or keystone_service_internaluri_insecure | bool) | default(false) }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/openrc
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openrc
@@ -1,4 +1,6 @@
 # COMMON OPENSTACK ENVS
+export OS_ENDPOINT_TYPE={{ openrc_os_endpoint_type }}
+
 export OS_USERNAME={{ maas_keystone_user }}
 export OS_PASSWORD={{ maas_keystone_password }}
 export OS_TENANT_NAME={{ keystone_admin_tenant_name }}


### PR DESCRIPTION
Closes-Bug: #781
(cherry picked from commit da1209e0cbf2d05763983e225e69c50603f786ea)
Signed-off-by: Matthew Thode <mthode@mthode.org>