### PR TITLE
Add bashate linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 before_script:
 - pip install tox
-- pip2 install --force-reinstall 'ansible===1.9.4'
-- ansible-galaxy install --role-file=ansible-role-requirements.yml --force --roles-path=/home/travis/build/rcbops/rpc-openstack/rpcd/playbooks/roles
 
 script: tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
       env: TOXENV=ansible-lint
     - python: 2.7
       env: TOXENV=releasenotes
+    - python: 2.7
+      env: TOXENV=bashate
 
 sudo: false

--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -14,32 +14,29 @@ timeout = 120
 # inventory script - new config setting for ansible v1.9 and above
 inventory = ../../openstack-ansible/playbooks/inventory/
 
-# Set the path to the folder in openstack-ansible which holds the dynamic
-# inventory script - uncomment if using ansible below v1.9
-#hostfile = ../../openstack-ansible/playbooks/inventory/
-
-# Set the path to the folder in openstack-ansible which holds the
-# libraries required
-library = ../../openstack-ansible/playbooks/library/
+# TODO(evrardjp - Newton) This library folder will be moved in Newton to
+# /etc/ansible/roles/plugins/ . This config change won't be needed anymore.
+library = /etc/ansible/plugins/library
 
 # Set the path to the folder in openstack-ansible which holds the roles
 # that are depended on by the rpc-openstack roles
 roles_path = ../../openstack-ansible/playbooks/roles/:/etc/ansible/roles/
 
-# Set the path to the folder in openstack-ansible which holds the
-# lookup plugins required
-lookup_plugins = ../../openstack-ansible/playbooks/plugins/lookups/
+# TODO(evrardjp - Newton) This lookup folder will be moved in Newton to
+# /etc/ansible/roles/plugins/ . This config change won't be needed anymore.
+lookup_plugins = /etc/ansible/plugins/lookup
 
-# Set the path to the folder in openstack-ansible which holds the filter
-# plugins required
-filter_plugins = ../../openstack-ansible/playbooks/plugins/filters/
+# TODO(evrardjp - Newton) This filter folder will be moved in Newton to
+# /etc/ansible/roles/plugins/ . This config change won't be needed anymore.
+filter_plugins = /etc/ansible/plugins/filter
 
-# Set the path to the folder in openstack-ansible which holds the action
-# plugins required
-action_plugins = ../../openstack-ansible/playbooks/plugins/actions/
+# TODO(evrardjp - Newton) This action folder will be moved in Newton to
+# /etc/ansible/roles/plugins/ . This config change won't be needed anymore.
+action_plugins = /etc/ansible/plugins/action
 
-# Enable playbook callbacks from OSA to display playbook statistics
-callback_plugins = ../../openstack-ansible/playbooks/plugins/callbacks
+# TODO(evrardjp - Newton) This callback folder will be moved in Newton to
+# /etc/ansible/roles/plugins/ . This config change won't be needed anymore.
+callback_plugins = /etc/ansible/plugins/callback
 
 [ssh_connection]
 pipelining = True

--- a/rpcd/playbooks/horizon_extensions.yml
+++ b/rpcd/playbooks/horizon_extensions.yml
@@ -17,6 +17,8 @@
   user: root
   roles:
     - horizon_extensions
+  vars:
+    roles_folder: "/etc/ansible/roles"
   vars_files:
     #- group_vars/all.yml
-    - "{{ rpc_repo_path }}/playbooks/roles/os_horizon/defaults/main.yml"
+    - "{{ roles_folder }}/os_horizon/defaults/main.yml"

--- a/rpcd/playbooks/roles/beaver/defaults/main.yml
+++ b/rpcd/playbooks/roles/beaver/defaults/main.yml
@@ -15,7 +15,7 @@
 
 # the pip packages to install
 beaver_pip_packages:
-  - "beaver==33.3.0"
+  - "beaver==36.2.0"
 
 # the beaver daemon settings
 beaver_daemon_log: "/var/log/beaver/beaver.log"

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install pip packages
+- name: Install pip packages (venv)
   pip:
     name: "{{ item }}"
     state: present
     extra_args: "{{ pip_install_options | default('') }}"
+    virtualenv: "{{ horizon_venv_bin | dirname }}"
+    virtualenv_site_packages: "no"
   register: install_pip_packages
   until: install_pip_packages|success
   retries: 5
   delay: 2
   with_items: "{{ horizon_extensions_pip_packages }}"
+  when:
+    horizon_venv_enabled | bool
   tags:
     - horizon-extensions-install
     - horizon-extensions-pip-packages

--- a/rpcd/playbooks/roles/rpc_maas/tasks/keystone_user.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/keystone_user.yml
@@ -19,17 +19,23 @@
 - name: Create keystone user for monitoring
   keystone:
     command: "ensure_user"
-    token: "{{ keystone_auth_admin_token }}"
     endpoint: "{{ keystone_service_adminurl }}"
+    login_user: "{{ keystone_admin_user_name }}"
+    login_password: "{{ keystone_auth_admin_password }}"
+    login_project_name: "{{ keystone_admin_tenant_name }}"
     user_name: "{{ maas_keystone_user }}"
     tenant_name: "{{ keystone_admin_tenant_name }}"
     password: "{{ maas_keystone_password }}"
+    insecure: "{{ keystone_service_adminuri_insecure }}"
 
 - name: Add monitoring keystone user to admin role
   keystone:
     command: "ensure_user_role"
-    token: "{{ keystone_auth_admin_token }}"
     endpoint: "{{ keystone_service_adminurl }}"
+    login_user: "{{ keystone_admin_user_name }}"
+    login_password: "{{ keystone_auth_admin_password }}"
+    login_project_name: "{{ keystone_admin_tenant_name }}"
     user_name: "{{ maas_keystone_user }}"
     tenant_name: "{{ keystone_admin_tenant_name }}"
     role_name: "admin"
+    insecure: "{{ keystone_service_adminuri_insecure }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
@@ -17,6 +17,6 @@ alarms            :
         label               : lb_api_alarm_cinder
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric['code'] != '200') {
+            if (metric['code'] != '200' && metric['code'] != '300') {
                 return new AlarmStatus(CRITICAL, 'API unavailable.');
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -5,7 +5,7 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : rabbitmq_status.py
-    args    : ["-H", "{{ ansible_ssh_host }}", "-n", "{{ inventory_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]
+    args    : ["-H", "{{ ansible_ssh_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]
 alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -27,7 +27,7 @@
       failed_when: verify_maas.rc != 0
       changed_when: False
       until: verify_maas.rc == 0
-      retries: 10
+      retries: 8
       delay: 60
 
     - name: "Allow MAAS time to run checks before verifying their status"
@@ -42,7 +42,7 @@
       failed_when: verify_status.rc != 0
       changed_when: False
       until: verify_status.rc == 0
-      retries: 10
+      retries: 8
       delay: 60
 
   vars_files:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -96,6 +96,9 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
     fi
     # set the ansible inventory hostname to the host's name
     sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
+    # set the affinity to 3 for infra cluster (necessary for maas testing)
+    sed -i "s/rabbit_mq_container: 1/rabbit_mq_container: 3/" /etc/openstack_deploy/openstack_user_config.yml
+    sed -i "s/galera_container: 1/galera_container: 3/" /etc/openstack_deploy/openstack_user_config.yml
     sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
   fi
   # remove swift config if not deploying swift.

--- a/scripts/linting-ansible.sh
+++ b/scripts/linting-ansible.sh
@@ -24,14 +24,14 @@ fi
 pushd rpcd/playbooks/
   echo "Running ansible-playbook syntax check"
   # Do a basic syntax check on all playbooks and roles.
-  ansible-playbook -i 'localhost,' --syntax-check *.yml --list-tasks
+  ansible-playbook -i 'localhost,' --syntax-check *.yml --list-tasks -e "roles_folder=~/.ansible/roles"
   # Perform a lint check on all playbooks and roles.
   ansible-lint --version
   echo "Running ansible-lint"
   # Lint playbooks and roles while skipping the ceph-* roles. They are not
   # ours and so we do not wish to lint them and receive errors about code we
   # do not maintain.
-  ansible-lint *.yml --exclude roles/ceph.ceph-common \
-                     --exclude roles/ceph.ceph-mon \
-                     --exclude roles/ceph.ceph-osd
+  ansible-lint *.yml --exclude ~/.ansible/roles/ceph.ceph-common \
+                     --exclude ~/.ansible/roles/ceph.ceph-mon \
+                     --exclude ~/.ansible/roles/ceph.ceph-osd
 popd

--- a/scripts/linting-bashate.sh
+++ b/scripts/linting-bashate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -euo pipefail
+
+## Main ----------------------------------------------------------------------
+if [[ -z "$VIRTUAL_ENV" ]] ; then
+    echo "WARNING: Not running hacking inside a virtual environment."
+fi
+
+echo "Running scripts syntax check"
+
+# Run bashate check for all bash scripts
+# Ignores the following rules based on OSA:
+#     E003: Indent not multiple of 4 (we prefer to use multiples of 2)
+#     E006: Line longer than 79 columns (as many scripts use jinja
+#           templating, this is very difficult)
+#     E040: Syntax error determined using `bash -n` (as many scripts
+#           use jinja templating, this will often fail and the syntax
+#           error will be discovered in execution anyway)
+
+bashate $(grep -rln '^.!.*\(ba\)\?sh$' *) \
+    --verbose --ignore=E003,E006,E040
+

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,20 @@ envlist = flake8,ansible-lint,docs,releasenotes
 [testenv]
 passenv = ANSIBLE_VERSION
 basepython = python2.7
+whitelist_externals =
+    bash
+    sed
 deps =
     -rtest-requirements.txt
-    ansible{env:ANSIBLE_VERSION:>=1.9.1,<2.0.0}
+    ansible{env:ANSIBLE_VERSION:>=1.9.1,<1.9.5}
     -e./hacking
+setenv =
+    ANSIBLE_ACTION_PLUGINS = {homedir}/.ansible/roles/plugins/action
+    ANSIBLE_CALLBACK_PLUGINS = {homedir}/.ansible/roles/plugins/callback
+    ANSIBLE_FILTER_PLUGINS = {homedir}/.ansible/roles/plugins/filter
+    ANSIBLE_LOOKUP_PLUGINS = {homedir}/.ansible/roles/plugins/lookup
+    ANSIBLE_LIBRARY = {homedir}/.ansible/roles/plugins/library
+    ANSIBLE_ROLES_PATH = {homedir}/.ansible/roles:{toxinidir}/rcpd/playbooks/roles:{toxinidir}/openstack-ansible/playbooks/roles
 
 
 [testenv:releasenotes]
@@ -30,7 +40,10 @@ commands =
 
 [testenv:ansible-lint]
 commands =
-    {toxinidir}/scripts/linting-ansible.sh
+    bash -c "sed '/etc\/ansible/d' {toxinidir}/openstack-ansible/ansible-role-requirements.yml | tee -a {homedir}/openstack-ansible-role-requirements.yml; \
+        ansible-galaxy install -r {toxinidir}/ansible-role-requirements.yml; \
+        ansible-galaxy install -r {homedir}/openstack-ansible-role-requirements.yml; \
+        {toxinidir}/scripts/linting-ansible.sh"
 
 [flake8]
 # Ignores the following rules due to how ansible modules work in general

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = flake8,ansible-lint,docs,releasenotes
+envlist = flake8,ansible-lint,bashate,docs,releasenotes
 
 [testenv]
 passenv = ANSIBLE_VERSION
@@ -33,6 +33,10 @@ commands=
 [testenv:venv]
 deps = -r{toxinidir}/test-requirements.txt
 commands = {posargs}
+
+[testenv:bashate]
+commands = 
+    {toxinidir}/scripts/linting-bashate.sh
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
This commit adds the linting-bashate.sh script which is used to do
syntax checks on our scripts. Some important pieces of code are
scripts and previously our linting only checked YAML and Python
files. Upstream Openstack-Ansible also already includes bashate.

The linting-bashate.sh script itself searches recursively through
our files and runs bashate on files that have a (ba)sh shebang at
the top of the file. The script ignores the same bashate errors as
upstream OSA. The tox.ini was modified in order to add the
bashate script to the list of tests run. The .travis.yml file was
modified in order to add the bashate tox enviroment.

Connects #454