### PR TITLE
Report status for all cinder services

### DIFF
--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -74,22 +74,19 @@ def check(auth_ref, args):
     status_ok()
 
     if args.host:
-        all_services_are_up = True
 
         for service in services:
             service_is_up = True
+            name = '%s_status' % service['binary']
 
             if service['status'] == 'enabled' and service['state'] != 'up':
                 service_is_up = False
-                all_services_are_up = False
 
             if '@' in service['host']:
                 [host, backend] = service['host'].split('@')
                 name = '%s-%s_status' % (service['binary'], backend)
-                metric_bool(name, service_is_up)
 
-        name = '%s_status' % service['binary']
-        metric_bool(name, all_services_are_up)
+            metric_bool(name, service_is_up)
     else:
         for service in services:
             service_is_up = True

--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -128,3 +128,8 @@ secure_cluster: true
 # List of secure flags to set on for a pool (options for the list are nodelete, nopgchange, nosizechange - prevents deletion, pg from changing and size from changing respectively).
 secure_cluster_flags:
   - nodelete
+
+# As part of https://github.com/rcbops/rpc-openstack/issues/1098 we changed the cinder_volume checks.
+# We need to exclude the original so that upgrades will work smoothly.
+maas_excluded_checks:
+  - cinder_volume_check

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -332,7 +332,7 @@ kernel_checks_list:
 openstack_service_local_checks_list:
   - { name: "cinder_api_local_check", group: "cinder_api" }
   - { name: "cinder_scheduler_check", group: "cinder_scheduler" }
-  - { name: "cinder_volume_check", group: "cinder_volume" }
+  - { name: "cinder_backup_check", group: "cinder_backup" }
   - { name: "glance_api_local_check", group: "glance_api" }
   - { name: "glance_registry_local_check", group: "glance_registry" }
   - { name: "heat_api_local_check", group: "heat_api" }

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_cinder_volumes_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_cinder_volumes_checks.yml
@@ -13,18 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Ensure local checks are removed
-  file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}--{{ inventory_hostname }}.yaml"
-    state: absent
-  with_items:
-    - "{{ maas_excluded_checks }}"
-  delegate_to: "{{ physical_host }}"
-
-- name: Ensure remote checks are removed
-  file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}.yaml"
-    state: absent
-  with_items:
-    - "{{ maas_excluded_checks }}"
+- name: Install local checks
+  template:
+    src: "cinder_volume_check.yaml.j2"
+    dest: "/etc/rackspace-monitoring-agent.conf.d/cinder_volume_{{ item.key }}_check--{{ inventory_hostname }}.yaml"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  with_dict: "{{ cinder_backends | default({}) }}"
+  when:
+    - inventory_hostname in groups["cinder_volume"]
+    - "'cinder_volume_{{ item.key }}_check' not in maas_excluded_checks"
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -17,6 +17,10 @@
   vars:
     checks: "{{ openstack_service_local_checks_list }}"
 
+- include: ensure_cinder_volumes_checks.yml
+  when:
+    - inventory_hostname in groups["cinder_volume"]
+
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ infra_service_local_checks_list }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
@@ -1,0 +1,17 @@
+type: agent.plugin
+label: cinder_backup_check--{{ ansible_hostname }}
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : cinder_service_check.py
+    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+alarms      :
+    cinder_backup_status :
+        label                   : cinder_backup_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["cinder-backup_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "cinder-backup down");
+            }

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -1,5 +1,5 @@
 type: agent.plugin
-label: cinder_volume_check--{{ ansible_hostname }}
+label: cinder_volume_{{ item.key }}_check--{{ ansible_hostname }}
 disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
@@ -7,11 +7,11 @@ details     :
     file    : cinder_service_check.py
     args    : ["--host", "{{ ansible_hostname }}", "{{ internal_vip_address }}"]
 alarms      :
-    cinder_volume_status :
-        label                   : cinder_volume_status--{{ ansible_hostname }}
+    cinder_volume_{{ item.key }}_status :
+        label                   : cinder_volume_{{ item.key }}_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["cinder-volume_status"] != 1) {
-                return new AlarmStatus(CRITICAL, "cinder-volume down");
+            if (metric["cinder-volume-{{ item.key}}_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "cinder-volume {{ item.key }} backend down");
             }


### PR DESCRIPTION
This fix resolves an issue where not all cinder service status were
reported as metrics.

cinder services should now have metrics created correctly based on the
services that are available on the host.

Additionally checks for cinder services needed to be fixed:
* Checks for each cinder backend are now created dynamically
* Check for cinder-backup service is created
* maas-exclude task is fixed to match the "--" used by all local checks

For the backport we need to exclude the previous 'cinder_volume_check'
using the maas_excluded_checks: var. This ensures upgrades will work.

Connected #1098

(cherry picked from commit e1dd1a4ab74d8de14d6ffedb7d53b3c6d6d913c0)
(cherry picked from commit 3405e55571725e0ae52fb2b7320a7a9a7afe67d4)