### PR TITLE
Update RPC-O for changes to Neutron in Mitaka

### DIFF
--- a/releasenotes/notes/master-b7edb49a0bbe6c2c.yaml
+++ b/releasenotes/notes/master-b7edb49a0bbe6c2c.yaml
@@ -1,0 +1,29 @@
+---
+prelude: >
+    Neutron has fixed bugs related to port-security,
+    allowing it to be re-enabled.  Additionally
+    handle_internal_only_routers now defaults to true,
+    allowing us to remove the override.
+features:
+  - LBaaSv2 can now be configured via Horizon.
+  - MTUs are now calculated correctly, overrides have
+    been removed.
+upgrade:
+  - The default value for the arp-responder has changed
+    when using ML2 and the Linux Bridge agent.  The
+    logical network will now utilize traditional flood
+    and learn through the overlay. When upgrading,
+    existing vxlan devices will retain their old setup
+    and be unimpacted by changes to this flag. To apply
+    this to older devices created with the Liberty agent,
+    the vxlan device must be removed and then the Mitaka
+    agent restarted.  The agent will recreate the vxlan
+    devices with the current settings upon restart.
+  - The default_subnet_pools option is now deprecated and
+    will be removed in the Newton release. The same
+    functionality is now provided by setting is_default
+    attribute on subnetpools to True using the API or
+    client.
+other:
+  - Overlay networks are not explicitly required, if
+    unset it will default to the ansible_ssh_host value.

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -103,16 +103,6 @@ swift_ceilometer_enabled: False
 keystone_ceilometer_enabled: False
 tempest_service_available_ceilometer: False
 
-# Disable port security binding for liberty. See https://bugs.launchpad.net/neutron/+bug/1509312
-neutron_ml2_conf_ini_overrides:
-    ml2:
-        extension_drivers: ''
-
-# Enable handle_internal_only_routers based on expected behavior since Juno
-# See https://bugs.launchpad.net/openstack-ansible/+bug/1577868
-neutron_l3_agent_ini_overrides:
-  DEFAULT:
-    handle_internal_only_routers: True
 # List of files to override using the OSA horizon role
 rackspace_static_files_folder: "/opt/rpc-openstack/rpcd/playbooks/roles/horizon_extensions/files"
 horizon_custom_uploads:


### PR DESCRIPTION
- We have removed neutron_l3_agent_ini_overrides as
  handle_internal_only_routers now defaults to True.
- We have removed ml2_conf_ini_overrides as we got the ok to
  re-enable port-security.

Connects https://github.com/rcbops/u-suk-dev/issues/242