### PR TITLE
Install horizon_extensions from pip wheel instead of source

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -104,3 +104,15 @@ neutron_ml2_conf_ini_overrides:
 neutron_l3_agent_ini_overrides:
   DEFAULT:
     handle_internal_only_routers: True
+# List of files to override using the OSA horizon role
+rackspace_static_files_folder: "/opt/rpc-openstack/rpcd/playbooks/roles/horizon_extensions/files"
+horizon_custom_uploads:
+  logo-splash:
+    src: "{{ rackspace_static_files_folder }}/logo-splash.png"
+    dest: img/logo-splash.png
+  logo:
+    src: "{{ rackspace_static_files_folder }}/logo.png"
+    dest: img/logo.png
+  favicon:
+    src: "{{ rackspace_static_files_folder }}/favicon.ico"
+    dest: img/favicon.ico

--- a/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/defaults/main.yml
@@ -17,4 +17,4 @@ horizon_extensions_git_repo: https://github.com/rcbops/horizon-extensions
 horizon_extensions_git_install_branch: master
 horizon_extensions_dest_dir: /opt/rackspace/horizon-extensions
 horizon_extensions_pip_packages:
-   - "markdown"
+   - horizon_extensions

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -13,19 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Clone Horizon Extensions repo
-  git:
-    repo: "{{ horizon_extensions_git_repo }}"
-    dest: "{{ horizon_extensions_dest_dir }}"
-    version: "{{ horizon_extensions_git_install_branch }}"
-
-- name: Install Horizon plugin
-  command: "python setup.py install"
-  args:
-    chdir: '{{ horizon_extensions_dest_dir }}'
-  become: true
-  notify: Restart apache2
-
 - name: Install pip packages
   pip:
     name: "{{ item }}"
@@ -35,7 +22,7 @@
   until: install_pip_packages|success
   retries: 5
   delay: 2
-  with_items: horizon_extensions_pip_packages
+  with_items: "{{ horizon_extensions_pip_packages }}"
   tags:
     - horizon-extensions-install
     - horizon-extensions-pip-packages

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -13,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: RPC branding for Horizon
-  copy:
-    src: "{{ item }}"
-    dest: "{{ horizon_lib_dir }}/openstack_dashboard/static/dashboard/img/{{ item }}"
-    mode: "0644"
-    owner: root
-    group: root
-  with_items:
-    - logo-splash.png
-    - logo.png
-    - favicon.ico
-
 - name: Clone Horizon Extensions repo
   git:
     repo: "{{ horizon_extensions_git_repo }}"


### PR DESCRIPTION
In order to properly address the issue of horizon_extensions not building properly, we are backporting the change to the way we install it (via a pip package rather than installing from source). In order to cherry-pick that patch cleanly, I have also needed to include the patch to brand horizon using osa code, as opposed to rpc-specific kludging. Both are appropriate backports, and I have kept them as separate commits for obvious reasons.

Connects #1100 