### PR TITLE
Unlock repo server pip during deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -114,6 +114,14 @@ openstack-ansible -i "localhost," patcher.yml
 
 # begin the openstack installation
 if [[ "${DEPLOY_OA}" == "yes" ]]; then
+
+  # This deploy script is also used for minor upgrades (within an openstack release)
+  # Some versions of liberty deploy pip lockdown to the repo server, in order for an
+  # upgrade to succeed the pip config must be removed so that repo builds have
+  # access to external repos.
+  # Issue tracking upstream fix: https://github.com/rcbops/rpc-openstack/issues/1028
+  ansible repo_all -m file -a 'name=/root/.pip state=absent' 2>/dev/null ||:
+
   cd ${OA_DIR}/playbooks/
 
   # ensure that the ELK containers aren't created if they're not


### PR DESCRIPTION
The deploy script is also used for minor upgrades (within an openstack release)
Some versions of liberty deploy pip lockdown to the repo server, in order for
an upgrade to suceed the pip config must be removed so that repo builds have
access to external repos.

Partial-Bug: #1028
(cherry picked from commit 610cd8c34addcd24fd325d8c3bf1381ee1d28417)