### PR TITLE
Fix bash linting errors

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -99,8 +99,7 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
     sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
   fi
   # remove swift config if not deploying swift.
-  if [[ "$DEPLOY_SWIFT" != "yes" ]]
-  then
+  if [[ "$DEPLOY_SWIFT" != "yes" ]]; then
     rm /etc/openstack_deploy/conf.d/swift.yml
   fi
   rm -f /etc/openstack_deploy/conf.d/aodh.yml
@@ -109,8 +108,7 @@ fi
 
 # Apply host security hardening with openstack-ansible-security
 # The is applied as part of setup-hosts.yml
-if [[ "$DEPLOY_HARDENING" == "yes" ]]
-then
+if [[ "$DEPLOY_HARDENING" == "yes" ]]; then
   if grep -q '^apply_security_hardening:' /etc/openstack_deploy/user_variables.yml
   then
     sed -i "s/^apply_security_hardening:.*/apply_security_hardening: true/" /etc/openstack_deploy/user_variables.yml

--- a/scripts/f5-monitor.sh
+++ b/scripts/f5-monitor.sh
@@ -39,8 +39,7 @@ EOF
     )
 
     # Exit if status is 401 (invalid username/pass)
-    if [[ "${resp[@]:(-1)}" == "401" ]]
-    then
+    if [[ "${resp[@]:(-1)}" == "401" ]]; then
         echo "Exiting after failure to get a valid token: Check user/pass."
         printf "%s\n" "${resp[@]}"
         exit -1
@@ -62,8 +61,7 @@ EOF
 # Read token from file or get new one
 get_token() {
     # If file exists
-    if [[ -f /var/tmp/keystone-token ]]
-    then
+    if [[ -f /var/tmp/keystone-token ]]; then
         # Read into token variable
         read -r token < /var/tmp/keystone-token
     else
@@ -129,19 +127,16 @@ get_token() {
 
       # Check if we've got an expected status code
       for status_code in $expected_statuses; do
-          if [[ "$status" == "$status_code" ]]
-          then
+          if [[ "$status" == "$status_code" ]]; then
               echo "Success" >&3
               exit 0
           fi
       done
 
       # Check for 401 (token expiration or unauthorized)
-      if [[ "$status" == "401" ]]
-      then
+      if [[ "$status" == "401" ]]; then
           # Exit if token is new
-          if [[ "$token_new" == "1" ]]
-          then
+          if [[ "$token_new" == "1" ]]; then
               echo "Exiting after failure to authorize with valid token $token on $check_url"
               printf "%s\n" "${resp[@]}"
               exit -1


### PR DESCRIPTION
This commit fixes errors that came up when running the new bashate
linting test script. The errors fixed were simple syntax fixes in
the deploy.sh and f5-monitor.sh files. This needs to be merged
in order for the bashate linting script to pass the Travis CI
build gating tests.

addresses pull request #1189