### PR TITLE
Force the maas_rabbitmq_password to set up in RabbitMQ

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/rabbitmq_user.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/rabbitmq_user.yml
@@ -23,6 +23,7 @@
     write_priv: ".*"
     tags: "administrator"
     state: "present"
+    force: "yes"
   tags:
     - rabbitmq-user
 


### PR DESCRIPTION
This change allows for the rabbitmq_user.yml file to force and
grab the correct password from user_extras_secret.yml file. This
was done to ensure that RabbitMQ can authenticate properly.

Connects #1147