### PR TITLE
Always install the latest version of a pip package

### DIFF
--- a/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
+++ b/rpcd/playbooks/roles/beaver/tasks/beaver_install.yml
@@ -16,7 +16,7 @@
 - name: Install pip packages
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -31,7 +31,7 @@
 - name: Install pip packages
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success

--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Install pip packages (venv)
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
     extra_args: "{{ pip_install_options | default('') }}"
     virtualenv: "{{ horizon_venv_bin | dirname }}"
     virtualenv_site_packages: "no"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -24,6 +24,6 @@
 - name: Install pip packages
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
     extra_args: "{{ pip_install_options | default('') }}"
   with_items: maas_pip_packages + maas_pip_dependencies

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -25,6 +25,7 @@
   pip:
     name: "{{ item }}"
     extra_args: "{{ pip_install_options|default('') }}"
+    state: latest
   with_items: holland_pip_dependencies
   when: holland_pip_dependencies is defined
   register: pip_install
@@ -45,6 +46,7 @@
   pip:
     name: "/opt/{{ holland_service_name }}_{{ holland_git_install_branch | replace('/', '_') }}"
     extra_args: "{{ pip_install_options|default('') }}"
+    state: latest
   register: pip_install
   until: pip_install|success
   retries: 5
@@ -56,6 +58,7 @@
   pip:
     name: "{{ holland_git_dest }}/{{ item.path }}/{{ item.package }}"
     extra_args: "{{ pip_install_options|default('') }}"
+    state: latest
   when: holland_git_dest is defined and holland_git_repo_plugins is defined
   with_items: holland_git_repo_plugins
   register: pip_install

--- a/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/pccommon_get.yml
@@ -26,7 +26,7 @@
 - name: Install pccommon pip dependencies
   pip:
     name: "{{ item }}"
-    state: present
+    state: latest
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_pip_packages
   until: install_pip_packages|success


### PR DESCRIPTION
When re-running playbooks, if a version of the pip package was changed,
the playbooks would just ignore the package change because the package
is already installed. This change forces to use the latest package
available.

Connects rcbops/u-suk-dev#218

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>