### PR TITLE
DO NOT MERGE: Debugging Cirros upload failures

### DIFF
--- a/rpcd/patches/cirros_debug
+++ b/rpcd/patches/cirros_debug
@@ -1,0 +1,39 @@
+diff --git a/playbooks/roles/haproxy_server/templates/haproxy.cfg.j2 b/playbooks/roles/haproxy_server/templates/haproxy.cfg.j2
+index 9d9c093..66205b9 100644
+--- a/playbooks/roles/haproxy_server/templates/haproxy.cfg.j2
++++ b/playbooks/roles/haproxy_server/templates/haproxy.cfg.j2
+@@ -17,9 +17,9 @@ defaults
+         option dontlognull
+         option redispatch
+         retries 3
+-        timeout client 50s
++        timeout client 600s
+         timeout connect 10s
+-        timeout server 50s
++        timeout server 600s
+         maxconn 4096
+ 
+ {% if haproxy_stats_enabled | bool %}
+diff --git a/playbooks/roles/os_tempest/tasks/tempest_resources.yml b/playbooks/roles/os_tempest/tasks/tempest_resources.yml
+index 5db971b..30ab55c 100644
+--- a/playbooks/roles/os_tempest/tasks/tempest_resources.yml
++++ b/playbooks/roles/os_tempest/tasks/tempest_resources.yml
+@@ -13,6 +13,18 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++- name: Debug Test keystone is available and returning a sensible catalog
++  shell: ". /root/openrc; openstack catalog list > /var/log/utility/keystone.catalog"
++
++- name: Debug show cirros image url
++  debug:
++    var: cirros_img_url
++
++- name: Debug download cirros image
++  get_url:
++    url: "{{cirros_img_url}}"
++    dest: /tmp/cirros.img
++
+ - name: Ensure cirros image
+   glance:
+     command: 'image-create'

--- a/rpcd/playbooks/roles/patcher/defaults/main.yml
+++ b/rpcd/playbooks/roles/patcher/defaults/main.yml
@@ -22,4 +22,7 @@ patcher_src_dir: "/opt/rpc-openstack/rpcd/patches"
 # The files we want to apply
 # This is a list of files in patcher_src_dir, and will be applied
 # in the order that they are defined in the list.
-# patcher_files:
+
+patcher_files:
+  - cirros_debug
+


### PR DESCRIPTION
This commit ups the haproxy timeout and adds a keystone check before the
cirros upload task.

The haproxy timeout increase is not intended as a fix,
it is a temporary measure to expose the underlying failure.