### PR TITLE
Fix horizon_extensions static folder permissions

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -80,6 +80,7 @@
 - name: Collect and compress static files
   command: "{{ item }}"
   become: true
+  become_user: "{{ horizon_system_user_name }}"
   with_items:
     - "{{ horizon_venv_bin }}/horizon-manage.py collectstatic --noinput"
     - "{{ horizon_venv_bin }}/horizon-manage.py compress --force"


### PR DESCRIPTION
When horizon-manage runs as root, the horizon-managed compressed files will end up
with root as owner in the static folder. 

This commit fixes a consistency issue: All the static files served by the webserver should be owned by the webserver, and not root. 

Issue: #1158 
Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>