### PR TITLE
Clarify message in disk IO utilization check

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -14,6 +14,6 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ disk_utilisation_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Disk utilisation for {{ device }} >= {{ disk_utilisation_threshold }}%");
+                return new AlarmStatus(CRITICAL, "Disk IO utilisation for {{ device }} >= {{ disk_utilisation_threshold }}%");
             }
 {% endfor %}


### PR DESCRIPTION
The previous message could lead one to believe that the disk was
filling up.  The new message specifies IO utilization vs storage
utilization.

Fixes-Branch: #831