### PR TITLE
Ensure all hosts have a pip.conf

### DIFF
--- a/rpcd/playbooks/pip-lockdown.yml
+++ b/rpcd/playbooks/pip-lockdown.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The purpose here is to allow for the environment to update/build the
+# python wheel files from the CURRENT release, as set in the rpc_release
+# variable.
+- name: Clean up pip release files from previous versions
+  hosts: hosts:all_containers
+  user: root
+  gather_facts: False
+  tasks:
+    - name: remove pip release directory
+      file:
+        path: /root/.pip/links.d/
+        state: absent
+      tags:
+        - pip-link-cleanup
+
+- name: Place pip.conf on hosts
+  hosts: hosts
+  user: root
+  roles:
+    - { role: "pip_lock_down" }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -160,6 +160,11 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   # setup the hosts and build the basic containers
   run_ansible setup-hosts.yml
 
+  # ensure correct pip.conf
+  pushd ${RPCD_DIR}/playbooks/
+    run_ansible pip-lockdown.yml
+  popd
+
   if [[ "$DEPLOY_CEPH" == "yes" ]]; then
     pushd ${RPCD_DIR}/playbooks/
       run_ansible ceph-all.yml

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -45,6 +45,9 @@ openstack-ansible -i "localhost," patcher.yml
 # are not on the repo server
 ansible repo_container -a 'rm -rf /root/.pip'
 
+# ensure correct pip.conf
+openstack-ansible pip-lockdown.yml
+
 # Do the upgrade for openstack-ansible components
 cd ${OA_DIR}
 echo 'YES' | ${OA_DIR}/scripts/run-upgrade.sh


### PR DESCRIPTION
Previously we were relying on some other side effects to get a
pip.conf file to be put onto the hosts:

- compute hosts got it because of the nova role
- infra hosts sometimes got it because of beaver/other roles

This commit ensures that we explicitly install a pip.conf for
the version that we are deploying by adding a playbook to run
the pip-lockdown role. Additionally, we remove any lingering
link files from previous versions to ensure that pip.conf
contains only links for the new version being installed.

Connects #1124