### PR TITLE
Add cpu/mem multipliers to nova_cloud_stats plugin

### DIFF
--- a/maas/plugins/nova_cloud_stats.py
+++ b/maas/plugins/nova_cloud_stats.py
@@ -82,8 +82,13 @@ def check(auth_ref, args):
         stats = nova.hypervisor_stats.statistics()
         cloud_stats = collections.defaultdict(dict)
         for metric_name, vals in stats_mapping.iteritems():
+            multiplier = 1
+            if metric_name == 'total_vcpus':
+                multiplier = args.cpu_allocation_ratio
+            elif metric_name == 'total_memory':
+                multiplier = args.mem_allocation_ratio
             cloud_stats[metric_name]['value'] = \
-                getattr(stats, vals['stat_name'])
+                (getattr(stats, vals['stat_name']) * multiplier)
             cloud_stats[metric_name]['unit'] = \
                 vals['unit']
             cloud_stats[metric_name]['type'] = \
@@ -106,6 +111,20 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(
             description='Check Nova hypervisor stats')
+        parser.add_argument('--cpu',
+                            type=float,
+                            default=1.0,
+                            required=False,
+                            action='store',
+                            dest='cpu_allocation_ratio',
+                            help='cpu allocation ratio')
+        parser.add_argument('--mem',
+                            type=float,
+                            default=1.0,
+                            required=False,
+                            action='store',
+                            dest='mem_allocation_ratio',
+                            help='mem allocation ratio')
         parser.add_argument('ip', nargs='?',
                             type=ipaddr.IPv4Address,
                             help='Nova API IP address')

--- a/releasenotes/notes/nova-allocation-ratios-869b6d3cabbf914d.yaml
+++ b/releasenotes/notes/nova-allocation-ratios-869b6d3cabbf914d.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - Previously, the nova_cloud_stats maas plugin was
+    incorrectly reporting total cpu and total memory
+    amounts available across all hypervisors, as it was
+    not taking into account the allocation_ratios that
+    are set at the hypervisor level. Now, it attempts
+    to correctly scale those values by passing in a
+    multiplier based on the allocation ratios set in
+    the config

--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -79,6 +79,10 @@ maas_filesystem_critical_threshold: 90.0
 #    warning_threshold: 80.0
 #    critical_threshold: 90.0
 
+# overrides for the nova_cloud_stats  maas plugin
+cloud_resource_cpu_allocation_ratio: "{{ nova_cpu_allocation_ratio }}"
+cloud_resource_mem_allocation_ratio: "{{ nova_ram_allocation_ratio }}"
+
 # For an AIO it's recommended to set the following to limit the expected RAM
 # usage of elasticsearch.
 # elasticsearch_heap_size_mb: 1024

--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -35,6 +35,8 @@ nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 nova_db_max_overflow: 60
 nova_db_max_pool_size: 120
 nova_db_pool_timeout: 60
+nova_cpu_allocation_ratio: 2.0
+nova_ram_allocation_ratio: 1.0
 
 # Nova config overrides
 nova_cross_az_attach: False

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -301,6 +301,8 @@ cloud_resource_warning_vcpus: 80.0
 cloud_resource_critical_vcpus: 90.0
 cloud_resource_warning_disk_space: 80.0
 cloud_resource_critical_disk_space: 90.0
+cloud_resource_cpu_allocation_ratio: 2.0
+cloud_resource_mem_allocation_ratio: 1.0
 
 # List of checks, by type - variable:
 hp_checks_list:

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -5,7 +5,8 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : nova_cloud_stats.py
-    args    : ["{{ ansible_ssh_host }}"]
+    args    : ["--cpu", "{{ cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ cloud_resource_mem_allocation_ratio }}", "{{ ansible_ssh_host }}"]
+
 alarms      :
     nova_cloud_memory_status :
         label                   : nova_cloud_memory_status--{{ ansible_hostname }}


### PR DESCRIPTION
The nova API reports 'total_vcpus' as the total number of physical cores
available on the hypervisors that it can see. However, because of the
setting cpu_allocation_ratio it's possible to see more 'used_vcpus' than
'total_vcpus' (actual physical cores in the machines).

The same is true of memory and mem_allocation_ratio.

Whilst the nova API does not have the capability of factoring in the
*_allocation_ratios across all hypervisors when reporting 'total_*' numbers,
we can fake it by passing a multiplier to the plugin using numbers that match
the nova conf settings. The default for the plugin remains to use the real
numbers as reported by the nova API.

It's accepted that this does not cover the case where different hypervisors
may have different allocation ratios, but should cover 95% of use cases where
the allocation_ratios are the same across all hypervisors.

Connects #1107