### PR TITLE
Adds iptables checksum fix for port 8000

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -179,6 +179,8 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   if [ "${DEPLOY_AIO}" == "yes" ]; then
     ansible neutron_agent -m command \
                           -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
+    ansible neutron_agent -m command \
+                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 8000 -j CHECKSUM --checksum-fill'
     ansible neutron_agent -m shell \
                           -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
   fi


### PR DESCRIPTION
Port 8000 is the heat metadata url that some heat
resources use for running heat-related hooks inside
an instance. Without this rule communication between
the instance and the service will fail.

Connects #1167