### PR TITLE
Updated Keystone token overrides in user_variables.yml

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -54,8 +54,8 @@ ssl_protocol: "ALL -SSLv2 -SSLv3"
 ssl_cipher_suite: "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
 
 # Keystone overrides
-keystone_token_provider: "keystone.token.providers.uuid.Provider"
-keystone_token_driver: "keystone.token.persistence.backends.sql.Token"
+keystone_token_provider: "uuid"
+keystone_token_driver: "sql"
 
 # Galera overrides
 galera_cluster_name: rpc_galera_cluster


### PR DESCRIPTION
This patch updates the keystone token overrides by changing keystone_token_provider
and keystone_token_driver in user_variables.yml to reflect the new entry point. 
This was done due to the fact that the direct of import keystone.token.providers.uuid.Provider for the token provider and keystone.token.persistence.backends.sql.Token for the token driver are deprecated
as of Liberty and may be removed in Newton.

Addresses #873