### PR TITLE
Deploy beaver only to hosts where pip is laid down

### DIFF
--- a/rpcd/playbooks/beaver.yml
+++ b/rpcd/playbooks/beaver.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Setup beaver log shipper
-  hosts: all
+  hosts: hosts:all_containers
   max_fail_percentage: 20
   user: root
   roles:


### PR DESCRIPTION
Deploy beaver only to hosts where pip is laid down

Beaver depends on the pip.conf gile being laid down.  Therefore we
should only deploy beaver to the same places pip.conf is laid down.

https://github.com/rcbops/rpc-openstack/blob/0c26acf4766c716295ed6a4e4db107512fc5841d/rpcd/playbooks/beaver.yml#L17

related bug: #991