### PR TITLE
Feature colorize Ansible output

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,6 +15,7 @@ export DEPLOY_CEPH=${DEPLOY_CEPH:-"no"}
 export DEPLOY_SWIFT=${DEPLOY_SWIFT:-"yes"}
 export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-""}
+export ANSIBLE_FORCE_COLOR=${ANSIBLE_FORCE_COLOR:-"true"}
 
 OA_DIR='/opt/rpc-openstack/openstack-ansible'
 RPCD_DIR='/opt/rpc-openstack/rpcd'


### PR DESCRIPTION
According to `Apsu` our jenkins server has the plugin installed to colorize ansible output, and according to this [`shady`](https://major.io/2014/06/25/get-colorful-ansible-output-in-jenkins/) site I found on the internet all we should have to do is to export `ANSIBLE_FORCE_COLOR` with a `true` value.