### PR TITLE
Remove one level of quoting inside the elasticsearch_url

### DIFF
--- a/rpcd/playbooks/roles/kibana/templates/config.js
+++ b/rpcd/playbooks/roles/kibana/templates/config.js
@@ -29,7 +29,7 @@ function (Settings) {
      *  +elasticsearch: {server: "http://localhost:9200", withCredentials: true}+
      *
      */
-    elasticsearch: "{{ elasticsearch_public_url }}",
+    elasticsearch: {{ elasticsearch_public_url }},
 
     /** @scratch /configuration/config.js/5
      *


### PR DESCRIPTION
The default value for the elasticsearch_url config inside kibana
already includes the correct quotes so there is no need for
additional quoting inside the config.js kibana template.

Closes-Bug: #1011
(cherry picked from commit ddd262a75b2b16ce20889a25f84a40f8012ac0cc)