### PR TITLE
RPC-R support plus ip argument and glance_api_local_check rewriting

### DIFF
--- a/maas/plugins/cinder_api_local_check.py
+++ b/maas/plugins/cinder_api_local_check.py
@@ -38,9 +38,9 @@ VOLUME_STATUSES = ['available', 'in-use', 'error']
 
 
 def check(auth_ref, args):
-
     keystone = get_keystone_client(auth_ref)
     auth_token = keystone.auth_token
+
     VOLUME_ENDPOINT = ('http://{ip}:8776/v1/{tenant}'.format
                        (ip=args.ip, tenant=keystone.tenant_id))
 
@@ -101,9 +101,10 @@ def main(args):
 
 if __name__ == "__main__":
     with print_output():
-        parser = argparse.ArgumentParser(description='Check cinder API')
+        parser = argparse.ArgumentParser(description="Check Cinder API against"
+                                         " local or remote address")
         parser.add_argument('ip',
                             type=ipaddr.IPv4Address,
-                            help='cinder API IP address')
+                            help='Cinder API server address')
         args = parser.parse_args()
         main(args)

--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -33,9 +33,9 @@ from requests import exceptions as exc
 
 
 def check(auth_ref, args):
-
     keystone = get_keystone_client(auth_ref)
     auth_token = keystone.auth_token
+
     VOLUME_ENDPOINT = (
         'http://{hostname}:8776/v1/{tenant}'.format(hostname=args.hostname,
                                                     tenant=keystone.tenant_id)
@@ -57,7 +57,7 @@ def check(auth_ref, args):
         status_err(str(e))
 
     if not r.ok:
-        status_err('could not get response from cinder api')
+        status_err('Could not get response from Cinder API')
 
     services = r.json()['services']
 
@@ -91,7 +91,8 @@ def main(args):
 
 if __name__ == "__main__":
     with print_output():
-        parser = argparse.ArgumentParser(description='Check cinder services')
+        parser = argparse.ArgumentParser(description="Check Cinder API against"
+                                         " local or remote address")
         parser.add_argument('hostname',
                             type=str,
                             help='Cinder API hostname or IP address')

--- a/maas/plugins/glance_registry_local_check.py
+++ b/maas/plugins/glance_registry_local_check.py
@@ -66,9 +66,9 @@ def main(args):
 
 if __name__ == "__main__":
     with print_output():
-        parser = argparse.ArgumentParser(description='Check glance registry')
-        parser.add_argument('ip',
-                            type=ipaddr.IPv4Address,
-                            help='glance registry IP address')
+        parser = argparse.ArgumentParser(description="Check Glance Registry "
+                                         " against local or remote address")
+        parser.add_argument('ip', type=ipaddr.IPv4Address,
+                            help='Glance Registry IP address')
         args = parser.parse_args()
         main(args)

--- a/maas/plugins/neutron_api_local_check.py
+++ b/maas/plugins/neutron_api_local_check.py
@@ -32,7 +32,11 @@ def check(args):
     NETWORK_ENDPOINT = 'http://{ip}:9696'.format(ip=args.ip)
 
     try:
-        neutron = get_neutron_client(endpoint_url=NETWORK_ENDPOINT)
+        if args.ip:
+            neutron = get_neutron_client(endpoint_url=NETWORK_ENDPOINT)
+        else:
+            neutron = get_neutron_client()
+
         is_up = True
     # if we get a NeutronClientException don't bother sending any other metric
     # The API IS DOWN
@@ -74,9 +78,10 @@ def main(args):
 
 if __name__ == "__main__":
     with print_output():
-        parser = argparse.ArgumentParser(description='Check neutron API')
-        parser.add_argument('ip',
+        parser = argparse.ArgumentParser(
+            description='Check Neutron API against local or remote address')
+        parser.add_argument('ip', nargs='?',
                             type=ipaddr.IPv4Address,
-                            help='neutron API IP address')
+                            help='Optional Neutron API server address')
         args = parser.parse_args()
         main(args)

--- a/maas/plugins/nova_api_local_check.py
+++ b/maas/plugins/nova_api_local_check.py
@@ -20,6 +20,7 @@ import time
 
 import ipaddr
 from maas_common import get_auth_ref
+from maas_common import get_keystone_client
 from maas_common import get_nova_client
 from maas_common import metric
 from maas_common import metric_bool
@@ -31,10 +32,9 @@ from novaclient.client import exceptions as exc
 SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
 
 
-def check(args):
-    auth_ref = get_auth_ref()
-    auth_token = auth_ref['auth_token']
-    tenant_id = auth_ref['project']['id']
+def check(auth_ref, args):
+    keystone = get_keystone_client(auth_ref)
+    tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
         'http://{ip}:8774/v2/{tenant_id}'.format(ip=args.ip,
@@ -42,8 +42,11 @@ def check(args):
     )
 
     try:
-        nova = get_nova_client(auth_token=auth_token,
-                               bypass_url=COMPUTE_ENDPOINT)
+        if args.ip:
+            nova = get_nova_client(bypass_url=COMPUTE_ENDPOINT)
+        else:
+            nova = get_nova_client()
+
         is_up = True
     except exc.ClientException:
         is_up = False
@@ -76,14 +79,16 @@ def check(args):
 
 
 def main(args):
-    check(args)
+    auth_ref = get_auth_ref()
+    check(auth_ref, args)
 
 
 if __name__ == "__main__":
     with print_output():
-        parser = argparse.ArgumentParser(description='Check nova API')
-        parser.add_argument('ip',
+        parser = argparse.ArgumentParser(
+            description='Check Nova API against local or remote address')
+        parser.add_argument('ip', nargs='?',
                             type=ipaddr.IPv4Address,
-                            help='nova API IP address')
+                            help='Optional Nova API server address')
         args = parser.parse_args()
         main(args)

--- a/maas/plugins/nova_cloud_stats.py
+++ b/maas/plugins/nova_cloud_stats.py
@@ -19,6 +19,7 @@ import collections
 
 import ipaddr
 from maas_common import get_auth_ref
+from maas_common import get_keystone_client
 from maas_common import get_nova_client
 from maas_common import metric
 from maas_common import print_output
@@ -59,10 +60,9 @@ stats_mapping = {
 }
 
 
-def check(args):
-    auth_ref = get_auth_ref()
-    auth_token = auth_ref['auth_token']
-    tenant_id = auth_ref['project']['id']
+def check(auth_ref, args):
+    keystone = get_keystone_client(auth_ref)
+    tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
         'http://{ip}:8774/v2/{tenant_id}'.format(ip=args.ip,
@@ -70,8 +70,11 @@ def check(args):
     )
 
     try:
-        nova = get_nova_client(auth_token=auth_token,
-                               bypass_url=COMPUTE_ENDPOINT)
+        if args.ip:
+            nova = get_nova_client(bypass_url=COMPUTE_ENDPOINT)
+        else:
+            nova = get_nova_client()
+
     except Exception as e:
         status_err(str(e))
     else:
@@ -95,15 +98,16 @@ def check(args):
 
 
 def main(args):
-    check(args)
+    auth_ref = get_auth_ref()
+    check(auth_ref, args)
 
 
 if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(
-            description='Check nova hypervisor stats')
-        parser.add_argument('ip',
+            description='Check Nova hypervisor stats')
+        parser.add_argument('ip', nargs='?',
                             type=ipaddr.IPv4Address,
-                            help='nova API IP address')
+                            help='Nova API IP address')
         args = parser.parse_args()
         main(args)

--- a/maas/plugins/nova_service_check.py
+++ b/maas/plugins/nova_service_check.py
@@ -17,6 +17,7 @@
 import argparse
 
 from maas_common import get_auth_ref
+from maas_common import get_keystone_client
 from maas_common import get_nova_client
 from maas_common import metric_bool
 from maas_common import print_output
@@ -24,10 +25,10 @@ from maas_common import status_err
 from maas_common import status_ok
 
 
-def check(args):
-    auth_ref = get_auth_ref()
-    auth_token = auth_ref['auth_token']
-    tenant_id = auth_ref['project']['id']
+def check(auth_ref, args):
+    keystone = get_keystone_client(auth_ref)
+    auth_token = keystone.auth_token
+    tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
         'http://{hostname}:8774/v2/{tenant_id}'.format(hostname=args.hostname,
@@ -67,7 +68,8 @@ def check(args):
 
 
 def main(args):
-    check(args)
+    auth_ref = get_auth_ref()
+    check(auth_ref, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes : 
- glance_api_local_check: utilize glanceclient now instead of requests
- auth_ref['auth_token'] reference has been updated to keystone.auth_token to support v2 and v3 token format
- auth_ref['project']['id'] reference has been updated to keystone.tenant_id to support v2 and v3 extraction
- IP argument now optional on many checks to fall to query the service endpoint rather than individual IP (except cinder)
- This adds support for RPC-R which still uses keystone v2 client/token format

Closes-Bug: #789 