### PR TITLE
Make rpc-o plabooks aware of venvs

### DIFF
--- a/rpcd/playbooks/roles/beaver/defaults/main.yml
+++ b/rpcd/playbooks/roles/beaver/defaults/main.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+beaver_venv_enabled: False
+beaver_venv_tag: untagged
+beaver_venv_bin: "/openstack/venvs/beaver-{{ beaver_venv_tag }}/bin"
+beaver_non_venv_bin: '/usr/local/bin'
+
 # the pip packages to install
 beaver_pip_packages:
   - "beaver==36.2.0"

--- a/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
+++ b/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
@@ -16,7 +16,9 @@
 - name: Install pip packages
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
+    virtualenv: "{{ beaver_venv_enabled | bool | ternary(beaver_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ beaver_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success

--- a/rpcd/playbooks/roles/beaver/templates/beaver.j2
+++ b/rpcd/playbooks/roles/beaver/templates/beaver.j2
@@ -15,7 +15,11 @@ PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH
 
 BEAVER_NAME="beaver"
+{% if beaver_venv_enabled | bool %}
+BEAVER_BIN={{ beaver_venv_bin }}/beaver
+{% else %}
 BEAVER_BIN="$(which "${BEAVER_NAME}")"
+{% endif %}
 BEAVER_LOG="{{ beaver_daemon_log }}"
 BEAVER_PID="{{ beaver_daemon_pid }}"
 BEAVER_OPTS="{{ beaver_daemon_opts }}"

--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+elasticsearch_venv_enabled: False
+elasticsearch_venv_tag: untagged
+elasticsearch_venv_bin: "/openstack/venvs/elasticsearch-{{ elasticsearch_venv_tag }}/bin"
+elasticsearch_non_venv_bin: '/usr/local/bin'
+
+elasticsearch_bin: "/usr/share/elasticsearch/bin"
+
 elasticsearch_apt_repo_url: "http://packages.elasticsearch.org/elasticsearch/1.5/debian"
 
 elasticsearch_apt_repos:

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -31,7 +31,9 @@
 - name: Install pip packages
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
+    virtualenv: "{{ elasticsearch_venv_enabled | bool | ternary(elasticsearch_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ elasticsearch_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success
@@ -42,46 +44,16 @@
     - elasticsearch-pip-packages
     - elasticsearch-install
 
-- name: Install ElasticHQ Plugin
-  command: ./plugin -install {{ item }}
+- name: Install Plugins
+  command: ./plugin -install {{ item.src }}
   args:
-    chdir: /usr/share/elasticsearch/bin
-    creates: /usr/share/elasticsearch/plugins/HQ
+    chdir: "{{ elasticsearch_bin }}"
+    creates: "{{ elasticsearch_bin|dirname }}/plugins/{{ item.dest }}"
   with_items:
-    - royrusso/elasticsearch-HQ
-  tags:
-    - elasticsearch-plugins
-    - elasticsearch-install
-
-- name: Install Kopf Plugin
-  command: ./plugin -install {{ item }}
-  args:
-    chdir: /usr/share/elasticsearch/bin
-    creates: /usr/share/elasticsearch/plugins/kopf
-  with_items:
-    - lmenezes/elasticsearch-kopf
-  tags:
-    - elasticsearch-plugins
-    - elasticsearch-install
-
-- name: Install Head Plugin
-  command: ./plugin -install {{ item }}
-  args:
-    chdir: /usr/share/elasticsearch/bin
-    creates: /usr/share/elasticsearch/plugins/head
-  with_items:
-    - mobz/elasticsearch-head
-  tags:
-    - elasticsearch-plugins
-    - elasticsearch-install
-
-- name: Install BigDesk Plugin
-  command: ./plugin -install {{ item }}
-  args:
-    chdir: /usr/share/elasticsearch/bin
-    creates: /usr/share/elasticsearch/plugins/bigdesk
-  with_items:
-    - lukas-vlcek/bigdesk/2.4.0
+    - { src: "royrusso/elasticsearch-HQ", dest: "HQ" }
+    - { src: "lmenezes/elasticsearch-kopf", dest: "kopf" }
+    - { src: "mobz/elasticsearch-head", dest: "head" }
+    - { src: "lukas-vlcek/bigdesk/2.4.0", dest: "BigDesk" }
   tags:
     - elasticsearch-plugins
     - elasticsearch-install

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
@@ -69,7 +69,7 @@
     minute: 0
     hour: 0
     user: "root"
-    job: "/usr/local/bin/curator --host {{ hostvars[inventory_hostname]['container_address'] }} delete indices --older-than {{ elasticsearch_prune_days }} --time-unit 'days' --timestring '%Y.%m.%d' --prefix 'logstash'"
+    job: "{{ elasticsearch_venv_enabled | bool | ternary(elasticsearch_venv_bin,elasticsearch_non_venv_bin) }}/curator --host {{ hostvars[inventory_hostname]['container_address'] }} delete indices --older-than {{ elasticsearch_prune_days }} --time-unit 'days' --timestring '%Y.%m.%d' --prefix 'logstash'"
     cron_file: "elasticsearch_curator"
   tags:
     - elasticsearch-post-install

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -16,17 +16,15 @@
 - name: Install pip packages (venv)
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
+    virtualenv: "{{ horizon_venv_enabled | bool | ternary(horizon_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ horizon_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options | default('') }}"
-    virtualenv: "{{ horizon_venv_bin | dirname }}"
-    virtualenv_site_packages: "no"
   register: install_pip_packages
   until: install_pip_packages|success
   retries: 5
   delay: 2
   with_items: "{{ horizon_extensions_pip_packages }}"
-  when:
-    horizon_venv_enabled | bool
   tags:
     - horizon-extensions-install
     - horizon-extensions-pip-packages

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+rpc_maas_venv_enabled: False
+rpc_maas_venv_tag: untagged
+rpc_maas_venv_bin: "/openstack/venvs/rpc_maas-{{ rpc_maas_venv_tag }}/bin"
+rpc_maas_non_venv_bin: '/usr/local/bin'
+
 ## MaaS Options
 #
 # maas_auth_method: Specifies how to authenticate against Rackspace Cloud Monitoring.

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -24,6 +24,8 @@
 - name: Install pip packages
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
+    virtualenv: "{{ rpc_maas_venv_enabled | bool | ternary(rpc_maas_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ rpc_maas_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options | default('') }}"
   with_items: maas_pip_packages + maas_pip_dependencies

--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -70,6 +70,15 @@ holland_packages:
   - mariadb-client
   - xtrabackup
 
+holland_venv_enabled: False
+holland_venv_tag: untagged
+holland_venv_bin: "/openstack/venvs/holland-{{ holland_venv_tag }}/bin"
+holland_non_venv_bin: '/usr/local/bin'
+pccommon_venv_enabled: False
+pccommon_venv_tag: untagged
+pccommon_venv_bin: "/openstack/venvs/pccommon-{{ pccommon_venv_tag }}/bin"
+pccommon_non_venv_bin: '/usr/local/bin'
+
 holland_pip_dependencies:
   - MySQL-python
 

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_config.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_config.yml
@@ -56,7 +56,7 @@
     minute: "{{ (ansible_eth0['ipv4']['address']|replace('.', '')|int)%60}}"
     hour: 23
     state: present
-    job: "/usr/local/bin/holland bk"
+    job: "{{ holland_venv_enabled | bool | ternary(holland_venv_bin,holland_non_venv_bin) }}/holland bk"
     user: root
     cron_file: holland_backups
   tags:

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -24,6 +24,9 @@
 - name: Install pip dependencies
   pip:
     name: "{{ item }}"
+    state: latest
+    virtualenv: "{{ holland_venv_enabled | bool | ternary(holland_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ holland_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options|default('') }}"
   with_items: holland_pip_dependencies
   when: holland_pip_dependencies is defined
@@ -44,6 +47,9 @@
 - name: Install service source
   pip:
     name: "/opt/{{ holland_service_name }}_{{ holland_git_install_branch | replace('/', '_') }}"
+    state: latest
+    virtualenv: "{{ holland_venv_enabled | bool | ternary(holland_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ holland_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options|default('') }}"
   register: pip_install
   until: pip_install|success
@@ -55,6 +61,9 @@
 - name: Install pip repo plugins
   pip:
     name: "{{ holland_git_dest }}/{{ item.path }}/{{ item.package }}"
+    state: latest
+    virtualenv: "{{ holland_venv_enabled | bool | ternary(holland_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ holland_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options|default('') }}"
   when: holland_git_dest is defined and holland_git_repo_plugins is defined
   with_items: holland_git_repo_plugins

--- a/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
@@ -26,7 +26,9 @@
 - name: Install pccommon pip dependencies
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
+    virtualenv: "{{ pccommon_venv_enabled | bool | ternary(pccommon_venv_bin|dirname, omit) }}"
+    virtualenv_site_packages: "{{ pccommon_venv_enabled | bool | ternary('no', omit) }}"
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success

--- a/rpcd/playbooks/roles/rpc_support/templates/holland.conf.j2
+++ b/rpcd/playbooks/roles/rpc_support/templates/holland.conf.j2
@@ -16,7 +16,7 @@ backupsets = rpc_support
 umask = 0007
 
 # Define a path for holland and its spawned processes
-path = /usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+path = {% if holland_venv_enabled | bool %}{{holland_venv_bin}}:{% endif %}/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
 
 [logging]
 ## where to write the log


### PR DESCRIPTION
In some of our playbooks/roles in rpc-o we assume venvs are being
used/not being used. This implements the conditional pattern of OSA
to account for either case.

Connects rcbops/u-suk-dev#206

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>