### PR TITLE
test fix for mysql start timeout [WIP] [DO NOT MERGE]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openstack-ansible"]
 	path = openstack-ansible
-	url = https://git.openstack.org/openstack/openstack-ansible
+	url = https://github.com/mancdaz/openstack-ansible


### PR DESCRIPTION
Here I'm testing a fix in OSA, but changing the submodule to point at
my fork of OSA where I have made a patch.  I have to do it this way
because OSA doesn't do upgrade testing of mariadb between kilo and
liberty, which explains why we're only seeing this mostly in rpco.

The fix is essentially to wait longer between mysql start attempts after doing a mariadb upgrade.

Please, feel free to recheck_upgrade on this because that's what I'm testing here.

FYI this is the OSA fix I am testing https://github.com/mancdaz/openstack-ansible/commits/mysql-start

Connects  #1201