### PR TITLE
Fix filebeat not started on containers

### DIFF
--- a/rpcd/playbooks/roles/filebeat/tasks/filebeat_post_install.yml
+++ b/rpcd/playbooks/roles/filebeat/tasks/filebeat_post_install.yml
@@ -22,3 +22,11 @@
   tags:
     - filebeat-configuration
     - filebeat-post-install
+
+- name: Ensuring filebeat is started on boot
+  service:
+    name: filebeat
+    enabled: yes
+    state: started
+  tags:
+    - filebeat-post-install


### PR DESCRIPTION
filebeat playbook ensure the service is restarted if running, but
doesn't ensure the service is started on boot.
This makes sure the service is listed in the appropriate rc folder.

This is useful for work on rcbops/u-suk-dev#179

Connects #1274

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>