### PR TITLE
Add issue template to get more complete issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+##### What version (commit) do you encounter this issue on?
+
+##### What type of issue is this (bug, feature, documentation, regression)?
+
+##### What is the expected behavior?
+
+##### What is actually happening?
+
+##### How can we reproduce this issue?
+
+##### How can we verify your issue is addressed?
+
+##### If this is a large issue, what can be done immediately to alleviate the issue while working on a longer-term solution?
+
+##### What is your evaluation on the importance of this issue, and why?
+
+##### What branches / milestones do you believe this issue should target?
+The list below is what is currently supported for backports, remove branches you do not wish to target.
+- [ ] Master
+- [ ] liberty-12.0
+- [ ] kilo


### PR DESCRIPTION
Add an issue template in the .github folder as described
https://github.com/blog/2111-issue-and-pull-request-templates

A list of questions has been added so that hopefully more information
is not needed when prioritizing, targeting, and working on issues.

Fixes: #855