### PR TITLE
Revising logstash LS_HEAP_SIZE calculation

### DIFF
--- a/rpcd/playbooks/roles/logstash/templates/logstash
+++ b/rpcd/playbooks/roles/logstash/templates/logstash
@@ -18,9 +18,9 @@ LS_OPTS="-w {{ logstash_workers|int }} {{ logstash_verbose|default() }}"
 {% if logstash_heap_size_mb is not defined %}
 {%   set memtotal_mb = hostvars[inventory_hostname]['ansible_memtotal_mb']|int %}
 {%   if memtotal_mb <= 32768 %}
-{%     set logstash_heap_size_mb = memtotal_mb // 2 %}
+{%     set logstash_heap_size_mb = memtotal_mb // 3 %}
 {%   else %}
-{%     set logstash_heap_size_mb = 16384 %}
+{%     set logstash_heap_size_mb = memtotal_mb // 2 %}
 {%   endif %}
 {% endif %}
 LS_HEAP_SIZE={{ logstash_heap_size_mb|int }}m


### PR DESCRIPTION
This fix revises the logstash LS_HEAP_SIZE calculation to 1/3rd
of the RAM when having less than 32G RAM available.
If a system has more than 32G RAM available, 1/2 of the RAM
is allocated to logstash.

Closes-Bug: #918
(cherry picked from commit 4c1dee14d88a685ea40f086043d77ce67d192659)