### PR TITLE
increase maas plugin metric limit to 50

### DIFF
--- a/maas/plugins/maas_common.py
+++ b/maas/plugins/maas_common.py
@@ -531,8 +531,8 @@ METRICS = []
 
 def metric(name, metric_type, value, unit=None):
     global METRICS
-    if len(METRICS) > 29:
-        status_err('Maximum of 30 metrics per check')
+    if len(METRICS) > 49:
+        status_err('Maximum of 50 metrics per check')
     metric_line = 'metric %s %s %s' % (name, metric_type, value)
     if unit is not None:
         metric_line = ' '.join((metric_line, unit))

--- a/releasenotes/notes/maas-metric-limit-increase-fc17cbec85a7952c.yaml
+++ b/releasenotes/notes/maas-metric-limit-increase-fc17cbec85a7952c.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - The number of metrics that maas plugins can emit has
+    been increased from 30 to 50, in line with new
+    limits in the maas API.


### PR DESCRIPTION
The maas team have increased the global limit of metrics allowed per
maas agent plugin from 30 to 50. This commit increases the artificial
limit in maas_common to match.

reference: https://developer.rackspace.com/docs/rackspace-monitoring/v1/developer-guide/#id76

Connects #1180