### PR TITLE
Prevent deployment of Ceilometer in AIO

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -91,6 +91,10 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   then
     rm /etc/openstack_deploy/conf.d/swift.yml
   fi
+  if [ "${DEPLOY_CEILOMETER}" != "yes" ]; then
+    rm -f /etc/openstack_deploy/conf.d/ceilometer.yml
+    sed -i 's/swift_ceilometer_enabled:.*/swift_ceilometer_enabled: False/' /etc/openstack_deploy/user_variables.yml
+  fi
 fi
 
 # bootstrap ansible if need be


### PR DESCRIPTION
Remove the Ceilometer conf.d file so that the Ceilometer groups are
empty thereby preventing the creation of any Ceilometer containers or
the Ceilometer playbooks finding any valid hosts.

This commit should have not impact on production deployments but is
intended to improve the the Kilo gating process.

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/945