### PR TITLE
Install packages required by Paramiko 2.0.0

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,6 +26,13 @@ function run_ansible {
   openstack-ansible ${ANSIBLE_PARAMETERS} --forks ${FORKS} $@
 }
 
+# https://github.com/rcbops/rpc-openstack/issues/1037
+# The latest openstack-ansible kilo tag, 11.2.14, fails due to a new version of
+# paramiko (2.0.0). The upstream fix is not in a tagged release. Installing the
+# following packages resolves the issue and can be removed once the openstack-ansible
+# SHA contains 75890e2372a66a8a9be24bc147179b6f08f90e76
+apt-get update && apt-get install -y build-essential libssl-dev libffi-dev python-dev
+
 # begin the bootstrap process
 cd ${OA_DIR}
 


### PR DESCRIPTION
Paramiko recently released version 2.0.0, this is installed by
bootstrap-ansible.sh and causes the script to fail due to missing
dependencies. This is addressed in openstack-ansible kilo but is not
included in the latest tag. deploy.sh has been modified to install the
missing packages. This is required until the next openstack-ansible tag
is released.

Issue: https://github.com/rcbops/rpc-openstack/issues/1037