### PR TITLE
Introduce nova Mitaka related changes

### DIFF
--- a/releasenotes/notes/nova-13.0-0c2497128e677cb2.yaml
+++ b/releasenotes/notes/nova-13.0-0c2497128e677cb2.yaml
@@ -1,0 +1,19 @@
+---
+prelude: >
+    This version introduces nova's new database,
+    nova api db.
+security:
+  - Live migration of nova is now ssh encrypted, using
+    qemu+ssh instead of qemu+tcp. This behavior can be
+    overriden by setting another uri in the variable
+    ``live_migration_uri``
+other:
+  - Due to the introduction of the new nova api db, the
+    variables ``nova_api_db_max_overflow``,
+    ``nova_api_db_max_pool_size`` and
+    ``nova_api_db_pool_timeout`` were introduced.
+    The tweaking of these variables can be done by
+    overriding them directly (for an api db change only),
+    or by adapting ``db_max_overflow``,
+    ``db_max_pool_size`` and ``db_pool_timeout`` (for a
+    global change)

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -22,24 +22,30 @@
 rpc_conn_pool_size: 180
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
+db_max_overflow: 60
+db_max_pool_size: 120
+db_pool_timeout: 60
 
-keystone_database_max_pool_size: 120
-keystone_database_pool_timeout: 60
+keystone_database_max_pool_size: "{{ db_max_pool_size }}"
+keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
 neutron_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-neutron_db_max_overflow: 60
-neutron_db_max_pool_size: 120
-neutron_db_pool_timeout: 60
+neutron_db_max_overflow: "{{ db_max_overflow }}"
+neutron_db_max_pool_size: "{{ db_max_pool_size }}"
+neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
 nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-nova_db_max_overflow: 60
-nova_db_max_pool_size: 120
-nova_db_pool_timeout: 60
+nova_db_max_overflow: "{{ db_max_overflow }}"
+nova_db_max_pool_size: "{{ db_max_pool_size }}"
+nova_db_pool_timeout: "{{ db_pool_timeout }}"
+nova_api_db_max_overflow: "{{ db_max_overflow }}"
+nova_api_db_max_pool_size: "{{ db_max_pool_size }}"
+nova_api_db_pool_timeout: "{{ db_pool_timeout }}"
 nova_cpu_allocation_ratio: 2.0
 nova_ram_allocation_ratio: 1.0
 
@@ -96,10 +102,6 @@ nova_ceilometer_enabled: False
 swift_ceilometer_enabled: False
 keystone_ceilometer_enabled: False
 tempest_service_available_ceilometer: False
-
-neutron_neutron_conf_overrides:
-  nova:
-    endpoint_type: internal
 
 # Disable port security binding for liberty. See https://bugs.launchpad.net/neutron/+bug/1509312
 neutron_ml2_conf_ini_overrides:


### PR DESCRIPTION
This commit:

- Adds the new RPC-O defaults for the nova API DB
- Removes the neutron override to talk with nova
- Documents Live migration behaviour change

Connects rcbops/u-suk-dev#238

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>