### PR TITLE
Fix ansible-lint octal permission failures

### DIFF
--- a/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
+++ b/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
@@ -44,7 +44,7 @@
     dest: "/etc/init.d/beaver"
     owner: "root"
     group: "root"
-    mode: 755
+    mode: 0755
   notify: Restart beaver
   tags:
     - beaver-install
@@ -56,7 +56,7 @@
     dest: "/etc/logrotate.d/beaver"
     owner: "root"
     group: "root"
-    mode: 644
+    mode: 0644
   tags:
     - beaver-install
     - beaver-logrotate

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
@@ -19,7 +19,7 @@
     content: "manual\n"
     owner: "root"
     group: "root"
-    mode: 644
+    mode: 0644
   tags:
     - logstash-web-disable
     - logstash-post-install


### PR DESCRIPTION
ansible-lint 2.3.5 introduced an updated check on octal permissions
requiring a leading 0.

(cherry picked from commit 2545ba4b48c13f68f5a37e7cc3d0f8149273d612)
Signed-off-by: Matthew Thode <mthode@mthode.org>