### PR TITLE
Pin elasticsearch-curator

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -27,7 +27,7 @@ elasticsearch_apt_packages:
 
 elasticsearch_pip_packages:
   - elasticsearch<2.1.0
-  - elasticsearch-curator
+  - elasticsearch-curator<3.5.0
 
 # This sets the cluster name
 elasticsearch_cluster: openstack


### PR DESCRIPTION
Elasticsearch-curator is now pinned to match elasticsearch. needed
because the 3.5.0 release of elasticsearch-curator requires
elasticsearch>=2.30, while we pin to <2.1.0.

Related: #902
(cherry picked from commit 1586bb86e88394647cb57b4c5ef7c6b199bf4f05)