### PR TITLE
Account for empty yaml file in update-yaml.py

### DIFF
--- a/releasenotes/notes/empty-yaml-bcbc0c731bed02e7.yaml
+++ b/releasenotes/notes/empty-yaml-bcbc0c731bed02e7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - The script update-yaml.py will now handle empty yaml
+    files

--- a/scripts/update-yaml.py
+++ b/scripts/update-yaml.py
@@ -37,12 +37,13 @@ def get_config(path):
             data = None
         else:
             raise e
+    else:
+        data = yaml.safe_load(data)
 
     if data is None:
         return {}
     else:
-        # assume config is a dict
-        return yaml.safe_load(data)
+        return data
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If reading a yaml file with no entries, yaml.safe_read() produces a
NoneType object. This commit fixes the issue by re-ordering to ensure
we convert to NoneType before the code to handle NoneType is executed.

Co-Authored-By: codebauss@gmail.com
(cherry picked from commit a945a31550509078c867914114554fe7a29e2381)