### PR TITLE
Add leading 0 to file permissions in plays

### DIFF
--- a/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
+++ b/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
@@ -44,7 +44,7 @@
     dest: "/etc/init.d/beaver"
     owner: "root"
     group: "root"
-    mode: 755
+    mode: 0755
   notify: Restart beaver
   tags:
     - beaver-install
@@ -56,7 +56,7 @@
     dest: "/etc/logrotate.d/beaver"
     owner: "root"
     group: "root"
-    mode: 644
+    mode: 0644
   tags:
     - beaver-install
     - beaver-logrotate

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
@@ -19,7 +19,7 @@
     content: "manual\n"
     owner: "root"
     group: "root"
-    mode: 644
+    mode: 0644
   tags:
     - logstash-web-disable
     - logstash-post-install


### PR DESCRIPTION
The new ansible linting breaks on 3 digit octal permissions. Adding
leading 0 to octal permissions will pass lint checks.

Closes: #812