### PR TITLE
Stick closer to OSA for horizon customisations

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -76,6 +76,7 @@ pkg_locations:
   - /etc/ansible/roles
   - /etc/openstack_deploy
   - /opt/rpc-openstack/rpcd
+  - /opt/rpc-openstack/rpcd/playbooks/roles
 
 # NOTE(mancdaz) there may be a better place to override this
 horizon_venv_tag: "{{ openstack_release }}"
@@ -104,3 +105,16 @@ neutron_ml2_conf_ini_overrides:
 neutron_l3_agent_ini_overrides:
   DEFAULT:
     handle_internal_only_routers: True
+
+# List of files to override using the OSA horizon role
+rackspace_static_files_folder: "/opt/rpc-openstack/rpcd/playbooks/roles/horizon_extensions/files"
+horizon_custom_uploads:
+  logo-splash:
+    src: "{{ rackspace_static_files_folder }}/logo-splash.png"
+    dest: img/logo-splash.png
+  logo:
+    src: "{{ rackspace_static_files_folder }}/logo.png"
+    dest: img/logo.png
+  favicon:
+    src: "{{ rackspace_static_files_folder }}/favicon.ico"
+    dest: img/favicon.ico

--- a/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 horizon_extensions_git_repo: https://github.com/rcbops/horizon-extensions
-horizon_extensions_git_install_branch: master
+horizon_extensions_git_install_branch: fb690bc528499bbf9aebba3ab0cce0b4dffd9e35
 horizon_extensions_dest_dir: /opt/rackspace/horizon-extensions
 horizon_extensions_pip_packages:
-   - "markdown"
+   - horizon_extensions

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -13,31 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: RPC branding for Horizon
-  copy:
-    src: "{{ item }}"
-    dest: "{{ horizon_lib_dir }}/openstack_dashboard/static/dashboard/img/{{ item }}"
-    mode: "0644"
-    owner: root
-    group: root
-  with_items:
-    - logo-splash.png
-    - logo.png
-    - favicon.ico
-
-- name: Clone Horizon Extensions repo
-  git:
-    repo: "{{ horizon_extensions_git_repo }}"
-    dest: "{{ horizon_extensions_dest_dir }}"
-    version: "{{ horizon_extensions_git_install_branch }}"
-
-- name: Install Horizon plugin
-  command: "python setup.py install"
-  args:
-    chdir: '{{ horizon_extensions_dest_dir }}'
-  become: true
-  notify: Restart apache2
-
 - name: Install pip packages
   pip:
     name: "{{ item }}"
@@ -47,7 +22,7 @@
   until: install_pip_packages|success
   retries: 5
   delay: 2
-  with_items: horizon_extensions_pip_packages
+  with_items: "{{ horizon_extensions_pip_packages }}"
   tags:
     - horizon-extensions-install
     - horizon-extensions-pip-packages
@@ -80,6 +55,7 @@
 - name: Collect and compress static files
   command: "{{ item }}"
   become: true
+  become_user: "{{ horizon_system_user_name }}"
   with_items:
     - "{{ horizon_venv_bin }}/horizon-manage.py collectstatic --noinput"
     - "{{ horizon_venv_bin }}/horizon-manage.py compress --force"


### PR DESCRIPTION
This commit leverages OSA work instead of reinventing the wheel in RPC.

- First, it uses the OSA branding
- Secondly, it uses the OSA repo-build process to build a horizon_extensions
pip package for installing Rackspace's horizon extensions.

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>