### PR TITLE
Update 20-openstack.j2

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/templates/20-openstack.j2
+++ b/rpcd/playbooks/roles/rpc_support/templates/20-openstack.j2
@@ -2,5 +2,5 @@
 printf "\n\n**************
 WARNING: This is an OpenStack Private Cloud device.
 Please log out if you are not familiar with these environments.
-Contact 700-NOVA if you have any questons.
+Contact 700-NOVA if you have any questions.
 **************\n\n"


### PR DESCRIPTION
Fix spelling mistake

s/questons/questions
(cherry picked from commit f32afe001724d19e90d4e24090978ddce3f6378a)

not sure if this should wait for 12.1.1 or not, we'll need a new milestone if so
Signed-off-by: Matthew Thode <mthode@mthode.org>