### PR TITLE
Update openstack-ansible SHA

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -79,6 +79,10 @@ pkg_locations:
   - /etc/openstack_deploy
   - /opt/rpc-openstack/rpcd
 
+# Override OpenStack upper constraints
+repo_build_upper_constraints_overrides:
+  - "elasticsearch<2.1.0"
+
 # NOTE(mancdaz) there may be a better place to override this
 horizon_venv_tag: "{{ openstack_release }}"
 


### PR DESCRIPTION
This commit updates the openstack-ansible SHA in preparation for the
next release.

openstack-ansible has changed the way Python package constraints are
applied, see 7055f795095d8e19c052371259ca77bf42c3095f, to address an
issue where they were being applied incorrectly. This change means the
version of elasticsearch specified in the elasticsearch role is no
longer honoured by the repo_build role. This commit sets the var
repo_build_upper_constraints_overrides to allow the requirements of the
role elasticsearch to be met.

The following issues are addressed by this change:
Connected https://github.com/rcbops/rpc-openstack/issues/1119
Connected https://github.com/rcbops/rpc-openstack/issues/1201
Connected https://github.com/rcbops/rpc-openstack/issues/1211