### PR TITLE
Fix enabled file installed from horizon-extensions

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/templates/_50_rackspace.py
+++ b/rpcd/playbooks/roles/horizon_extensions/templates/_50_rackspace.py
@@ -4,5 +4,7 @@ ADD_INSTALLED_APPS = [
     'rackspace',
 ]
 
+ADD_ANGULAR_MODULES = ['horizon.dashboard.rackspace']
+
 # If set to True, this dashboard will not be added to the settings.
 DISABLED = False


### PR DESCRIPTION
Add the angularjs module containing the Rackspace Solutions
panel code to the Horizon application so it works.

Requires accompanying patch
https://github.com/rcbops/horizon-extensions/pull/7
for the panel to work with this change.

closes #891

(cherry picked from commit b535dcc490f56a54b92443172ad0b5828bc5a540)
Signed-off-by: Matthew Thode <mthode@mthode.org>