### PR TITLE
Add retry & force to support apt installs

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/support_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/support_preinstall.yml
@@ -19,6 +19,11 @@
     state: present
     update_cache: yes
     cache_valid_time: 600
+    force: yes
   with_items: support_util_packages
+  register: support_packge_installs
+  until: support_packge_installs|success
+  retries: 3
+  delay: 10
   tags:
     - support_packages


### PR DESCRIPTION
So far 29 RPC-AIO gate jobs have failed on the rpc support package
install task. Usually most containers succeed but one or two fail. This
patch increases the chances of success by retrying and adding force so
that unauthenticated packages can be installed.