### PR TITLE
MaaS Horizon Site Name Check

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -285,6 +285,11 @@ Checks the status of the horizon dashboard. First checks that the login page is 
 
 ##### Mandatory Arguments:
 IP address of service to test
+
+#### Optional Arguments:
+
+site_name_regexp: name of the horizon dashboard used to find the login page (default: 'openstack dashboard')
+
 ##### Example Output:
 
     metric splash_status_code uint32 200

--- a/maas/plugins/horizon_check.py
+++ b/maas/plugins/horizon_check.py
@@ -59,7 +59,7 @@ def check(args):
         is_up = False
     else:
         if not (r.ok and
-                re.search('openstack dashboard', r.content, re.IGNORECASE)):
+                re.search(args.site_name_regexp, r.content, re.IGNORECASE)):
             status_err('could not load login page')
 
         splash_status_code = r.status_code
@@ -111,5 +111,9 @@ if __name__ == "__main__":
         parser.add_argument('ip',
                             type=ipaddr.IPv4Address,
                             help='horizon dashboard IP address')
+        parser.add_argument('site_name_regexp',
+                            type=str,
+                            default='openstack dashboard',
+                            help='Horizon Site Name')
         args = parser.parse_args()
         main(args)

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -442,3 +442,8 @@ maas_excluded_checks: []
 # This is necessary until LP #1537117 is implemented
 openrc_os_endpoint_type: internalURL
 openrc_insecure: "{{ (keystone_service_adminuri_insecure | bool or keystone_service_internaluri_insecure | bool) | default(false) }}"
+
+#
+# Default horizon site name
+#
+horizon_site_name: "openstack dashboard"

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -5,7 +5,7 @@ period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
     file    : horizon_check.py
-    args    : ["{{ ansible_ssh_host }}"]
+    args    : ["{{ ansible_ssh_host }}", "{{ horizon_site_name }}"]
 alarms      :
     horizon_local_status :
         label                   : "horizon_local_status--{{ ansible_hostname }}"


### PR DESCRIPTION
This commit fixes a bug in the horizon_check.py plugin for MaaS.
Previously in the horizon check plugin it would search for the
horizon site name using a hardcoded value. This causes the
MaaS check to fail if the horizon site name is overridden in
the user variables file.

This is fixed setting the default value for horizon_site_name
in the rpc_maas main.yml that will get overridden if
horizon_site_name is set in user variables. That value is
passed to the horizon check plugin through the
horizon_local_check.yaml.j2 template and used by the horizon
check plugin as an argument for site name regex search.

Connects #1135

(cherry picked from commit dfeccf2a332382a0d9c9b82c84b476529fcf99e8)