### PR TITLE
Fix holland_preinstall to build wheels for the holland plugins.

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -57,10 +57,12 @@ holland_git_repo: https://github.com/holland-backup/holland
 holland_git_install_branch: "v1.0.10"
 holland_git_dest: "/opt/{{ holland_repo_path }}"
 # git_repo_plugins are other installable packages contained within the same git repo
-holland_git_repo_plugins:
+holland_repo_plugins:
   - { path: "plugins", package: "holland.lib.common" }
   - { path: "plugins", package: "holland.lib.mysql" }
   - { path: "plugins", package: "holland.backup.xtrabackup" }
+# we have to set the version of the plugin so that pip knows what to install
+holland_plugin_version: "1.0.10dev-r0"
 
 holland_pip_wheel_name: holland
 

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -43,7 +43,7 @@
 
 - name: Install service source
   pip:
-    name: "/opt/{{ holland_service_name }}_{{ holland_git_install_branch | replace('/', '_') }}"
+    name: "{{ holland_service_name }}"
     extra_args: "{{ pip_install_options|default('') }}"
   register: pip_install
   until: pip_install|success
@@ -54,10 +54,10 @@
 
 - name: Install pip repo plugins
   pip:
-    name: "{{ holland_git_dest }}/{{ item.path }}/{{ item.package }}"
+    name: "{{ item.package }}>={{ holland_plugin_version }}"
     extra_args: "{{ pip_install_options|default('') }}"
-  when: holland_git_dest is defined and holland_git_repo_plugins is defined
-  with_items: holland_git_repo_plugins
+  when: holland_git_dest is defined and holland_repo_plugins is defined
+  with_items: holland_repo_plugins
   register: pip_install
   until: pip_install|success
   retries: 5


### PR DESCRIPTION
The variable name for the holland plugins in main.yml was slightly
incorrect causing the wheel builder to skip over them.  This fix
corrects the variable name and modifies the preinstall play to
install the pluigins from the local repo.

Fixes: #777