### PR TITLE
Added double quotes around $@

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/run_plugin_in_venv.sh.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/run_plugin_in_venv.sh.j2
@@ -4,4 +4,4 @@
 source {{ maas_venv_bin }}/activate
 {% endif %}
 
-python2.7 $@
+python2.7 "$@"


### PR DESCRIPTION
This is to ensure that muti-word arguments are supported by the
maas plugins wrapper script

Connects #1257