### PR TITLE
Remove Travis CI testing support for Ansible>2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,5 @@ matrix:
       env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=ansible-lint
-    - python: 2.7
-      env: TOXENV=ansible-lint ANSIBLE_VERSION='>=2.0'
 
 sudo: false


### PR DESCRIPTION
With the release of Ansible 2.1 the Travis CI job to run ansible-lint on
RPCO with ansible>2 is now failing. Due to RPCO currently only
supporting Ansible versions less than 2 the job will be removed.

openstack-ansible is currently looking to make ansible>=2 a requirement
for Newton and therefore ansible-lint support will need updating in a
future release.

Issue: https://github.com/rcbops/rpc-openstack/issues/1105