### PR TITLE
[WIP] Run ceph roles serially

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -136,6 +136,11 @@ secure_cluster: true
 # List of secure flags to set on for a pool (options for the list are nodelete, nopgchange, nosizechange - prevents deletion, pg from changing and size from changing respectively).
 secure_cluster_flags:
   - nodelete
+# This is necessary if we want to bootstrap MONs serially, failing to set this
+# will result in additional MONs failing to bootstrap due to lack of quorum.
+ceph_conf_overrides:
+  mon:
+    mon initial members: "{{ hostvars[groups['mons'][0]]['ansible_hostname'] }}"
 
 # We need to override the OpenStack upper constraint for Mitaka which is version 1.9.0, We should be able to remove this in Newton as the upper constraint moves to 2.3.0
 repo_build_upper_constraints_overrides:

--- a/rpcd/playbooks/ceph-mon.yml
+++ b/rpcd/playbooks/ceph-mon.yml
@@ -17,8 +17,13 @@
   hosts: mons
   user: root
   max_fail_percentage: 0
+  serial: 1
   roles:
     - ceph.ceph-mon
+
+- name: Remove rbd pool
+  hosts: mons[0]
+  user: root
   tasks:
     - name: Check if rbd pool exists and is empty
       shell: rados -p rbd df | egrep '^rbd( +0){9}$'

--- a/rpcd/playbooks/ceph-osd.yml
+++ b/rpcd/playbooks/ceph-osd.yml
@@ -19,6 +19,8 @@
 - name: Deploy osds
   hosts: osds
   user: root
+  max_fail_percentage: 0
+  serial: 1
   pre_tasks:
     - name: Create log dir
       file:


### PR DESCRIPTION
This commit uses ansible's `serial` to deploy MONs and OSDs serially,
which should prevent masses of services restarting at the same time.

In order for MONs to bootstrap one by one, we need to set `mon initial
members` in ceph.conf.

Additionally, we separate out the tasks in ceph-mon.yml so these can
be targetted at a different host group (with the end goal of these
tasks only being run once).

NOTE: Bootstrapping OSDs serially may be slow, so we can introduce a
      variable override that can be passed in on the command line to
      disable `serial: 1`.
