### PR TITLE
Remove liberty-12.1 from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,7 +21,6 @@
 ###### Remove branches (lines) you do not wish to target.
 - [ ] Master
 - [ ] liberty-12.2
-- [ ] liberty-12.1
 - [ ] kilo
 
 ##### DocImpact: This section is to be completed by the issue owner as part of the issue's resolution.


### PR DESCRIPTION
The branch liberty-12.1 has been removed from the project. This commit
updates ISSUE_TEMPLATE.md in line with that change so that new issues
do not reference a non-existent branch.