### PR TITLE
Make ansible playbook runs unbuffered

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,7 @@
 set -e -u -x
 set -o pipefail
 
+export PYTHONUNBUFFERED=1
 export ADMIN_PASSWORD=${ADMIN_PASSWORD:-"secrete"}
 export DEPLOY_AIO=${DEPLOY_AIO:-"no"}
 export DEPLOY_HAPROXY=${DEPLOY_HAPROXY:-"no"}


### PR DESCRIPTION
This makes sure the content of the ansible runs are directly
sent to stdout, instead of waiting the end of the playbook.

The need appeared when debugging verify-maas playbook, which can
take a while, and didn't output anything (because jenkins job
timed out before the end of the run).