### PR TITLE
Use OSA code for RPC branding

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -104,3 +104,15 @@ neutron_ml2_conf_ini_overrides:
 neutron_l3_agent_ini_overrides:
   DEFAULT:
     handle_internal_only_routers: True
+# List of files to override using the OSA horizon role
+rackspace_static_files_folder: "/opt/rpc-openstack/rpcd/playbooks/roles/horizon_extensions/files"
+horizon_custom_uploads:
+  logo-splash:
+    src: "{{ rackspace_static_files_folder }}/logo-splash.png"
+    dest: img/logo-splash.png
+  logo:
+    src: "{{ rackspace_static_files_folder }}/logo.png"
+    dest: img/logo.png
+  favicon:
+    src: "{{ rackspace_static_files_folder }}/favicon.ico"
+    dest: img/favicon.ico

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -13,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: RPC branding for Horizon
-  copy:
-    src: "{{ item }}"
-    dest: "{{ horizon_lib_dir }}/openstack_dashboard/static/dashboard/img/{{ item }}"
-    mode: "0644"
-    owner: root
-    group: root
-  with_items:
-    - logo-splash.png
-    - logo.png
-    - favicon.ico
-
 - name: Clone Horizon Extensions repo
   git:
     repo: "{{ horizon_extensions_git_repo }}"


### PR DESCRIPTION
This commit leverages OSA work instead of reinventing the wheel in RPC.
It uses OSA's os_horizon role "horizon_custom_uploads" variable for
determining which files to upload where.

Issue: https://github.com/rcbops/rpc-openstack/issues/1088
Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>