### PR TITLE
Catch IOError exception when configuring logging

### DIFF
--- a/maas/plugins/maas_common.py
+++ b/maas/plugins/maas_common.py
@@ -532,8 +532,13 @@ def metric_bool(name, success):
     metric(name, 'uint32', value)
 
 
-logging.basicConfig(filename='/var/log/maas_plugins.log',
-                    format='%(asctime)s %(levelname)s: %(message)s')
+try:
+    logging.basicConfig(filename='/var/log/maas_plugins.log',
+                        format='%(asctime)s %(levelname)s: %(message)s')
+except IOError as e:
+    logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s')
+    logging.error('An error occurred accessing /var/log/maas_plugins.log. %s' %
+                  e)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Catch the IOError exception raised when specifying a log file location that can
not be accessed, and fall back to default output behavior.

Fixes: #826
(cherry picked from commit c42831b823b306e0e8a496c2dc73ebf2c706ceda)
Signed-off-by: Matthew Thode <mthode@mthode.org>