### PR TITLE
Accept cinder's HTTP 300 return code

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
@@ -17,6 +17,6 @@ alarms            :
         label               : lb_api_alarm_cinder
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric['code'] != '200') {
+            if (metric['code'] != '200' && metric['code'] != '300') {
                 return new AlarmStatus(CRITICAL, 'API unavailable.');
             }


### PR DESCRIPTION
According to [1], we should accept 300 as a normal return code for
cinder checks. This commit adds this support.

[1]: http://developer.openstack.org/api-ref-blockstorage-v2.html

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>