### PR TITLE
Create run level links for Beaver

### DIFF
--- a/rpcd/playbooks/roles/beaver/tasks/beaver_post_install.yml
+++ b/rpcd/playbooks/roles/beaver/tasks/beaver_post_install.yml
@@ -25,3 +25,11 @@
   tags:
     - beaver-post-install
     - beaver-conf
+
+- name: Ensure beaver is started on boot
+  service:
+    name: beaver
+    enabled: yes
+    state: started
+  tags:
+    - beaver-post-install


### PR DESCRIPTION
This commit fixes an issue where the beaver deamon would not
restart after each reboot because it is not linked inside of the
legacy init /etc/rcX.d directories. This issue would also cause
commands like 'update-rc.d -f beaver enable 2 3 4 5' to fail.

This fix is done by adding a task inside of
beaver_post_install.yml that makes sure the beaver service is
listed in the appropriate rcX.d folders.

Connects #934 