### PR TITLE
Change memcached monitoring to monitor curr_conns

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -275,7 +275,7 @@ IP address of memcached server
     metric memcache_total_items uint64 563324 items
     metric memcache_get_hits uint64 4543534 hits
     metric memcache_get_misses uint64 2346565 misses
-    metric memcache_total_connections uint64 42565 connections
+    metric memcache_curr_connections uint64 42565 connections
 
 ***
 #### horizon_check.py

--- a/maas/plugins/memcached_status.py
+++ b/maas/plugins/memcached_status.py
@@ -31,7 +31,7 @@ VERSIONS = ['1.4.14 (Ubuntu)', '1.4.15']
 MEMCACHE_METRICS = {'total_items': 'items',
                     'get_hits': 'cache_hits',
                     'get_misses': 'cache_misses',
-                    'total_connections': 'connections'}
+                    'curr_connections': 'connections'}
 
 
 def item_stats(host, port):

--- a/maas/testing/tests/integration/maas_local
+++ b/maas/testing/tests/integration/maas_local
@@ -876,6 +876,15 @@
                         "disabled": false,
                         "metadata": null,
                         "scheduled_suppressions": []
+                    },
+                    "memcache_curr_connections--CONTROLLER_memcached_container_UID": {
+                        "active_suppressions": [],
+                        "confd_hash": null,
+                        "confd_name": null,
+                        "criteria": ":set consecutiveCount=3 if (metric[\"memcache_curr_connections\"] > 922) { return new AlarmStatus(WARNING, \"memcached connection count is >= 90% of max\"); }",
+                        "disabled": false,
+                        "metadata": null,
+                        "scheduled_suppressions": []
                     }
                 },
                 "confd_hash": null,
@@ -901,8 +910,8 @@
                         "name": "memcache_get_misses",
                         "unit": "cache_misses"
                     },
-                    "memcache_total_connections": {
-                        "name": "memcache_total_connections",
+                    "memcache_curr_connections": {
+                        "name": "memcache_curr_connections",
                         "unit": "connections"
                     },
                     "memcache_total_items": {

--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -42,6 +42,10 @@ nova_cross_az_attach: False
 # RabbitMQ overrides
 rabbitmq_ulimit: 65535
 
+# Memcached overrides
+# needed so that maas can consume what was only consumable in the memcached role
+memcached_connections: 1024
+
 ## Apache SSL Settings
 # These do not need to be configured unless you're creating certificates for
 # services running behind Apache (currently, Horizon and Keystone).

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -15,3 +15,11 @@ alarms      :
             if (metric["memcache_api_local_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "memcache unavailable");
             }
+    memcache_curr_connections :
+        label                   : memcache_curr_connections--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["memcache_curr_connections"] > {{ ((memcached_connections*0.9)|round|int) }}) {
+                return new AlarmStatus(WARNING, "memcached connection count is >= 90% of max");
+            }


### PR DESCRIPTION

https://github.com/rcbops/rpc-openstack/compare/kilo...bugs/1025-kilo?expand=1Memcached previously monitored total connections, this is does not
tell us useful information, so I changed it to monitor current
connections and also alarm (WARNING) against reaching 90% of the
maximum active connection limit.

`memcached_connections` is also set globally so that it can be used
in both the memcached role and in the maas role.

Related: #1025
(cherry picked from commit 441b8320346001829b09f0af0a1990855b7f21db)
Signed-off-by: Matthew Thode <mthode@mthode.org>