### PR TITLE
Make holland use 127.0.0.1 for backups

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/templates/holland-xtrabackup.conf.j2
+++ b/rpcd/playbooks/roles/rpc_support/templates/holland-xtrabackup.conf.j2
@@ -37,5 +37,5 @@ stream = xbstream
 defaults-extra-file = /root/.my.cnf
 user = rpc_support
 password = {{ rpc_support_holland_password }}
-host = {{ internal_lb_vip_address }}
+host = 127.0.0.1
 port = 3306


### PR DESCRIPTION
Currently holland runs in a galera container and connects to the load
balancer VIP. This commit ensures that it backs up from the local mysql
instance meaning backups can still happen even if the load balancer is
unavailable.

Connects #348
Backport-of daa2b8ec16d0b17c747e4ebb0c2fb92ec6760982