### PR TITLE
Disable xtrabackup version check

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -55,6 +55,9 @@ keystone_token_driver: "keystone.token.persistence.backends.sql.Token"
 
 # Galera overrides
 galera_cluster_name: rpc_galera_cluster
+galera_cluster_cnf_overrides:
+  xtrabackup:
+    no-version-check: true
 
 # Ceph overrides
 ceph_mons: >


### PR DESCRIPTION
Galera upstream has known bug in mariadb 5.5 where the permissiions
on the version check file in /tmp will be reset, causing errors.
Disable the check for kilo, where the error exists.  This is fixed
in liberty where we use maria 10.

Closes: #536