### PR TITLE
Increase memcache ttl for distributing ssh keys

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/distribute_auth_key.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/distribute_auth_key.yml
@@ -20,6 +20,7 @@
     state: "present"
     server: "{{ hostvars[groups['memcached'][0]]['ansible_ssh_host'] }}:11211"
     encrypt_string: "{{ memcached_encryption_key }}"
+    expires: 86400
   with_items:
     - { src: "/root/.ssh/rpc_support", name: "rpc_support" }
     - { src: "/root/.ssh/rpc_support.pub", name: "rpc_support_pub" }


### PR DESCRIPTION
The rpc-support play can take longer then the default ttl of 300
seconds, this causes the task to fail to retrieve the ssh keys from
memcache and the play to then fail as well.

related bug #967

(cherry picked from commit 68621a5b8375a386f33f82a82a5760f0da5d1ba4)
Signed-off-by: Matthew Thode <mthode@mthode.org>