### PR TITLE
Remove fixed elasticsearch URL from Kibana

### DIFF
--- a/rpcd/playbooks/roles/kibana/defaults/main.yml
+++ b/rpcd/playbooks/roles/kibana/defaults/main.yml
@@ -20,7 +20,7 @@ kibana_sha256sum: "480562733c2c941525bfa26326b6fae5faf83109b452a6c4e283a5c37e308
 
 elasticsearch_http_port: 9200
 elasticsearch_vip: "{{ internal_lb_vip_address }}"
-elasticsearch_public_url: "https://{{ external_lb_vip_address }}:8443/elasticsearch/"
+elasticsearch_public_url: '"https://"+window.location.hostname+":8443/elasticsearch/"'
 
 kibana_apt_packages:
   - apache2

--- a/rpcd/playbooks/roles/kibana/templates/000-kibana.conf
+++ b/rpcd/playbooks/roles/kibana/templates/000-kibana.conf
@@ -1,13 +1,10 @@
 <VirtualHost *:80>
-    ServerName {{ kibana_server_name }}
     RewriteEngine On
     RewriteCond %{HTTPS} !=on
     RewriteRule ^/?(.*) https://%{HTTP_HOST}:{{ kibana_ssl_port }}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost *:{{ kibana_ssl_port }}>
-    ServerName {{ kibana_server_name }}
-
     LogLevel  {{  kibana_log_level|default('info') }}
     ErrorLog  /var/log/apache2/kibana-error.log
     CustomLog /var/log/apache2/ssl_access.log combined


### PR DESCRIPTION
Remove hard coded elasticsearch URL from the kibana configuration
and the apache proxy server.
The window hostname in which kibana is started, is used to compose the
elasticsearch URL.
This change enables access of the Kibana application through port
tunneling protocols like SSH.

Closes-Bug: #916
(cherry picked from commit 2ad48166c183a6cc6988aa07cc00b7cfbcf38ed3)