### PR TITLE
Add bashate linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
       env: TOXENV=ansible-lint
     - python: 2.7
       env: TOXENV=releasenotes
+    - python: 2.7
+      env: TOXENV=bashate
 
 sudo: false

--- a/scripts/linting-bashate.sh
+++ b/scripts/linting-bashate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -euo pipefail
+
+## Main ----------------------------------------------------------------------
+if [[ -z "$VIRTUAL_ENV" ]] ; then
+    echo "WARNING: Not running hacking inside a virtual environment."
+fi
+
+echo "Running scripts syntax check"
+
+# Run bashate check for all bash scripts
+# Ignores the following rules based on OSA:
+#     E003: Indent not multiple of 4 (we prefer to use multiples of 2)
+#     E006: Line longer than 79 columns (as many scripts use jinja
+#           templating, this is very difficult)
+#     E040: Syntax error determined using `bash -n` (as many scripts
+#           use jinja templating, this will often fail and the syntax
+#           error will be discovered in execution anyway)
+
+bashate $(grep -rln '^.!.*\(ba\)\?sh$' *) \
+    --verbose --ignore=E003,E006,E040

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = flake8,ansible-lint,docs,releasenotes
+envlist = flake8,ansible-lint,bashate,docs,releasenotes
 
 [testenv]
 passenv = ANSIBLE_VERSION
@@ -37,6 +37,10 @@ commands = {posargs}
 [testenv:flake8]
 commands =
     {toxinidir}/scripts/linting-pep8.sh
+
+[testenv:bashate]
+commands = 
+    {toxinidir}/scripts/linting-bashate.sh
 
 [testenv:ansible-lint]
 commands =


### PR DESCRIPTION
This commit adds the linting-bashate.sh script which is used to do
syntax checks on our scripts. Some important pieces of code are
scripts and previously our linting only checked YAML and Python
files. Upstream Openstack-Ansible also already includes bashate.

The linting-bashate.sh script itself searches recursively through
our files and runs bashate on files that have a (ba)sh shebang at
the top of the file. The script ignores the same bashate errors as
upstream OSA. The tox.ini was modified in order to add the
bashate script to the list of tests run. The .travis.yml file was
modified in order to add the bashate tox enviroment.

Addresses #454