### PR TITLE
Add virtual environment for MaaS plugins

### DIFF
--- a/releasenotes/notes/maas-plugins-venv-4a195e0b0271bf29.yaml
+++ b/releasenotes/notes/maas-plugins-venv-4a195e0b0271bf29.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - Deployers need to be aware of upgrading from a
+    system that isn't running the maas plugins inside
+    of a virtualenv. They need to decide if they want
+    the maas plugins to continue to run on the global
+    environment or a virtual environment.
+fixes:
+  - MaaS Plugins now run inside their own virtual
+    environment

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -448,3 +448,9 @@ maas_excluded_checks: []
 # This is necessary until LP #1537117 is implemented
 openrc_os_endpoint_type: internalURL
 openrc_insecure: "{{ (keystone_service_adminuri_insecure | bool or keystone_service_internaluri_insecure | bool) | default(false) }}"
+# Name of the virtual env to deploy into (maas)
+maas_venv: "/openstack/venvs/maas-{{ rpc_release }}"
+maas_venv_bin: "{{ maas_venv }}/bin"
+# Set this to enable or disable installing in a venv
+maas_venv_enabled: true
+

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -21,9 +21,20 @@
     cache_valid_time: 600
   with_items: maas_apt_packages
 
-- name: Install pip packages
+- name: Update pip
+  pip:
+    name: pip
+    state: latest
+    virtualenv: "{{ maas_venv_enabled | bool | ternary(maas_venv, omit) }}"
+
+- name: Install pip packages to venv
   pip:
     name: "{{ item }}"
-    state: latest
+    state: present
     extra_args: "{{ pip_install_options | default('') }}"
+    virtualenv: "{{ maas_venv_enabled | bool | ternary(maas_venv, omit) }}"
+  register: install_pip_packages
+  until: install_pip_packages|success
+  retries: 5
+  delay: 2
   with_items: maas_pip_packages + maas_pip_dependencies

--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -20,6 +20,15 @@
   synchronize:
     src={{ maas_plugin_dir }} dest=/usr/lib/rackspace-monitoring-agent/plugins/ delete=yes
 
+- name: Drop in wrapper script to run maas plugins in venv
+  template:
+    src: "run_plugin_in_venv.sh.j2"
+    dest: "/usr/lib/rackspace-monitoring-agent/plugins/run_plugin_in_venv.sh"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  when: maas_venv_enabled
+
 - name: List plugin files to chmod
   shell: "ls -1 /usr/lib/rackspace-monitoring-agent/plugins/*.py"
   register: plugin_files
@@ -39,12 +48,20 @@
     mode: "0600"
 
 - name: Verify raxmon-entities-list and MaaS API authentication does not fail
-  command: "raxmon-entities-list"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-entities-list
   register: raxmon_output
   failed_when: raxmon_output.rc != 0
 
 - name: Entity {{ entity_name }} count
-  shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l
   register: entity_count
 
 - name: Zero entities with label {{ entity_name }} exist
@@ -58,14 +75,26 @@
   when: entity_count.stdout|int != 1
 
 - name: Get entity {{ entity_name }}
-  shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | awk '{print $2}' | cut -d= -f2"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | awk '{print $2}' | cut -d= -f2
   register: entity
 
 - name: Assign agent ID to entity
-  shell: "raxmon-entities-update --id {{ entity.stdout }} --agent-id {{ entity_name }}"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-entities-update --id {{ entity.stdout }} --agent-id {{ entity_name }}
 
 - name: Agent token {{ entity_name }} count
-  shell: "raxmon-agent-tokens-list | grep ' label={{ entity_name }}, ' | wc -l"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-agent-tokens-list | grep ' label={{ entity_name }}, ' | wc -l
   register: agent_token_count
   when: maas_agent_token is not defined
 
@@ -75,12 +104,20 @@
   when: maas_agent_token is not defined and agent_token_count.stdout|int > 1
 
 - name: Create agent token
-  shell: "raxmon-agent-tokens-create --label={{ entity_name }}"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-agent-tokens-create --label={{ entity_name }}
   register: agent_token
   when: maas_agent_token is not defined and agent_token_count.stdout|int == 0
 
 - name: Get agent token
-  shell: "raxmon-agent-tokens-list | grep '<AgentToken: id=.* label={{ entity_name }}, .*>' | awk '{print $2}' | sed -e 's/id=\\(.*\\),/\\1/g'"
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-agent-tokens-list | grep '<AgentToken: id=.* label={{ entity_name }}, .*>' | awk '{print $2}' | sed -e 's/id=\(.*\),/\1/g'
   register: maas_agent_token_id
   when: maas_agent_token is not defined
 

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : ceph_monitoring.py
-    args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "cluster"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "cluster"]
 alarms      :
     ceph_health_err :
         label                   : ceph_health_err--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : ceph_monitoring.py
-    args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "mon", "--host", "{{ ansible_hostname }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "mon", "--host", "{{ ansible_hostname }}"]
 alarms      :
     mon_health_err :
         label                   : mon_health_err--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : ceph_monitoring.py
-    args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') }}"]
 alarms      :
 {% for osd_id in ceph_osd_host['osd_ids'] %}
     ceph_warn_osd.{{ osd_id }} :

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : cinder_api_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}cinder_api_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     cinder_api_local_status :
         label                   : cinder_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : cinder_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_scheduler_status :
         label                   : cinder_scheduler_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : vg_check.py
-    args    : ["{{ item.cinder_vg_name }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}vg_check.py", "{{ item.cinder_vg_name }}"]
 alarms      :
     cinder_vg_space_status :
         label                   : cinder_vg_space_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : cinder_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_volume_status :
         label                   : cinder_volume_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : conntrack_count.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}conntrack_count.py", "{{ ansible_ssh_host }}"]
 alarms      :
     conntrack_count_status :
         label                   : conntrack_count_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : disk_utilisation.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}disk_utilisation.py", "{{ ansible_ssh_host }}"]
 alarms      :
 {% for device in disk_util_devices %}
     percentage_disk_utilisation_{{ device }}:

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : galera_check.py
-    args    : ["-H", "{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}galera_check.py", "-H", "{{ ansible_ssh_host }}"]
 alarms      :
     wsrep_cluster_size :
         label                   : wsrep_cluster_size--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : glance_api_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}glance_api_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     glance_api_local_status :
         label                   : glance_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : glance_registry_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}glance_registry_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     glance_registry_local_status :
         label                   : glance_registry_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : heat_api_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}heat_api_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     heat_api_local_status :
         label                   : heat_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["heat_cfn", "{{ ansible_ssh_host }}", "8000"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "heat_cfn", "{{ ansible_ssh_host }}", "8000"]
 alarms      :
     heat_cfn_api_local_status :
         label                   : heat_cfn_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["heat_cw", "{{ ansible_ssh_host }}", "8003"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "heat_cw", "{{ ansible_ssh_host }}", "8003"]
 alarms      :
     heat_cw_api_local_status :
         label                   : heat_cw_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : horizon_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}horizon_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     horizon_local_status :
         label                   : "horizon_local_status--{{ ansible_hostname }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
@@ -4,7 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : hp_monitoring.py
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]
 alarms      :
     hp-memory_status :
         label                   : hp-memory--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
@@ -4,7 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : hp_monitoring.py
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]
 alarms      :
     hp-processors_status :
         label                   : hp-processors--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
@@ -4,7 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : hp_monitoring.py
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]
 alarms      :
     hp-disk_status :
         label                   : hp-disk--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : keystone_api_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}keystone_api_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     keystone_api_local_status :
         label                   : keystone_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : memcached_status.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}memcached_status.py", "{{ ansible_ssh_host }}"]
 alarms      :
     memcache_api_local_status :
         label                   : memcache_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : neutron_api_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}neutron_api_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     neutron_api_local_status :
         label                   : neutron_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : neutron_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : neutron_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : neutron_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : neutron_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : neutron_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metering_agent_status :
         label                   : neutron_metering_agent_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_api_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_api_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     nova_api_local_status :
         label                   : nova_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_api_metadata_local_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_api_metadata_local_check.py", "{{ ansible_ssh_host }}"]
 alarms      :
     nova_api_metadata_local_status :
         label                   : nova_api_metadata_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_cert_status :
         label                   : nova_cert_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_cloud_stats.py
-    args    : ["--cpu", "{{ cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ cloud_resource_mem_allocation_ratio }}", "{{ ansible_ssh_host }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_cloud_stats.py", "--cpu", "{{ cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ cloud_resource_mem_allocation_ratio }}", "{{ ansible_ssh_host }}"]
 
 alarms      :
     nova_cloud_memory_status :

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_compute_status :
         label                   : nova_compute_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_conductor_status :
         label                   : nova_conductor_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_consoleauth_status :
         label                   : nova_consoleauth_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : nova_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_scheduler_status :
         label                   : nova_scheduler_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["nova_spice", "{{ ansible_ssh_host }}", "6082", "--path", "spice_auto.html"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "nova_spice", "{{ ansible_ssh_host }}", "6082", "--path", "spice_auto.html"]
 alarms      :
     nova_spice_api_local_status :
         label                   : nova_spice_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : openmanage.py
-    args    : ["chassis", "memory"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}openmanage.py", "chassis", "memory"]
 alarms      :
     openmanage-memory_status :
         label                   : openmanage-memory--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : openmanage.py
-    args    : ["chassis", "processors"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}openmanage.py", "chassis", "processors"]
 alarms      :
     openmanage-processors :
         label                   : openmanage-processors--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : openmanage.py
-    args    : ["storage", "vdisk"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}openmanage.py", "storage", "vdisk"]
 alarms      :
     openmanage-vdisk :
         label                   : openmanage-vdisk--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : rabbitmq_status.py
-    args    : ["-H", "{{ ansible_ssh_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}rabbitmq_status.py", "-H", "{{ ansible_ssh_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]
 alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/run_plugin_in_venv.sh.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/run_plugin_in_venv.sh.j2
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+{% if maas_venv_enabled | bool %}
+source {{ maas_venv_bin }}/activate
+{% endif %}
+
+python2.7 $@

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : swift-recon.py
-    args    : ["--ring-type", "account", "replication"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}swift-recon.py", "--ring-type", "account", "replication"]
 alarms      :
     swift_account_replication_failure_check :
         label                   : swift_account_replication_failure_check--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["swift_account_server", "--path", "/healthcheck", "{{ storage_address }}", "6002"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_account_server", "--path", "/healthcheck", "{{ storage_address }}", "6002"]
 alarms      :
     swift_account_server_api_local_status :
         label                   : swift_account_server_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : swift-recon.py
-    args    : ["async-pendings"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}swift-recon.py", "async-pendings"]
 alarms      :
     swift_async_failure_check :
         label                   : swift_async_failure_check--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : swift-recon.py
-    args    : ["--ring-type", "container", "replication"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}swift-recon.py", "--ring-type", "container", "replication"]
 alarms      :
     swift_container_replication_failure_check :
         label                   : swift_container_replication_failure_check--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["swift_container_server", "--path", "/healthcheck", "{{ storage_address }}", "6001"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_container_server", "--path", "/healthcheck", "{{ storage_address }}", "6001"]
 alarms      :
     swift_container_server_api_local_status :
         label                   : swift_container_server_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : swift-recon.py
-    args    : ["md5"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}swift-recon.py", "md5"]
 alarms      :
     swift_ring_md5_check :
         label                   : swift_ring_md5_check--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : swift-recon.py
-    args    : ["--ring-type", "object", "replication"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}swift-recon.py", "--ring-type", "object", "replication"]
 alarms      :
     swift_object_replication_failure_check :
         label                   : swift_object_replication_failure_check--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["swift_object_server", "--path", "/healthcheck", "{{ storage_address }}", "6000"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_object_server", "--path", "/healthcheck", "{{ storage_address }}", "6000"]
 alarms      :
     swift_object_server_api_local_status :
         label                   : swift_object_server_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : service_api_local_check.py
-    args    : ["swift_proxy_server", "--path", "/healthcheck", "{{ ansible_ssh_host }}", "8080"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_proxy_server", "--path", "/healthcheck", "{{ ansible_ssh_host }}", "8080"]
 alarms      :
     swift_proxy_server_api_local_status :
         label                   : swift_proxy_server_api_local_status--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : swift-recon.py
-    args    : ["quarantine"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}swift-recon.py", "quarantine"]
 alarms      :
     swift_quarantine_object_failed :
         label                   : swift_quarantine_object_failed--{{ ansible_hostname }}

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -18,9 +18,12 @@
   user: root
   tasks:
     - name: "Verify Checks & Alarms are registered"
-      script: >
-        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-created
-        --entity {{ inventory_hostname }}
+      shell: |
+        {% if maas_venv_enabled | bool %}
+        . {{ maas_venv_bin }}/activate
+        {% endif %}
+        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-created \
+        --entity {{ inventory_hostname }} \
         {% for ec in maas_excluded_checks %} --excludedcheck {{ec}}
         {% endfor %}
       register: verify_maas
@@ -35,8 +38,11 @@
         minutes: 2
 
     - name: "Verify Check & Alarm Status"
-      script: >
-        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status
+      shell: |
+        {% if maas_venv_enabled | bool %}
+        . {{ maas_venv_bin }}/activate
+        {% endif %}
+        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status \
         --entity {{ inventory_hostname }}
       register: verify_status
       failed_when: verify_status.rc != 0


### PR DESCRIPTION
Previous MaaS was built without virtual environment and relied
on global dependencies. Adding venv makes MaaS plugins work
under an isolated enviroment. The basic idea is the utilization
of a wrapper script to activate the virtualenv before
installing the plugins. And the main changes include adding
set-up virtualenv in the MaaS task and updating templates of
plugins by injecting wrapper script.

Connects #787