### PR TITLE
pin setuptools to 19.3

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -62,3 +62,9 @@ ceph_mons: >
   {% endfor -%}
   {% endif -%}
   {{ _var }}
+
+galera_pip_packages:
+  - MySQL-python
+  - python-memcached
+  - pycrypto
+  - setuptools==19.3


### PR DESCRIPTION
this commit pins setuptools to 19.3 in the galera containers.
setuptools>=19.4 does not allow holland installs to work the way we are
currently doing them (local pip installs).

This will unblock the kilo gate and allow us to work on the better
solution of having the holland pip wheels get built by the repo builder
and install that way, rather than a local pip install.

Partial: #777 