### PR TITLE
Use v2.1 nova apis

### DIFF
--- a/maas/plugins/nova_api_local_check.py
+++ b/maas/plugins/nova_api_local_check.py
@@ -37,8 +37,8 @@ def check(auth_ref, args):
     tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
-        'http://{ip}:8774/v2/{tenant_id}'.format(ip=args.ip,
-                                                 tenant_id=tenant_id)
+        'http://{ip}:8774/v2.1/{tenant_id}'
+        .format(ip=args.ip, tenant_id=tenant_id)
     )
 
     try:

--- a/maas/plugins/nova_cloud_stats.py
+++ b/maas/plugins/nova_cloud_stats.py
@@ -65,8 +65,8 @@ def check(auth_ref, args):
     tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
-        'http://{ip}:8774/v2/{tenant_id}'.format(ip=args.ip,
-                                                 tenant_id=tenant_id)
+        'http://{ip}:8774/v2.1/{tenant_id}'
+        .format(ip=args.ip, tenant_id=tenant_id)
     )
 
     try:

--- a/maas/plugins/nova_service_check.py
+++ b/maas/plugins/nova_service_check.py
@@ -31,8 +31,8 @@ def check(auth_ref, args):
     tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
-        'http://{hostname}:8774/v2/{tenant_id}'.format(hostname=args.hostname,
-                                                       tenant_id=tenant_id)
+        'http://{hostname}:8774/v2.1/{tenant_id}'
+        .format(hostname=args.hostname, tenant_id=tenant_id)
     )
     try:
         nova = get_nova_client(auth_token=auth_token,


### PR DESCRIPTION
The nova /v2/ API is deprecated and /v2.1/ should be used instead.
This changes the python scripts, which shouldn't have any impact on
the reported data.

Connects rcbops/u-suk-dev#246

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>