### PR TITLE
Alter pip behavior of horizon_extensions play

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
@@ -16,5 +16,5 @@
 horizon_extensions_git_repo: https://github.com/rcbops/horizon-extensions
 horizon_extensions_git_install_branch: master
 horizon_extensions_dest_dir: /opt/rackspace/horizon-extensions
-
-horizon_extensions_pip_requirements_file: "/opt/rackspace/horizon-extensions/requirements.txt"
+horizon_extensions_pip_packages:
+   - "markdown"

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -38,10 +38,19 @@
   become: true
   notify: Restart apache2
 
-- name: Install python dependencies
+- name: Install pip packages
   pip:
-    requirements: "{{ horizon_extensions_pip_requirements_file }}"
+    name: "{{ item }}"
+    state: present
     extra_args: "{{ pip_install_options | default('') }}"
+  register: install_pip_packages
+  until: install_pip_packages|success
+  retries: 5
+  delay: 2
+  with_items: horizon_extensions_pip_packages
+  tags:
+    - horizon-extensions-install
+    - horizon-extensions-pip-packages
 
 - name: "Create /etc/rackspace if it doesn't exist"
   file:


### PR DESCRIPTION
This fix alters the pip behavior of the `horizon_extensions` play to
bring it to liberty standards.  Since we are no longer running the
`repo-build` play from within the rpcd directory the existing
requirements file is no longer being used by the OSA `repo-build`
play.  This commit adds the `horizon_extensions_pip_packages` variable
to the defaults and uses the updated pip form for installation.

Closes-bug: #1100
(cherry picked from commit cc8f0a6fa878fbd1405f7ed45ef94a3a8bbb3f17)