### PR TITLE
Adding missing nova db settings

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -32,6 +32,9 @@ neutron_db_pool_timeout: 60
 nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
+nova_db_max_overflow: 60
+nova_db_max_pool_size: 120
+nova_db_pool_timeout: 60
 
 # Nova config overrides
 nova_cross_az_attach: False


### PR DESCRIPTION
This fix will increase nova DB settings we have determined for RPC-O.
The setting is similar to the neutron component, at least to start with.

Closes-Bug: #861