### PR TITLE
Add more checks for the galera MaaS plugins

### DIFF
--- a/maas/plugins/README.md
+++ b/maas/plugins/README.md
@@ -335,18 +335,25 @@ connects to an individual member of a galera cluster and checks various statuses
 
 ##### Example Output:
 
-    metric wsrep_replicated_bytes int64 320737952 bytes
-    metric wsrep_received_bytes int64 33470 bytes
-    metric wsrep_commit_window double 1.000000
+    metric wsrep_replicated_bytes int64 1307 bytes
+    metric wsrep_received_bytes int64 299878933 bytes
+    metric wsrep_commit_window_size double 1.000143 sequence_delta
     metric wsrep_cluster_size int64 3 nodes
-    metric queries_per_second int64 5792715 qps
-    metric wsrep_cluster_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
-    metric wsrep_cluster_status string primary
-    metric wsrep_local_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
-    metric wsrep_local_state_comment string synced
+    metric queries_per_second int64 380289 qps
+    metric wsrep_cluster_state_uuid string 6a3b85c0-4b07-11e6-8778-3f5baf70ad5c
+    metric wsrep_cluster_status string Primary
+    metric wsrep_local_state_uuid string 6a3b85c0-4b07-11e6-8778-3f5baf70ad5c
+    metric wsrep_local_state_comment string Synced
     metric mysql_max_configured_connections int64 800 connections
     metric mysql_current_connections int64 1 connections
     metric mysql_max_seen_connections int64 2 connections
+    metric num_of_open_files int64 14 files
+    metric open_files_limit int64 65535 files
+    metric innodb_row_lock_time_avg int64 0 milliseconds
+    metric innodb_deadlocks int64 0 deadlocks
+    metric access_denied_errors int64 0 access_denied_errors
+    metric aborted_clients int64 0 aborted_clients
+    metric aborted_connects int64 0 aborted_connects
 
 ***
 #### conntrack_count.py

--- a/maas/plugins/galera_check.py
+++ b/maas/plugins/galera_check.py
@@ -90,6 +90,20 @@ def print_metrics(replica_status):
            replica_status['Threads_connected'], 'connections')
     metric('mysql_max_seen_connections', 'int64',
            replica_status['Max_used_connections'], 'connections')
+    metric('num_of_open_files', 'int64',
+           replica_status['Open_files'], 'files')
+    metric('open_files_limit', 'int64',
+           replica_status['open_files_limit'], 'files')
+    metric('innodb_row_lock_time_avg', 'int64',
+           replica_status['Innodb_row_lock_time_avg'], 'milliseconds')
+    metric('innodb_deadlocks', 'int64',
+           replica_status['Innodb_deadlocks'], 'deadlocks')
+    metric('access_denied_errors', 'int64',
+           replica_status['Access_denied_errors'], 'access_denied_errors')
+    metric('aborted_clients', 'int64',
+           replica_status['Aborted_clients'], 'aborted_clients')
+    metric('aborted_connects', 'int64',
+           replica_status['Aborted_connects'], 'aborted_connects')
 
 
 def main():

--- a/releasenotes/notes/add-more-galera-checks-032c765829e922a2.yaml
+++ b/releasenotes/notes/add-more-galera-checks-032c765829e922a2.yaml
@@ -1,0 +1,26 @@
+---
+features:
+  - |
+    The galera_check.py plugin now provides the following
+    metrics.
+    * num_of_open_files
+    * open_files_limit
+    * innodb_row_lock_time_avg
+    * innodb_deadlocks
+    * access_denied_errors
+    * aborted_clients
+    * aborted_connects
+  - |
+    | New alarms have been created with the following criteria.
+    | open_file_size_limit_reached:
+    | metric["num_of_open_files"] > metric["open_files_limit"]
+    | innodb_row_lock_time_avg:
+    | metric["innodb_row_lock_time_avg"] > {{ innodb_row_lock_time_avg_critical_threshold }}
+    | innodb_deadlocks:
+    | metric["innodb_deadlocks"] != 0
+    | access_denied_errors:
+    | rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_warning_threshold }}
+    | aborted_clients:
+    | rate(metric["aborted_clients"]) > 1
+    | aborted_connects:
+    | rate(metric["aborted_connects"]) > 1

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -236,6 +236,36 @@ maas_filesystem_critical_threshold: 90.0
 mysql_connection_warning_threshold: 80
 mysql_connection_critical_threshold: 90
 
+# Maas mysql access denied thresholds
+# e.g If number of access denied errors inbetween checks
+# exceeds 20, the alarm will go into CRITICAL status.
+mysql_access_denied_errors_rate_warning_threshold: 10
+mysql_access_denied_errors_rate_critical_threshold: 20
+
+# Maas mysql aborted clients rate threshold
+# The rate is derived on a per-check basis.
+# In other words, this threshold defines how many
+# aborted_clients per check are needed to trigger
+# an alarm.
+mysql_aborted_clients_rate_warning_threshold: 1
+mysql_aborted_clients_rate_critical_threshold: 2
+
+# Maas mysql aborted connects rate threshold
+# The rate is derived on a per-check basis.
+# In other words, this threshold defines how many
+# aborted_connects per check are needed to trigger
+# an alarm
+mysql_aborted_connects_rate_warning_threshold: 1
+mysql_aborted_connects_rate_critical_threshold: 2
+
+# Maas mysql open file percentage threshold
+mysql_open_files_percentage_warning_threshold: 90
+mysql_open_files_percentage_critical_threshold: 95
+
+# Maas InnoDB row lock time avg thresholds, in milliseconds.
+innodb_row_lock_time_avg_warning_threshold: 2000
+innodb_row_lock_time_avg_critical_threshold: 10000
+
 # cinder-volumes volume group thresholds
 cinder_volumes_vg_warning_threshold: 80.0
 cinder_volumes_vg_critical_threshold: 90.0

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -34,3 +34,66 @@ alarms      :
             if (percentage(metric["mysql_current_connections"], metric["mysql_max_configured_connections"]) > {{ mysql_connection_warning_threshold }} ) {
                 return new AlarmStatus(WARNING, "Mysql connectons has exceeded {{ mysql_connection_warning_threshold }}% of configured maximum");
             }
+    open_file_size_limit_reached :
+        label                   : open_file_size_limit_reached--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["num_of_open_files"], metric["open_files_limit"]) > {{ mysql_open_files_percentage_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Number of open files has exceeded {{ mysql_open_files_percentage_critical_threshold }}% of open file limit");
+            }
+            if (percentage(metric["num_of_open_files"], metric["open_files_limit"]) > {{ mysql_open_files_percentage_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Number of open files has exceeded {{ mysql_open_files_percentage_warning_threshold }}% of open file limit");
+            }
+    innodb_row_lock_time_avg :
+        label                   : innodb_row_lock_time_avg--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["innodb_row_lock_time_avg"] > {{ innodb_row_lock_time_avg_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "InnoDB row lock time average has exceeded {{ innodb_row_lock_time_avg_critical_threshold }} milliseconds");
+            }
+            if (metric["innodb_row_lock_time_avg"] > {{ innodb_row_lock_time_avg_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "InnoDB row lock time average has exceeded {{ innodb_row_lock_time_avg_warning_threshold }} milliseconds");
+            }
+    innodb_deadlocks :
+        label                   : innodb_deadlocks--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["innodb_deadlocks"] != 0) {
+                return new AlarmStatus(CRITICAL, "InnoDB has experienced a deadlock");
+            }
+    access_denied_errors :
+        label                   : access_denied_errors--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Access denied errors rate is greater than {{ mysql_access_denied_errors_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+            }
+            if (rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Access denied errors rate is greater than {{ mysql_access_denied_errors_rate_critical_threshold }} per {{ maas_check_period }} seconds");
+            }
+    aborted_clients :
+        label                   : aborted_clients--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["aborted_clients"]) > {{ mysql_aborted_clients_rate_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Aborted clients rate is greater than {{ mysql_aborted_clients_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+            }
+            if (rate(metric["aborted_clients"]) > {{ mysql_aborted_clients_rate_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Aborted clients rate is greater than {{ mysql_aborted_clients_rate_critical_threshold }} per {{ maas_check_period }} seconds");
+            }
+    aborted_connects :
+        label                   : aborted_connects--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric["aborted_connects"]) > {{ mysql_aborted_connects_rate_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "Aborted connects rate is greater than {{ mysql_aborted_connects_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+            }
+            if (rate(metric["aborted_connects"]) > {{ mysql_aborted_connects_rate_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "Aborted connects rate is greater than {{ mysql_aborted_connects_rate_critical_threshold }} per {{ maas_check_period }} seconds");
+            }


### PR DESCRIPTION
This commit will add some more robust checks for the galera
plugin. We also create some alarms for the corresponding checks.
The criteria for these alarms include(when the alarms will trigger):

* Open_files > open file limit
* Innodb_row_lock_time_avg > Innodb_row_lock_time_max
* Innodb_deadlocks != 0
* Aborted_clients > mysql_aborted_clients_rate_warning_threshold [1]
* Aborted_connects > mysql_aborted_connects_rate_warning_threshold [1]
* access_denied_errors" >  mysql_access_denied_errors_rate_warning_threshold [1]
* percentage("mysql_max_seen_connections, mysql_max_configured_connections) > mysql_max_seen_connections_critical_threshold

[1] The rate function modifier is used here.
    By definition:
    Rate as defined by this formula where V=value, and T=time:
    (V1 - V0) / (T1 - T0).
    This is more of a ratio as to how many clients/connects are
    being aborted every {{ maas_check_period }} seconds (default is 60).

Connects #1164

(cherry picked from commit fab231ee50d8e34dbda9ffff2c936c5f56722c60)
Signed-off-by: Miguel Alex Cantu <miguel.cantu@rackspace.com>