### PR TITLE
Add multiple backend support to cinder_service_check.py

### DIFF
--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -72,17 +72,32 @@ def check(auth_ref, args):
         status_err('No host(s) found in the service list')
 
     status_ok()
-    for service in services:
-        service_is_up = True
-        if service['status'] == 'enabled' and service['state'] != 'up':
-            service_is_up = False
 
-        if args.host:
-            name = '%s_status' % service['binary']
-        else:
+    if args.host:
+        all_services_are_up = True
+
+        for service in services:
+            service_is_up = True
+
+            if service['status'] == 'enabled' and service['state'] != 'up':
+                service_is_up = False
+                all_services_are_up = False
+
+            if '@' in service['host']:
+                [host, backend] = service['host'].split('@')
+                name = '%s-%s_status' % (service['binary'], backend)
+                metric_bool(name, service_is_up)
+
+        name = '%s_status' % service['binary']
+        metric_bool(name, all_services_are_up)
+    else:
+        for service in services:
+            service_is_up = True
+            if service['status'] == 'enabled' and service['state'] != 'up':
+                service_is_up = False
+
             name = '%s_on_host_%s' % (service['binary'], service['host'])
-
-        metric_bool(name, service_is_up)
+            metric_bool(name, service_is_up)
 
 
 def main(args):


### PR DESCRIPTION
When the host argument is supplied and the host has multiple cinder
backends configured, duplicate status metrics are returned. MaaS
currently only checks the last value during alarm evaluation. If the
last backend metric is 1 (up) but previous backend metrics are 0 (down),
no MaaS alert will be fired.

This change addresses this by evaluating all services for a host first,
and then aggregating the results into one status metric.

Additionally, each backend on the host now has its own status metric to
aid in troubleshooting and allow for alarms to be set on individual
backends.

Issue #836

(cherry picked from commit ef3f99fb909da4c16adbc5dd33a21d22be5a38ca)