### PR TITLE
add liberty-12.1 branch to the list of branches

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,9 @@
 ##### What is your evaluation on the importance of this issue, and why?
 
 ##### What branches / milestones do you believe this issue should target?
-The list below is what is currently supported for backports, remove branches you do not wish to target.
+###### The list below is what is currently supported for backports
+###### Remove branches (lines) you do not wish to target.
 - [ ] Master
+- [ ] liberty-12.1
 - [ ] liberty-12.0
 - [ ] kilo


### PR DESCRIPTION
This adds to the list of the branches we can target for issues to
backport fixes.  We also attempt to clarify how to use the branch
targeting for easier end user use.