### PR TITLE
Make Neutron use internal Nova endpoint

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -82,3 +82,8 @@ nova_ceilometer_enabled: False
 swift_ceilometer_enabled: False
 keystone_ceilometer_enabled: False
 tempest_service_available_ceilometer: False
+
+neutron_git_repo: "https://git.openstack.org/openstack/neutron"
+neutron_git_install_branch: "b80fa23ac0b292db84df84855141eb16a4e0fec0"
+neutron_git_dest: "/opt/neutron_{{ neutron_git_install_branch | replace('/', '_') }}"
+neutron_neutron_conf_overrides: {"nova": {"endpoint_type": "internal"}}


### PR DESCRIPTION
Update Neutron SHA and add configuration override to enable Neutron to
use Nova's internal endpoint.

This removes the need to change the OpenStack-Ansible SHA to address the
issue but will require an upgrade task to remove these changes in a
future release.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/897