### PR TITLE
Exclude remote Swift regions for Beaver install.

### DIFF
--- a/rpcd/playbooks/beaver.yml
+++ b/rpcd/playbooks/beaver.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Setup beaver log shipper
-  hosts: all
+  hosts: all_containers:hosts
   max_fail_percentage: 20
   user: root
   roles:


### PR DESCRIPTION
The Beaver install has a dependency on pip lockdown, causing the
pip.conf files in the remote Swift regions to be reconfigured to point
to the repo in a different region. This can result in hanging when
attempting to install packages on the remote Swift regions, as the
management network is not routed between regions.

This change alters the target hosts of the Beaver install to exclude
any remote Swift regions.
