### PR TITLE
Use ansible_nodename for Cinder service checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
@@ -5,7 +5,7 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : cinder_service_check.py
-    args    : ["--host", "{{ ansible_hostname }}", "{{ internal_vip_address }}"]
+    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_scheduler_status :
         label                   : cinder_scheduler_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -5,7 +5,7 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : cinder_service_check.py
-    args    : ["--host", "{{ ansible_hostname }}", "{{ internal_vip_address }}"]
+    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_volume_status :
         label                   : cinder_volume_status--{{ ansible_hostname }}


### PR DESCRIPTION
Replace ansible_hostname with ansible_nodename as the host argument
supplied to the cinder_service_check.py MaaS plugin by the configured
checks.

The default value for the hostname used in Cinder is supplied by
socket.gethostname. The Ansible fact that should be equivalent to this
is ansible_nodename.

ansible_hostname == ansible_nodename.split('.')[0]

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/924
(cherry picked from commit 0b2ade51277ce00281ce56129850ce363e6f9e95)