### PR TITLE
Use rpc python package index

### DIFF
--- a/releasenotes/notes/rpc_package_index-a03d4d131c16d710.yaml
+++ b/releasenotes/notes/rpc_package_index-a03d4d131c16d710.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - A new user variable (list type) named
+    ``repo_build_pip_extra_indexes`` was introduced
+    to fetch pip packages from rpc repository.

--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -116,3 +116,7 @@ horizon_custom_uploads:
   favicon:
     src: "{{ rackspace_static_files_folder }}/favicon.ico"
     dest: img/favicon.ico
+
+# Use RPC python package index
+repo_build_pip_extra_indexes:
+  - "https://rpc-repo.rackspace.com/pools"


### PR DESCRIPTION
This adds rpc specific package index on top of pypi.
The bump of OSA to mitaka changed the way to use PyPI, and the variable
we should use from now on is ```repo_build_pip_extra_indexes```.

Connects rcbops/u-suk-dev#171

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>