### PR TITLE
Disable glance image cache

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -158,3 +158,9 @@ ssh_delay: 60
 
 # Use the correct secrets file
 osa_secrets_file_name: "user_osa_secrets.yml"
+
+# Disable glance image cache
+glance_flavor: keystone
+glance_glance_api_conf_overrides:
+  DEFAULT:
+    image_cache_dir: None


### PR DESCRIPTION
The glance image cache is now disabled, primarily to prevent container
filesystems to fill up with temporary glance operations like uploading
images from cinder into glance.
Additionally the cinder image_conversion_dir is set to /openstack/backup
to prevent local root partion of cinder volumes container or nodes to fill
up. The /openstack partition has usually all available disk space assigned.

Connects #1005
