### PR TITLE
Issue template update

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,11 @@
-##### What version (commit) do you encounter this issue on?
+#### Do NOT include any confidential information, this issue will be created on a public repo
+#### This section is completed by the issue reporter
+##### On which version(s) do you encounter this issue?
+###### Please provide the output to 'git describe --all' for  all deployments where you have confirmed it occurs.
 
-##### What type of issue is this (bug, feature, documentation, regression)?
+##### What type of issue is this? Please tick the appropriate box.
+- [ ] bug - existing functionality that does not work for you as documented
+- [ ] feature - new functionality that you would like to see added
 
 ##### What is the expected behavior?
 
@@ -12,19 +17,41 @@
 
 ##### How can we verify your issue is addressed?
 
-##### If this is a large issue, what can be done immediately to alleviate the issue while working on a longer-term solution?
+##### If you are using or know of a workaround please describe the necessary steps?
 
 ##### What is your evaluation on the importance of this issue, and why?
 
-##### What branches / milestones do you believe this issue should target?
-###### The list below is what is currently supported for backports
-###### Remove branches (lines) you do not wish to target.
-- [ ] Master
+----------------------------------------------------------------------------------------------------------------------------
+#### This section is completed during the issue resolution process. If you are reporting an issue, please do not modify the section below.
+##### Which branches are impacted by this issue?
+###### Remove branches that are not impacted.
+###### For each pull request, update the branch line to reference it.
+- [ ] master
 - [ ] liberty-12.2
 - [ ] kilo
 
-##### DocImpact: This section is to be completed by the issue owner as part of the issue's resolution.
+##### Upgrade impact. Consider the impact on moving between major, minor and patch releases.
+- [ ] This change does not impact upgrades
+- [ ] This change addresses a potential upgrade impact
+- [ ] The upgrade impact is being tracked by another issue.
+
+The issue tracking the upgrade impact is:
+
+##### Testing impact
+- [ ] An issue/pull-request has been create or exists to track the testing gap, and is referenced below
+- [ ] This change includes additional testing
+- [ ] This change is tested by the existing setup
+
+Additional testing links:
+
+##### Release note
+- [ ] This change includes a release note.
+- [ ] This change does not require a release note.
+
+##### Doc Impact
 ##### Does your change require documentation?
 - [ ] Yes, and I submitted an issue to [Docs issues](https://github.com/rackerlabs/docs-rpc/issues "Docs issues")
 - [ ] Yes, and I contributed a documentation patch to [docs-rpc](https://github.com/rackerlabs/docs-rpc "docs-rpc")
 - [ ] No documentation required for this change
+
+Additional documentation links (please add links if you have ticked yes):


### PR DESCRIPTION
The issue template is used by GitHub when a new issue is created.
Currently its main purpose is to prompt the issue reporter in to
providing all the information required to triage and investigate the
issue.

The main purpose of this patch is to give the individual working on
fixing the issue better guidance as to the steps that need to be taken
to complete it. This includes requiring the the individual to keep the
description (the section populated by the template) up-to-date with the
progress on work that has been done, e.g. pull requests created or
decisions made. In addition this patch seeks to make a clearer
distinction between the responsibilities of the issue reporter and the
issue assignee.