### PR TITLE
Enable handle_internal_only_routers by default

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -94,7 +94,13 @@ neutron_neutron_conf_overrides:
   nova:
     endpoint_type: internal
 
-# Diasble port security binding for liberty. See https://bugs.launchpad.net/neutron/+bug/1509312
+# Disable port security binding for liberty. See https://bugs.launchpad.net/neutron/+bug/1509312
 neutron_ml2_conf_ini_overrides:
     ml2:
         extension_drivers: ''
+
+# Enable handle_internal_only_routers based on expected behavior since Juno
+# See https://bugs.launchpad.net/openstack-ansible/+bug/1577868
+neutron_l3_agent_ini_overrides:
+  DEFAULT:
+    handle_internal_only_routers: True


### PR DESCRIPTION
The default value for handle_internal_only_routers changed from True to
False in OSA upstream, causing a unexpected behavior.
RPC-O enables handle_internal_only_routers in order allow Neutron
router without having to attach external networks. This is a valid
customer use case.

Connects #1046
(cherry picked from commit ed72b32f913ff42b0b740b87ac4b0da8e149c92f)