### PR TITLE
Bootstrap Ansible whenever deploy.sh is run

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,7 +32,7 @@ function run_ansible {
 cd ${OA_DIR}
 
 # bootstrap ansible and install galaxy roles (needed whether AIO or multinode)
-which openstack-ansible || ./scripts/bootstrap-ansible.sh
+./scripts/bootstrap-ansible.sh
 ansible-galaxy install --role-file=/opt/rpc-openstack/ansible-role-requirements.yml --force \
                            --roles-path=/opt/rpc-openstack/rpcd/playbooks/roles
 


### PR DESCRIPTION
openstack-ansible/scripts/bootstrap-ansible.sh is used to setup Ansible
which includes downloading the roles required by openstack-ansible
(OSA).

deploy.sh is updated so that bootstrap-ansible.sh runs whenever
deploy.sh does. This resolves an issue where the role
openstack-ansible-security is not getting downloaded because OSA
introduced it as part of a patch release.

This change should also ensure that all the OSA required roles are at
the correct versions as well as Ansible itself.

Issue: https://github.com/rcbops/rpc-openstack/issues/1026
(cherry picked from commit c756edd0a78ccc1ad737fb5b8d834c2cec522100)