### PR TITLE
add override to enable l2pop

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -29,6 +29,9 @@ neutron_db_max_overflow: 60
 neutron_db_max_pool_size: 120
 neutron_db_pool_timeout: 60
 
+# Enable l2pop as the default changed upstream https://github.com/rcbops/rpc-openstack/issues/973
+neutron_l2_population: "True"
+
 nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"


### PR DESCRIPTION
Upstream OSA disabled l2pop in liberty and later.  This will cause
existing customers to have failed guest networking.  A migration
to vxlan multicast will eventually be needed, but for the moment we
can override and turn on l2pop.

related-bug: #973
(cherry picked from commit 0a6319a3b776f4bca975fcdbf328412fa364633b)
Signed-off-by: Matthew Thode <mthode@mthode.org>