### PR TITLE
Added data disk size precheck

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -44,10 +44,12 @@ grep -q callback_plugins playbooks/ansible.cfg || sed -i '/\[defaults\]/a callba
 
 # bootstrap the AIO
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
-  # Determine the largest secondary disk device available for repartitioning
-  DATA_DISK_DEVICE=$(lsblk -brndo NAME,TYPE,RO,SIZE | \
-                     awk '/d[b-z]+ disk 0/{ if ($4>m){m=$4; d=$1}}; END{print d}')
 
+  # Get minimum disk size
+  DATA_DISK_MIN_SIZE="$((1024**3 * $(awk '/bootstrap_host_data_disk_min_size/{print $2}' ${OA_DIR}/tests/roles/bootstrap-host/defaults/main.yml) ))"
+  # Determine the largest secondary disk device available for repartitioning which meets the minimum size requirements
+  DATA_DISK_DEVICE=$(lsblk -brndo NAME,TYPE,RO,SIZE | \
+                     awk '/d[b-z]+ disk 0/{ if ($4>m && $4>='$DATA_DISK_MIN_SIZE'){m=$4; d=$1}}; END{print d}')
   # Only set the secondary disk device option if there is one
   if [ -n "${DATA_DISK_DEVICE}" ]; then
     export BOOTSTRAP_OPTS="${BOOTSTRAP_OPTS} bootstrap_host_data_disk_device=${DATA_DISK_DEVICE}"


### PR DESCRIPTION
In order to solve an issue where the deploy would fail if a small
secondary disk exists on the system. This is becuse the deploy.sh
script would try to use the small disk as a data partition. Added
a precheck within deploy.sh to ensure any potential data devices
are large enough. The minimum disk size is pulled from the
main.yml playbook in OSA.

Connects #1235