### PR TITLE
update OSA sha to 11.2.12 (25/03/2016)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,7 @@ envlist = flake8,ansible-lint
 
 [testenv]
 basepython = python2.7
-deps =
-    -ropenstack-ansible/dev-requirements.txt
-    ansible>=1.9.1,<2.0.0
+deps = -ropenstack-ansible/dev-requirements.txt
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
Also removes ansible from the requirements as OSA is tracking it
Closes #899