### PR TITLE
Disable L3HA as default setting

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -127,3 +127,9 @@ repo_build_pip_extra_indexes:
 # variable to 'true'.
 # Docs: http://docs.openstack.org/developer/openstack-ansible-security/
 # apply_security_hardening: true
+
+# Based on https://bugs.launchpad.net/neutron/+bug/1591386
+# L3HA has to be disabled until all major issues are fixed
+neutron_neutron_conf_overrides:
+  DEFAULT:
+      l3_ha: False


### PR DESCRIPTION
Based on many open Neutron issues around L3HA RPC-O currently
disables L3HA until the known issues like
https://bugs.launchpad.net/neutron/+bug/1591386 are addressed by the
Neutron community.

The HA functionality will be still served by the neutron-ha-tool script.

Connects #1149