### PR TITLE
Use OSA code for building RPC horizon_extensions

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
@@ -17,4 +17,4 @@ horizon_extensions_git_repo: https://github.com/rcbops/horizon-extensions
 horizon_extensions_git_install_branch: master
 horizon_extensions_dest_dir: /opt/rackspace/horizon-extensions
 horizon_extensions_pip_packages:
-   - "markdown"
+   - horizon_extensions

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -13,19 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Clone Horizon Extensions repo
-  git:
-    repo: "{{ horizon_extensions_git_repo }}"
-    dest: "{{ horizon_extensions_dest_dir }}"
-    version: "{{ horizon_extensions_git_install_branch }}"
-
-- name: Install Horizon plugin
-  command: "python setup.py install"
-  args:
-    chdir: '{{ horizon_extensions_dest_dir }}'
-  become: true
-  notify: Restart apache2
-
 - name: Install pip packages
   pip:
     name: "{{ item }}"
@@ -35,7 +22,7 @@
   until: install_pip_packages|success
   retries: 5
   delay: 2
-  with_items: horizon_extensions_pip_packages
+  with_items: "{{ horizon_extensions_pip_packages }}"
   tags:
     - horizon-extensions-install
     - horizon-extensions-pip-packages


### PR DESCRIPTION
This commit leverages OSA work instead of reinventing the wheel in RPC.

It uses OSA's repo-build process: this fetches the source for horizon_extensions, 
and creates a wheel if the horizon_extensions pip package should be installed.
Here, the wheel is installed during RPC's horizon_extensions role.

No behavior was changed in the process: the wheel making still use master
branch of horizon-extensions repo, which should be moved to a sha in a later
commit for stable branches.

Issue: #1100
Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>