### PR TITLE
Use the correct URL in nova-api F5 heath checks

### DIFF
--- a/scripts/f5-monitor.sh
+++ b/scripts/f5-monitor.sh
@@ -103,7 +103,7 @@ get_token() {
               ;;
           8774)
               #Nova API Compute
-              check_url="$check_proto://$check_ip:$check_port/v3/"
+              check_url="$check_proto://$check_ip:$check_port/v2.1/"
               ;;
           8004)
               #Heat API


### PR DESCRIPTION
The `v3` endpoint went away.  Both `v2` and `v2.1` are in use in
Liberty, however, going forward `v2.1` seems to be used more (see
current upstream Mitaka docs).  Because of this, we change the
healthcheck to monitor the `v2.1` endpoint.

related: #965