### PR TITLE
fix holland backups

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_config.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_config.yml
@@ -13,35 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Create rpc_support backup user
-  mysql_user:
-    name: "{{ item.name }}"
-    host: "{{ item.host }}"
-    password: "{{ item.password }}"
-    priv: "{{ item.priv }}"
-    state: "{{ item.state }}"
-  with_items:
-    - name: "rpc_support"
-      host: "%"
-      password: "{{ rpc_support_holland_password }}"
-      priv: "*.*:ALL"
-      state: present
-    - name: "rpc_support"
-      host: "localhost"
-      password: "{{ rpc_support_holland_password }}"
-      priv: "*.*:ALL"
-      state: present
-  run_once: true
-  tags:
-    - holland_sql_user
-    - holland_all
-
 - name: Create supporting holland directories
   file:
     state: directory
     path: "{{ item }}"
   with_items:
     - "/var/backup/holland_backups"
+    - "/var/log/holland"
     - "/etc/holland"
   tags:
     - holland_dir

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_db_setup.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_db_setup.yml
@@ -1,0 +1,36 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create rpc_support backup user
+  mysql_user:
+    name: "{{ item.name }}"
+    host: "{{ item.host }}"
+    password: "{{ item.password }}"
+    priv: "{{ item.priv }}"
+    state: "{{ item.state }}"
+  with_items:
+    - name: "rpc_support"
+      host: "%"
+      password: "{{ rpc_support_holland_password }}"
+      priv: "*.*:ALL"
+      state: present
+    - name: "rpc_support"
+      host: "localhost"
+      password: "{{ rpc_support_holland_password }}"
+      priv: "*.*:ALL"
+      state: present
+  tags:
+    - holland_sql_user
+    - holland_all

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -67,6 +67,10 @@
   when: >
     inventory_hostname in groups['galera']
 
+- include: holland_db_setup.yml
+  when: >
+    inventory_hostname == groups['galera'][0]
+
 - include: holland_config.yml
   when: >
     inventory_hostname in groups['galera']

--- a/rpcd/playbooks/roles/rpc_support/templates/holland-xtrabackup.conf.j2
+++ b/rpcd/playbooks/roles/rpc_support/templates/holland-xtrabackup.conf.j2
@@ -21,9 +21,9 @@ estimated-size-factor = 1.0
 # of the plugin defined above.
 [xtrabackup]
 global-defaults = /etc/mysql/my.cnf
-# innobackupex =
+innobackupex = /usr/bin/innobackupex
 # ibbackup =
-# stream =
+stream = xbstream
 # apply-logs =
 # slave-info =
 # safe-slave-backup =

--- a/rpcd/playbooks/roles/rpc_support/templates/holland.conf.j2
+++ b/rpcd/playbooks/roles/rpc_support/templates/holland.conf.j2
@@ -20,7 +20,7 @@ path = /usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
 
 [logging]
 ## where to write the log
-filename = /var/log/backup/holland_backups/holland.log
+filename = /var/log/holland/holland.log
 
 ## debug, info, warning, error, critical (case insensitive)
 level = info


### PR DESCRIPTION
This commit fixes holland backups with a few modifications:

- The db grants for the backup user are moved into a separate task that is now
  properly called for the first host in the galera groups (run_once was causing the task
  to be skipped because of the way the host list was evaluated)
- The stream type is set explicitly to xbstream away from the default of tar
- The path to the innobackupex binary is explicitly set
- The log directory is now set and created properly

Partial Issue: #1121 
(cherry picked from commit 349a61b1e41f9a67e7887dbfa4572a94556a3f46)