### PR TITLE
Report status for non @backend cinder services

### DIFF
--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -86,18 +86,25 @@ def check(auth_ref, args):
             if '@' in service['host']:
                 [host, backend] = service['host'].split('@')
                 name = '%s-%s_status' % (service['binary'], backend)
-                metric_bool(name, service_is_up)
+            else:
+                name = '%s_status' % service['binary']
 
-        name = '%s_status' % service['binary']
-        metric_bool(name, all_services_are_up)
+            metric_bool(name, service_is_up)
+
+        metric_bool('cinder-volume_status', all_services_are_up)
     else:
+        all_services_are_up = True
+
         for service in services:
             service_is_up = True
             if service['status'] == 'enabled' and service['state'] != 'up':
                 service_is_up = False
+                all_services_are_up = False
 
             name = '%s_on_host_%s' % (service['binary'], service['host'])
             metric_bool(name, service_is_up)
+
+        metric_bool('cinder-volume_status', all_services_are_up)
 
 
 def main(args):


### PR DESCRIPTION
This fix reports service states for cinder service names
for all services beyond cinder backends like LVM.
Additionally it adds a cinder-volume_status status check
in order to trigger a MAAS alarm since the alarm is only configured
to look at the cinder-volume_status service.

Connects #1098