### PR TITLE
Ensure critical threshold

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -242,10 +242,12 @@ cinder_volumes_vg_critical_threshold: 90.0
 cinder_vg_name: "{{ cinder_backends['lvm']['volume_group'] }}"
 
 # MaaS CPU idle threshold
-cpu_idle_percent_avg_threshold: 10.0
+cpu_idle_percent_avg_warning_threshold: 10.0
+cpu_idle_percent_avg_critical_threshold: 1.0
 
 # MaaS Memory in use threshold
-memory_used_percentage_threshold: 95.0
+memory_used_percentage_warning_threshold: 90.0
+memory_used_percentage_critical_threshold: 99.0
 
 # Set the threshold for the "Max Channels per Connection" Rabbitmq alarm
 rabbitmq_max_channels_per_con_threshold: 10
@@ -259,10 +261,12 @@ rabbitmq_queue_growth_rate_threshold: 15
 
 
 # Set the threshold for the "Disk utilisation" MaaS alarms
-disk_utilisation_threshold: 90
+disk_utilisation_warning_threshold: 90
+disk_utilisation_critical_threshold: 99
 
 # nf_conntrack threshold
-nf_conntrack_threshold: 90
+nf_conntrack_warning_threshold: 80
+nf_conntrack_critical_threshold: 90
 
 # net_max_speed has units of Mb/s, set to null for auto discovery
 net_max_speed: null

--- a/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
@@ -12,6 +12,9 @@ alarms      :
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ nf_conntrack_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Connection count is > {{ nf_conntrack_threshold }}% of maximum allowed.");
+            if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ nf_conntrack_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Connection count is > {{ nf_conntrack_critical_threshold }}% of maximum allowed.");
+            }
+            if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ nf_conntrack_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Connection count is > {{ nf_conntrack_warning_threshold }}% of maximum allowed.");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
@@ -9,6 +9,9 @@ alarms            :
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["idle_percent_average"] <= {{ cpu_idle_percent_avg_threshold }}) {
-                return new AlarmStatus(WARNING, "CPU time spent idle has dropped to <= {{ cpu_idle_percent_avg_threshold }}%");
+            if (metric["idle_percent_average"] <= {{ cpu_idle_percent_avg_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "CPU time spent idle has dropped to <= {{ cpu_idle_percent_avg_critical_threshold }}%");
+            }
+            if (metric["idle_percent_average"] <= {{ cpu_idle_percent_avg_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "CPU time spent idle has dropped to <= {{ cpu_idle_percent_avg_warning_threshold }}%");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -13,7 +13,10 @@ alarms      :
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["disk_utilisation_{{ device }}"] > {{ disk_utilisation_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Disk IO utilisation for {{ device }} >= {{ disk_utilisation_threshold }}%");
+            if (metric["disk_utilisation_{{ device }}"] > {{ disk_utilisation_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Disk IO utilisation for {{ device }} >= {{ disk_utilisation_critical_threshold }}%");
+            }
+            if (metric["disk_utilisation_{{ device }}"] > {{ disk_utilisation_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Disk IO utilisation for {{ device }} >= {{ disk_utilisation_warning_threshold }}%");
             }
 {% endfor %}

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -21,5 +21,8 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_curr_connections"] > {{ ((memcached_connections*0.9)|round|int) }}) {
-                return new AlarmStatus(WARNING, "memcached connection count is >= 90% of max");
+                return new AlarmStatus(CRITICAL, "memcached connection count is >= 90% of max");
+            }
+            if (metric["memcache_curr_connections"] > {{ ((memcached_connections*0.8)|round|int) }}) {
+                return new AlarmStatus(WARNING, "memcached connection count is >= 80% of max");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
@@ -9,6 +9,9 @@ alarms            :
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (percentage(metric["actual_used"], metric["total"]) >= {{ memory_used_percentage_threshold }}) {
-                return new AlarmStatus(WARNING, "Memory is {{ memory_used_percentage_threshold }}%+ in use.");
+            if (percentage(metric["actual_used"], metric["total"]) >= {{ memory_used_percentage_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Memory is {{ memory_used_percentage_critical_threshold }}%+ in use.");
+            }
+            if (percentage(metric["actual_used"], metric["total"]) >= {{ memory_used_percentage_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Memory is {{ memory_used_percentage_warning_threshold }}%+ in use.");
             }


### PR DESCRIPTION
Checks without a CRITICAL threshold will never be seen by 90% of Rackspace customers so add CRITICAL threshold to various alarms.

Addresses bug #1091