### PR TITLE
Move user variables/secrets files to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ as well as adding a Rackspace tab and a Solutions tab, which provides
 Heat templates for commonly deployed applications.
 * `kibana.yml` - Setup Kibana on the Kibana hosts for the logging dashboard.
 * `logstash.yml` - deploys a logstash host. If this play is used, be sure to
-uncomment the related block in user_extra_variables.yml before this play is
-run and then rerun the appropriate plays in openstack-ansible after this
-play to ensure that rsyslog ships logs to logstash. See steps 11 - 13 below
-for more.
+copy the related block in user_rpco_variables_defaults.yml to
+user_rpco_variables_overrides before this play is run and then rerun the
+appropriate plays in openstack-ansible after this play to ensure that rsyslog
+ships logs to logstash. See steps 2-4 and 3-2 below for more.
 * `repo-build.yml` - scans throug the YAML files in the source tree and builds
 any packages or git sources into wheels and deploys them to the local repo
 server(s).
@@ -70,13 +70,14 @@ alarm configured for it.
 2. Unless doing an AIO build, prepare the openstack-ansible configuration.
   1. recursively copy the openstack-ansible-deployment configuration files:
      `cp -R openstack-ansible/etc/openstack_deploy /etc/openstack_deploy`
-  2. merge /etc/openstack_deploy/user_variables.yml with rpcd/etc/openstack_deploy/user_variables.yml:
+  2. move OSA variables to the correct locations.
 
      ```
-     scripts/update-yaml.py /etc/openstack_deploy/user_variables.yml rpcd/etc/openstack_deploy/user_variables.yml
+     rm /etc/openstack_deploy/user_variables.yml  # unused, nothing set
+     mv /etc/openstack_deploy/user_secrets.yml /etc/openstack_deploy/user_osa_secrets.yml
      ```
   3. copy the RPC configuration files:
-     1. `cp rpcd/etc/openstack_deploy/user_extras_*.yml /etc/openstack_deploy`
+     1. `cp rpcd/etc/openstack_deploy/user_*_defaults.yml /etc/openstack_deploy`
      2. `cp rpcd/etc/openstack_deploy/env.d/* /etc/openstack_deploy/env.d`
   4. If the ELK stack is not going to be used, remove the container
      configurations from the environment:
@@ -90,7 +91,8 @@ alarm configured for it.
   1. If building AIO, set `DEPLOY_AIO=yes` before running
   2. If building without the ELK stack, set `DEPLOY_ELK=no` before running
 4. If you want MaaS working with AIO, do the following:
-  1. edit `/etc/openstack_deploy/user_extras_variables.yml` to add credentials
+  1. edit `/etc/openstack_deploy/user_rpco_variables_overrides.yml` to add
+     credentials
   2. run the MaaS setup plays:
      `cd /opt/rpc-openstack/rpcd/playbooks && openstack-ansible setup-maas.yml`
   3. run the MaaS verify play:

--- a/releasenotes/notes/master-96b4f6d34b87fe3d.yaml
+++ b/releasenotes/notes/master-96b4f6d34b87fe3d.yaml
@@ -1,0 +1,21 @@
+---
+features:
+  - Variables and secrets are now managed in a manner that
+    allows downstream deployers to not have to worry about
+    their settings being overwritten.  They are provided
+    with overrides files that they alone manage after we
+    lay them down.  We have also taken this time to rename
+    our user_* files to separate out what specifically the
+    variables override, whether it be upstream splitting
+    the OSA relevant changed of the local RPC-O changes or
+    local RPCO changes.
+deprecations:
+  - We are deprecating the use of user_variables and
+    user_secrets files other than the ones found below.
+
+    user_osa_secrets.yml
+    user_osa_variables_defaults.yml
+    user_osa_variables_overrides.yml
+    user_rpco_secrets.yml
+    user_rpco_variables_defaults.yml
+    user_rpco_variables_overrides.yml

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2015, Rackspace US, Inc.
+# Copyright 2016, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+## Warning
+#
+# This file is controlled by the devs and will be overwritten on upgrade
+# If you wish to override the variables set here, use /etc/openstack_deploy/user_osa_variables_overrides.yml
 
 # SQLAlchemy/Olso Thread Pool Settings
 rpc_conn_pool_size: 180
@@ -122,3 +127,11 @@ horizon_custom_uploads:
 # Use RPC python package index
 repo_build_pip_extra_indexes:
   - "https://rpc-repo.rackspace.com/pools"
+
+## Host security hardening
+# The openstack-ansible-security role provides security hardening for hosts
+# by applying security configurations from the STIG. Hardening is disabled by
+# default, but an option to opt-in is available by setting the following
+# variable to 'true'.
+# Docs: http://docs.openstack.org/developer/openstack-ansible-security/
+# apply_security_hardening: true

--- a/rpcd/etc/openstack_deploy/user_osa_variables_overrides.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_overrides.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2016, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
-maas_rabbitmq_password:
-fsid_uuid:
+## Using this file
+#
+# This file is laid down only once and is used for overriding variables based on the file name.
+# This file will not be overwritten by upgrades.
+
+# this variable is here because vars files need to have at least ONE variable defined.
+this_file_is_reserved_for_support: True

--- a/rpcd/etc/openstack_deploy/user_rpco_secrets.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_secrets.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maas_keystone_password:
+rpc_support_holland_password:
+kibana_password:
+maas_rabbitmq_password:
+fsid_uuid:

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2016, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+## Warning
+#
+# This file is controlled by the devs and will be overwritten on upgrade
+# If you wish to override the variables set here, use /etc/openstack_deploy/user_rpco_variables_overrides.yml
 
 ## Rackspace Cloud Details
 rackspace_cloud_auth_url: https://identity.api.rackspacecloud.com/v2.0

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_overrides.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_overrides.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Using this file
+#
+# This file is laid down only once and is used for overriding variables based on the file name.
+# This file will not be overwritten by upgrades.
+
+# this variable is here because vars files need to have at least ONE variable defined.
+this_file_is_reserved_for_support: True


### PR DESCRIPTION
Here we use a new filestructure so that deployers and devs will
not step on eachother's feet when changing variables around.  The
new user variables file layout looks like this.

```
user_osa_secrets.yml
user_osa_variables_defaults.yml
user_osa_variables_overrides.yml
user_rpco_secrets.yml
user_rpco_variables_defaults.yml
user_rpco_variables_overrides.yml
```

This patch does the following

1. Combine rpcd/etc/openstack_deploy/user_extras_variables.yml and
   rpcd/etc/openstack_deploy/user_variables.yml into a new file
   named rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml.
2. Delete rpcd/etc/openstack_deploy/user_extras_variables.yml and
   rpcd/etc/openstack_deploy/user_variables.yml
3. Rename (move) rpcd/etc/openstack_deploy/user_extras_secrets.yml
   to rpcd/etc/openstack_deploy/user_rpco_secrets.yml.
4. Update install script to move OSA user/secrets files to the
   correct location.

Connects https://github.com/rcbops/u-suk-dev/issues/185