### PR TITLE
Update master Liberty SHA to include repo upgrade fix.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint>=2.0.3
+ansible-lint>=2.0.3,<=2.3.6
 flake8==2.2.4
 hacking>=0.10.0,<0.11
 pep8==1.5.7


### PR DESCRIPTION
This SHA bump includes the repository upgrade fix outlined in
[`1566915`](https://bugs.launchpad.net/openstack-ansible/+bug/1566915).

Closes: #961