### PR TITLE
Disable ceph-ansible fsid auto-generation

### DIFF
--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -98,6 +98,9 @@ maas_filesystem_critical_threshold: 90.0
 # Ceph options
 # fsid is the unique identifier for your object store.
 fsid: '{{ fsid_uuid }}'
+# Since we assign our own fsid, we do not need ceph-ansible to auto-generate
+# an fsid for us.
+generate_fsid: false
 # directory for backing up ceph keys.
 fetch_directory: /etc/openstack_deploy/ceph_fetch
 # Use stable version of ceph


### PR DESCRIPTION
By default, ceph-ansible also creates a cluster fsid even when fsid is
overridden in user variables.  Commit [1] adds a new variable called
generate_fsid which, when set to false, will disable ceph-ansible's uuid
generation.

Note that leaving generate_fsid set to true does not have any effect on
the fsid we assign to the cluster, however it does create a file called
/etc/openstack_deploy/ceph_fetch/ceph_cluster_uuid.conf which does not
reflect the actual fsid of the cluster.

[1] https://github.com/ceph/ceph-ansible/commit/8e0d53e

Closes #1001 