### PR TITLE
Disable ml2 port_security extension

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -89,3 +89,8 @@ tempest_service_available_ceilometer: False
 neutron_neutron_conf_overrides:
   nova:
     endpoint_type: internal
+
+# Diasble port security binding for liberty. See https://bugs.launchpad.net/neutron/+bug/1509312
+neutron_ml2_conf_ini_overrides:
+    ml2:
+        extension_drivers: ''


### PR DESCRIPTION
In order to achieve parity between upgraded and freshly installed
environments, the ml2 port_security extension is disabled in Liberty.

While greenfield environments are not affected, environments upgraded
from Kilo to Liberty will experience VM breakage when connecting to
pre-existing networks. https://bugs.launchpad.net/neutron/+bug/1509312
has more detail, including a patch that allows neutron to handle this
gracefully, but that patch has not yet merged into Mitaka or Liberty as
of this writing.

closes #929