### PR TITLE
Report MaaS API and raxmon auth fails correctly

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -38,6 +38,11 @@
     group: "root"
     mode: "0600"
 
+- name: Verify raxmon-entities-list and MaaS API authentication does not fail
+  command: "raxmon-entities-list"
+  register: raxmon_output
+  failed_when: raxmon_output.rc != 0
+
 - name: Entity {{ entity_name }} count
   shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
   register: entity_count


### PR DESCRIPTION
This commit verifies that raxmon-entities-list command runs
correctly by running it without piping it first then running it
with the pipe. Now when the command fails it ends the error message
with: InvalidCredsError: 'Invalid credentials with the provider.'
Previously the command was piped to another shell command that
would never fail which would cause a different error to be
thrown later on.

Connects #1188