### PR TITLE
Set galera_wait_timeout override to 3600

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -55,6 +55,7 @@ keystone_token_driver: "keystone.token.persistence.backends.sql.Token"
 
 # Galera overrides
 galera_cluster_name: rpc_galera_cluster
+galera_wait_timeout: 3600
 
 # Ceph overrides
 ceph_mons: >


### PR DESCRIPTION
This Galera setting uses the same timeout for SQl connection
as configured inside SQL Alchemy (pool_recycle) and prevent possibly
SQL session build up due to a large default setting (8 Hours)

Closes-Bug: #995