### PR TITLE
Retry MaaS alarm status verification, closes #903

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -38,6 +38,12 @@
       script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status
         --entity {{ inventory_hostname }}
+      register: verify_status
+      failed_when: verify_status.rc != 0
+      changed_when: False
+      until: verify_status.rc == 0
+      retries: 10
+      delay: 60
 
   vars_files:
     - "roles/rpc_maas/defaults/main.yml"


### PR DESCRIPTION
Add retrying to the task verifying the status of MaaS alarms.

MaaS alarms can take several minutes, after a plugin starts returning
the correct data, to return to an okay state. This is causing the
upgrade script to fail intermittently. This change will allow more time
before reporting a failure.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/903