### PR TITLE
Install HWRaid packages as part of rpc_support

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -72,3 +72,15 @@ holland_packages:
 
 holland_pip_dependencies:
   - MySQL-python
+
+hwraid_apt_repo_url: "http://hwraid.le-vert.net/ubuntu"
+
+hwraid_apt_repos:
+  - { repo: "deb {{ hwraid_apt_repo_url }} {{ ansible_lsb.codename }} main", state: "present" }
+
+hwraid_apt_keys:
+  - { url: "http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key", state: "present" }
+
+hwraid_apt_packages:
+  - megacli
+  - lsiutil

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -27,6 +27,14 @@
 
 - include: support_preinstall.yml
 
+- include: raid_preinstall.yml
+  when: >
+    inventory_hostname in groups['hosts']
+
+- include: raid_install.yml
+  when: >
+    inventory_hostname in groups['hosts']
+
 - include: bashrc.yml
 
 - include: histformat.yml

--- a/rpcd/playbooks/roles/rpc_support/tasks/raid_install.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/raid_install.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install HWRaid packages
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 600
+  with_items: hwraid_apt_packages
+  when: hwraid_apt_packages is defined
+  tags:
+    - hwraid-apt-packages
+    - hwraid-install

--- a/rpcd/playbooks/roles/rpc_support/tasks/raid_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/raid_preinstall.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add HWRaid apt keys
+  apt_key:
+    url: "{{ item.url }}"
+    state: "{{ item.state }}"
+  with_items: hwraid_apt_keys
+  when: hwraid_apt_keys is defined
+  register: add_keys_url
+  until: add_keys_url|success
+  retries: 5
+  delay: 2
+  tags:
+    - hwraid-apt-keys
+    - hwraid-pre-install
+
+- name: Add HWRaid apt repositories
+  apt_repository:
+    repo: "{{ item.repo }}"
+    state: "{{ item.state }}"
+  with_items: hwraid_apt_repos
+  register: add_repos
+  until: add_repos|success
+  retries: 5
+  delay: 2
+  tags:
+    - hwraid-apt-repos
+    - hwraid-pre-install


### PR DESCRIPTION
Add HWRaid repo and install default packages `megaraid` and `lsiutil`. The RAID
tools installed can be overridden with the variable `hwraid_apt_packages`.

Partial-Fix: #186
Signed-off-by: Matthew Thode <mthode@mthode.org>