### PR TITLE
Override neutron.conf to add endpoint type

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -85,3 +85,7 @@ nova_ceilometer_enabled: False
 swift_ceilometer_enabled: False
 keystone_ceilometer_enabled: False
 tempest_service_available_ceilometer: False
+
+neutron_neutron_conf_overrides:
+  nova:
+    endpoint_type: internal


### PR DESCRIPTION
In issue #897 we pulled in an upstream fix which adds the ability
to specify the type of nova endpoint to use. The endpoint specified
should be one of public, internal or admin and will be looked up
in the keystone catalog.  OSA did not add the key in `neutron.conf`
to specify the endpoint type as the default `public` works for most
deployments.  RPC-O deployments on the other hand typically have
the public endpoints inaccessible from the control plane thus
requiring us to override that value.

Partially-fixes: #897

This was cherry picked from the liberty-12.0 branch because the fix was
mistakenly not first committed to master.
(cherry picked from commit aadb2d42a0c07603f95f995dd840919371333080)