### PR TITLE
Fix rpc-maas-tool usage in maas migrations

### DIFF
--- a/rpcd/playbooks/maas-20151013-2-pre-migrate.yml
+++ b/rpcd/playbooks/maas-20151013-2-pre-migrate.yml
@@ -19,7 +19,7 @@
   user: root
   tasks:
     - name: Inspect existing checks - all entities
-      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py --tab True checks"
+      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py list-checks"
       register: maas_prior_checks
       changed_when: False
     - name: Record report of existing checks - all entities

--- a/rpcd/playbooks/maas-20151013-3-purge-checks.yml
+++ b/rpcd/playbooks/maas-20151013-3-purge-checks.yml
@@ -19,18 +19,8 @@
   pre_tasks:
     - meta: flush_handlers
   tasks:
-    - name: Lookup Entity ID for physical_host
-      shell: raxmon-entities-list | grep "label={{ physical_host|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
-      register: entity_id
-      changed_when: False
-    - name: Identify checks to purge
-      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py --prefix {{ inventory_hostname }} --tab True checks"
-      register: checks_purge_list
-      changed_when: False
-    - name: Delete existing checks and alarms
-      shell: raxmon-checks-delete --entity-id={{ entity_id.stdout }} --id=$(echo '{{ item }}'| awk '{print $3}') --why="MaaS Migration 20151013"
-      when: inventory_hostname in "{{ item }}"
-      with_items: checks_purge_list.stdout_lines
+    - name: Delete existing checks
+      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py delete --entity {{ inventory_hostname }} --force"
   post_tasks:
     - name: Record migration in index
       local_action: file path={{ migrations_dir }}/maas-20151013 state=touch

--- a/rpcd/playbooks/maas-20151013-6-post-migrate.yml
+++ b/rpcd/playbooks/maas-20151013-6-post-migrate.yml
@@ -19,7 +19,7 @@
   user: root
   tasks:
     - name: Inspect existing checks - all entities
-      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py --tab True checks"
+      script: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py list-checks"
       when: inventory_hostname == groups['hosts'][0]
       register: maas_post_checks
       changed_when: False

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -35,7 +35,7 @@
   command: "python setup.py install"
   args:
     chdir: '{{ horizon_extensions_dest_dir }}'
-  sudo: yes
+  become: true
   notify: Restart apache2
 
 - name: Install python dependencies
@@ -70,7 +70,7 @@
 
 - name: Collect and compress static files
   command: "{{ item }}"
-  sudo: yes
+  become: true
   with_items:
     - horizon-manage.py collectstatic --noinput
     - horizon-manage.py compress --force


### PR DESCRIPTION
Rpc-maas-tool was refactored and the cli changed, however the maas
migrations were not updated. This patch updates the rpc-maas-tool usage
in the maas migrations.

Related: #808
(cherry picked from commit 3898baa74a033a92371db1807e68c7a6dac4828b)
Signed-off-by: Matthew Thode <mthode@mthode.org>