### PR TITLE
Constrain version of ansible-lint

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint>=2.0.3
+ansible-lint>=2.0.3,<=2.3.6
 flake8==2.2.4
 hacking>=0.10.0,<0.11
 pep8==1.5.7


### PR DESCRIPTION
ansible-lint version 2.5.0 causes scripts/linting-ansible.sh to fail.
The error appear to be due to a bug introduced into 2.5.0 that is
affecting tasks using the modules in rpcd/playbooks/library. There is an
issue tracking this on the ansible-lint GitHub repo [1].

This patch constrains the version of ansible-lint to avoid hitting the
bug. The version contraints mirror those in openstack-ansible Liberty.

[1] https://github.com/willthames/ansible-lint/issues/145

Closes-issue: https://github.com/rcbops/rpc-openstack/issues/963