### PR TITLE
Include commit message checks from hacking

### DIFF
--- a/hacking/rpco_checks.py
+++ b/hacking/rpco_checks.py
@@ -1,0 +1,111 @@
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+"""Contain all custom extensions to hacking and flake8 for RPCO."""
+
+import os
+import re
+import subprocess
+
+from hacking import core
+
+
+class GitCheck(core.GlobalCheck):
+    """Base-class for Git related checks."""
+
+    def _get_commit_title(self):
+        # Check if we're inside a git checkout
+        try:
+            subp = subprocess.Popen(
+                ['git', 'rev-parse', '--show-toplevel'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            gitdir = subp.communicate()[0].rstrip()
+        except OSError:
+            # "git" was not found
+            return None
+
+        if not os.path.exists(gitdir):
+            return None
+
+        # Get title of most recent commit
+        subp = subprocess.Popen(
+            ['git', 'log', '--no-merges', '--pretty=%s', '-1'],
+            stdout=subprocess.PIPE)
+        title = subp.communicate()[0]
+
+        if subp.returncode:
+            raise Exception("git log failed with code %s" % subp.returncode)
+        return title.decode('utf-8')
+
+
+class OnceGitCheckCommitTitleBug(GitCheck):
+    """Check git commit messages for bugs.
+
+    OpenStack HACKING recommends not referencing a bug or blueprint in first
+    line. It should provide an accurate description of the change
+    R801
+    """
+    name = "GitCheckCommitTitleBug"
+
+    # From https://github.com/openstack/openstack-ci-puppet
+    #       /blob/master/modules/gerrit/manifests/init.pp#L74
+    # Changeid|bug|blueprint
+    GIT_REGEX = re.compile(
+        r'(I[0-9a-f]{8,40})|'
+        '([Bb]ug|[Ll][Pp])[\s\#:]*(\d+)|'
+        '([Bb]lue[Pp]rint|[Bb][Pp])[\s\#:]*([A-Za-z0-9\\-]+)')
+
+    def run_once(self):
+        title = self._get_commit_title()
+
+        # NOTE(jogo) if match regex but over 3 words, acceptable title
+        if (title and self.GIT_REGEX.search(title) is not None
+                and len(title.split()) <= 3):
+            return (1, 0,
+                    "R801: git commit title ('%s') should provide an "
+                    "accurate description of the change, not just a reference"
+                    " to a bug or blueprint" % title.strip(), self.name)
+
+
+class OnceGitCheckCommitTitleLength(GitCheck):
+    """Check git commit message length."""
+    name = "GitCheckCommitTitleLength"
+
+    def run_once(self):
+        title = self._get_commit_title()
+
+        if title and len(title) > 50:
+            return (
+                1, 0,
+                "R802: git commit title ('%s') should be under 50 chars"
+                % title.strip(),
+                self.name)
+
+
+class OnceGitCheckCommitTitlePeriodEnding(GitCheck):
+    """Check the end of the first line of git commit messages.
+
+    The first line of git commit message should not end with a period.
+
+    R803 Commit message should not end with a period
+    """
+    name = "GitCheckCommitTitlePeriodEnding"
+
+    def run_once(self):
+        title = self._get_commit_title()
+
+        if title and title.rstrip().endswith('.'):
+            return (
+                1, 0,
+                "R803: git commit title ('%s') should not end with period"
+                % title.strip(),
+                self.name)
+    pass

--- a/hacking/setup.py
+++ b/hacking/setup.py
@@ -1,0 +1,37 @@
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+import setuptools
+
+version = '1.0.0'
+
+setuptools.setup(
+    name='rpco-hacking-checks',
+    author='Rackspace Private Cloud',
+    description='Hacking/Flake8 checks for rpc-openstack',
+    version=version,
+    install_requires=['hacking'],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+    ],
+    py_modules=['rpco_checks'],
+    provides=['rpco_checks'],
+    entry_points={
+        'flake8.extension': [
+            'rpco.git_title_bug = rpco_checks:OnceGitCheckCommitTitleBug',
+            ('rpco.git_title_length = '
+             'rpco_checks:OnceGitCheckCommitTitleLength'),
+            ('rpco.git_title_period = '
+             'rpco_checks:OnceGitCheckCommitTitlePeriodEnding'),
+        ]
+    },
+)

--- a/scripts/linting-pep8.sh
+++ b/scripts/linting-pep8.sh
@@ -21,6 +21,12 @@ if [[ -z "$VIRTUAL_ENV" ]] ; then
     echo "WARNING: Not running hacking inside a virtual environment."
 fi
 
+# NOTE(sigmavirus24): This allows us to utilize multiprocessing for the python
+# files (for speed)
 flake8 $(grep -rln -e '^#!/usr/bin/env python' \
                    -e '^#!/bin/python' \
                    -e '^#!/usr/bin/python' * )
+# NOTE(sigmavirus24): This will run the git commit checks while ensuring that
+# the commit error messages do not appear more than once (by constraining
+# flake8 to not using multiprocessing). It's hacky but presently necessary
+flake8 --ignore F403,H303 --jobs 0 hacking/

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ basepython = python2.7
 deps =
     -rtest-requirements.txt
     ansible{env:ANSIBLE_VERSION:>=1.9.1,<2.0.0}
+    -e./hacking
 
 [testenv:flake8]
 commands =
@@ -22,6 +23,7 @@ commands =
 # Ignores the following rules due to how ansible modules work in general
 #     F403 'from ansible.module_utils.basic import *' used; unable to detect undefined names
 #     H303  No wildcard (*) import.
+#     R     excludes all of the RPC specific checks
 # Excluding our upstream submodule, and our vendored f5 configuration script.
-ignore=F403,H303
+ignore=F403,H303,R
 exclude=openstack-ansible/*,f5-config.py


### PR DESCRIPTION
Hacking 0.9 was the last version that included commit title checks.
After that, they were removed from hacking and so we need to vendor
these into our own project.

Addresses #1036

(cherry picked from commit 4a2bf44d3e4f263bf64e7917e5e6b114389b29e6)