### PR TITLE
Fixing bare variable deprecation warnings

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -25,7 +25,7 @@
   command: "cat /sys/class/net/{{ item.name }}/speed"
   ignore_errors: true
   register: discover_nic_speed
-  with_items: network_checks_list
+  with_items: "{{ network_checks_list }}"
 
 - name: Install network throughput checks
   template:
@@ -45,6 +45,6 @@
   file:
     path: "/etc/rackspace-monitoring-agent.conf.d/network_throughput-{{ item.name }}-{{ inventory_hostname }}.yaml"
     state: absent
-  with_items: network_checks_list
+  with_items: "{{ network_checks_list }}"
   when:
     - "'network_throughput-{{ item.name }}' in maas_excluded_checks"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -19,7 +19,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 600
-  with_items: maas_apt_packages
+  with_items: "{{ maas_apt_packages }}"
 
 - name: Update pip
   pip:
@@ -37,4 +37,4 @@
   until: install_pip_packages|success
   retries: 5
   delay: 2
-  with_items: maas_pip_packages + maas_pip_dependencies
+  with_items: "{{ maas_pip_packages + maas_pip_dependencies }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/repo_setup.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/repo_setup.yml
@@ -17,14 +17,14 @@
   apt_key:
     url: "{{ item.url }}"
     state: "{{ item.state }}"
-  with_items: maas_apt_keys
+  with_items: "{{ maas_apt_keys }}"
   when: "ansible_distribution_version in ['12.04', '13.04', '13.10', '14.04'] and maas_apt_keys is defined"
 
 - name: Add Container repos
   apt_repository:
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
-  with_items: maas_apt_repos
+  with_items: "{{ maas_apt_repos }}"
   when: "ansible_distribution_version in ['12.04', '13.04', '13.10', '14.04'] and maas_apt_repos is defined"
   register: add_repos
   until: add_repos|success

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -18,7 +18,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 600
-  with_items: holland_packages
+  with_items: "{{ holland_packages }}"
   when: holland_packages is defined
 
 - name: Install pip dependencies
@@ -26,7 +26,7 @@
     name: "{{ item }}"
     extra_args: "{{ pip_install_options|default('') }}"
     state: latest
-  with_items: holland_pip_dependencies
+  with_items: "{{ holland_pip_dependencies }}"
   when: holland_pip_dependencies is defined
   register: pip_install
   until: pip_install|success
@@ -60,7 +60,7 @@
     extra_args: "{{ pip_install_options|default('') }}"
     state: latest
   when: holland_git_dest is defined and holland_git_repo_plugins is defined
-  with_items: holland_git_repo_plugins
+  with_items: "{{ holland_git_repo_plugins }}"
   register: pip_install
   until: pip_install|success
   retries: 5

--- a/rpcd/playbooks/roles/rpc_support/tasks/host_kernel_modules.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/host_kernel_modules.yml
@@ -16,7 +16,7 @@
 - name: "Ensure kernel module(s)"
   modprobe:
     name: "{{ item }}"
-  with_items: rpc_host_kernel_modules
+  with_items: "{{ rpc_host_kernel_modules }}"
   when: rpc_host_kernel_modules is defined
   tags:
     - rpc-host-kernel-modules
@@ -25,7 +25,7 @@
   lineinfile:
     dest: /etc/modules
     line: "{{ item }}"
-  with_items: rpc_host_kernel_modules
+  with_items: "{{ rpc_host_kernel_modules }}"
   when: rpc_host_kernel_modules is defined
   tags:
     - rpc-host-kernel-modules

--- a/rpcd/playbooks/roles/rpc_support/tasks/host_kernel_tuning.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/host_kernel_tuning.yml
@@ -21,5 +21,5 @@
     state: "{{ item.state|default('present') }}"
     reload: "{{ item.reload|default('yes') }}"
   ignore_errors: true
-  with_items: rpc_host_kernel_sysctl
+  with_items: "{{ rpc_host_kernel_sysctl }}"
   when: rpc_host_kernel_sysctl is defined

--- a/rpcd/playbooks/roles/rpc_support/tasks/neutron_debug.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/neutron_debug.yml
@@ -19,7 +19,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 600
-  with_items: support_neutron_debug_packages
+  with_items: "{{ support_neutron_debug_packages }}"
   tags:
     - support_packages
     - neutron_debug_packages

--- a/rpcd/playbooks/roles/rpc_support/tasks/raid_install.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/raid_install.yml
@@ -19,7 +19,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 600
-  with_items: hwraid_apt_packages
+  with_items: "{{ hwraid_apt_packages }}"
   when: hwraid_apt_packages is defined
   tags:
     - hwraid-apt-packages

--- a/rpcd/playbooks/roles/rpc_support/tasks/raid_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/raid_preinstall.yml
@@ -17,7 +17,7 @@
   apt_key:
     url: "{{ item.url }}"
     state: "{{ item.state }}"
-  with_items: hwraid_apt_keys
+  with_items: "{{ hwraid_apt_keys }}"
   when: hwraid_apt_keys is defined
   register: add_keys_url
   until: add_keys_url|success
@@ -31,7 +31,7 @@
   apt_repository:
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
-  with_items: hwraid_apt_repos
+  with_items: "{{ hwraid_apt_repos }}"
   register: add_repos
   until: add_repos|success
   retries: 5

--- a/rpcd/playbooks/roles/rpc_support/tasks/support_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/support_preinstall.yml
@@ -20,7 +20,7 @@
     update_cache: yes
     cache_valid_time: 600
     force: yes
-  with_items: support_util_packages
+  with_items: "{{ support_util_packages }}"
   register: support_packge_installs
   until: support_packge_installs|success
   retries: 3
@@ -34,7 +34,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 600
-  with_items: support_host_packages
+  with_items: "{{ support_host_packages }}"
   when: inventory_hostname in groups['hosts']
   tags:
     - support_packages


### PR DESCRIPTION
In Ansible 2.0 using bare variables in 'with_' loops is deprecated, and
is scheduled to be removed in 2.2. They should instead use the "{{var}}"
syntax.
https://docs.ansible.com/ansible/porting_guide_2.0.html#deprecated

Connected https://github.com/rcbops/rpc-openstack/issues/1210