### PR TITLE
Disable AODH and Ceilometer

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -72,3 +72,13 @@ pkg_locations:
 
 # NOTE(mancdaz) there may be a better place to override this
 horizon_venv_tag: "{{ openstack_release }}"
+
+# disable ceilometer
+cinder_ceilometer_enabled: False
+glance_ceilometer_enabled: False
+heat_ceilometer_enabled: False
+neutron_ceilometer_enabled: False
+nova_ceilometer_enabled: False
+swift_ceilometer_enabled: False
+keystone_ceilometer_enabled: False
+tempest_service_available_ceilometer: False

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -110,6 +110,13 @@ fi
 cd ${RPCD_DIR}/playbooks
 openstack-ansible -i "localhost," patcher.yml
 
+# disable aodh and ceilometer
+export DEPLOY_CEILOMETER=no
+rm /etc/openstack_deploy/conf.d/aodh.yml
+rm /etc/openstack_deploy/conf.d/ceilometer.yml
+rm /etc/openstack_deploy/env.d/aodh.yml
+rm /etc/openstack_deploy/env.d/ceilometer.yml
+
 # begin the openstack installation
 if [[ "${DEPLOY_OA}" == "yes" ]]; then
   cd ${OA_DIR}/playbooks/

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -26,6 +26,13 @@ cp ${RPCD_DIR}/etc/openstack_deploy/user_variables.yml /tmp/upgrade_user_variabl
 ${BASE_DIR}/scripts/update-yaml.py /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 mv /tmp/upgrade_user_variables.yml /etc/rpc_deploy/user_variables.yml
 
+# disable aodh and ceilometer
+export DEPLOY_CEILOMETER=no
+rm /etc/openstack_deploy/conf.d/aodh.yml
+rm /etc/openstack_deploy/conf.d/ceilometer.yml
+rm /etc/openstack_deploy/env.d/aodh.yml
+rm /etc/openstack_deploy/env.d/ceilometer.yml
+
 # Upgrade Ansible in-place so we have access to the patch module.
 cd ${OA_DIR}
 


### PR DESCRIPTION
Closes: #821

RPC-O does not support either of these two products and should
therefore not deploy these services.  By removing the associated env.d
files we disables these services and prevent their deployment.