### PR TITLE
Added double quotes around $@

### DIFF
--- a/maas/plugins/horizon_check.py
+++ b/maas/plugins/horizon_check.py
@@ -59,7 +59,7 @@ def check(args):
         is_up = False
     else:
         if not (r.ok and
-                re.search('openstack dashboard', r.content, re.IGNORECASE)):
+                re.search(args.site_name_regexp, r.content, re.IGNORECASE)):
             status_err('could not load login page')
 
         splash_status_code = r.status_code
@@ -111,5 +111,8 @@ if __name__ == "__main__":
         parser.add_argument('ip',
                             type=ipaddr.IPv4Address,
                             help='horizon dashboard IP address')
+        parser.add_argument('site_name_regexp',
+                            type=str,
+                            help='Horizon Site Name')
         args = parser.parse_args()
         main(args)

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -454,3 +454,7 @@ maas_venv_bin: "{{ maas_venv }}/bin"
 # Set this to enable or disable installing in a venv
 maas_venv_enabled: true
 
+#
+# Default horizon site name
+#
+horizon_site_name: "openstack dashboard"

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -5,7 +5,7 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}horizon_check.py", "{{ ansible_ssh_host }}"]
+    args    : ["{{ maas_plugin_dir }}horizon_check.py", "{{ ansible_ssh_host }}", "'{{ horizon_site_name }}'"]
 alarms      :
     horizon_local_status :
         label                   : "horizon_local_status--{{ ansible_hostname }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/run_plugin_in_venv.sh.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/run_plugin_in_venv.sh.j2
@@ -4,4 +4,4 @@
 source {{ maas_venv_bin }}/activate
 {% endif %}
 
-python2.7 $@
+python2.7 "$@"


### PR DESCRIPTION
This is to ensure multi-word arguments are supported when invoking
the maas plugin wrapper script.

Connects #1257