### PR TITLE
Pause before checking alarm status

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -30,6 +30,10 @@
       retries: 10
       delay: 60
 
+    - name: "Allow MAAS time to run checks before verifying their status"
+      pause:
+        minutes: 2
+
     - name: "Verify Check & Alarm Status"
       script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status


### PR DESCRIPTION
The Verify-Maas playbook has two tasks:
1) Wait for all checks & alarms to be registered
2) Check that no alarms are triggered.

The problem is the step 2 happens before most of the checks have had
time to run. This patch introduces a two minute wait, to ensure all
checks have had time to run. (default check interval is 60s).

Related: #798