### PR TITLE
Enumerate log file targets and multiline config

### DIFF
--- a/rpcd/playbooks/roles/filebeat/defaults/main.yml
+++ b/rpcd/playbooks/roles/filebeat/defaults/main.yml
@@ -33,23 +33,244 @@ filebeat_logstash_port: "{{ logstash_beats_port |default(5044) }}"
 #"{{ groups['logstash_all'] | map('extract', hostvars, ['container_address']) | list }}"
 filebeat_logstash_hosts: "{% for host in groups['logstash_all'] %}{{ hostvars[host]['ansible_ssh_host'] }}:{{ filebeat_logstash_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
-filebeat_config_overrides:
-  filebeat:
-    prospectors:
-      - paths:
-        - /var/log/*.log
-        - /var/log/*/*.log
-        encoding: utf-8
-        input_type: log
-    registry_file: /var/lib/filebeat/registry
-  output:
-    logstash:
-      hosts: "{{ filebeat_logstash_hosts.split(',')|list }}"
-  shipper: null
-  logging:
-    files:
-      rotateeverybytes: 10485760  # = 10MB
-      keepfiles: 7
+# NOTE(sigmavirus24): Explanation of the regular expression:
+# - The Date is formatted by oslo.log as YYYY-MM-DD
+# - The Time is formatted by oslo.log as HH:MM:SS.Microseconds
+# - The Python Module tends to look like "cinder.api.scheduler"
+# - The Id is the group of request Ids, e.g., [req-<UUID4> ...]
+# We don't want lines like these to be captures as "multiline"
+# (hence the negate: true line) so we match the lines that we want
+# to be single log line items and negate them. We want to exclude
+# "Traceback" here because:
+# 1. It's not useful - it has the same timestamp as the actual
+#    traceback.
+# 2. If there is a multiline log before it, you would get one large
+#    log item instead of two discrete items.
+# See also https://play.golang.org/p/Y6qBej0IB2
+#
+#                              Date        Time       PID     Level   Python Module   Id
+multiline_openstack_pattern: '^[0-9-]{10} +[0-9:\.]+ +[0-9]+ +[A-Z]+ +[A-Za-z0-9\._]+ \[|Traceback'
+
+filebeat_logging_paths:
+  - paths:
+    - '/var/log/cinder/*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - cinder
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  - paths:
+    - '/var/log/glance/*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - glance
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  - paths:
+    - '/var/log/heat/*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - heat
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  - paths:
+    - '/var/log/horizon/*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - horizon
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  - paths:
+    - '/var/log/keystone/keystone.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - keystone
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  - paths:
+    - '/var/log/keystone/ssl_access.log'
+    - '/var/log/keystone/keystone-apache-error.log'
+    tags:
+    - openstack
+    - apache
+    - apache-access
+    - keystone
+  - paths:
+    - '/var/log/neutron/*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - neutron
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  - paths:
+    - '/var/log/nova/*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - oslofmt
+    - nova
+    multiline:
+      pattern: "{{ multiline_openstack_pattern }}"
+      negate: 'true'
+      match: after
+  # NOTE(sigmavirus24): Swift does not use oslo.log, so we cannot rely on our
+  # oslo-based pattern
+  - paths:
+    - '/var/log/swift/account*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - swift
+    - swift-account
+  - paths:
+    - '/var/log/swift/container*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - swift
+    - swift-container
+  - paths:
+    - '/var/log/swift/object*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - swift
+    - swift-object
+  - paths:
+    - '/var/log/swift/proxy*.log'
+    document_type: openstack
+    tags:
+    - openstack
+    - swift
+    - swift-proxy
+  # Start of non-OpenStack services whose logs we'd like to ship
+  - paths:
+    - '/var/log/apparmor/*.log'
+    tags:
+    - apparmor
+    - infrastructure
+  - paths:
+    - '/var/log/audit/*.log'
+    tags:
+    - audit
+  - paths:
+    - '/var/log/fsck/*'
+    tags:
+    - fsck
+  - paths:
+    - '/var/log/haproxy/*.log'
+    tags:
+    - haproxy
+    - infrastructure
+  - paths:
+    - '/var/log/libvirt/*.log'
+    - '/var/log/libvirt/*/*.log'
+    tags:
+    - libvirt
+    - nova
+  - paths:
+    - '/var/log/lxc/*.log'
+    tags:
+    - lxc
+    - infrastructure
+  - paths:
+    - '/var/log/upstart/*.log'
+    tags:
+    - upstart
+    - infrastructure
+  - paths:
+    - '/var/log/mysql_logs/*.log'
+    tags:
+    - galera
+    - mysql
+    - infrastructure
+    multiline:
+      # See https://play.golang.org/p/1r4iM0xwjQ
+      pattern: '^([^0-9W]|$)'
+      negate: 'false'
+      match: after
+  - paths:
+    - '/var/log/rabbitmq/*'
+    multiline:
+      # See https://play.golang.org/p/2SwhbSZxue
+      pattern: '^='
+      negate: 'true'
+      match: after
+    tags:
+    - rabbitmq
+    - infrastructure
+  - paths:
+    - '/var/log/elasticsearch/*.log'
+    multiline:
+      # See https://play.golang.org/p/Fo3bb7Mcgr
+      pattern: '^[^\[]'
+      negate: 'false'
+      match: after
+    tags:
+    - elasticsearch
+    - infrastructure
+    - logging
+  - paths:
+    - '/var/log/logstash/*.log'
+    tags:
+    - logstash
+    - infrastructure
+    - logging
+  - paths:
+    - '/var/log/ceph/ceph-mon.*.log'
+    multiline:
+      pattern: '^[a-z_]* '
+      negate: 'false'
+      match: after
+    tags:
+    - ceph-mon
+    - ceph
+    - infrastructure
+  - paths:
+    - '/var/log/ceph/ceph-osd.*.log'
+    tags:
+    - ceph-osd
+    - ceph
+    - infrastructure
+  - paths:
+    - '/var/log/nginx/*access.log'
+    tags:
+    - repo
+    - nginx
+    - nginx-access
+    - infrastructure
+  - paths:
+    - '/var/log/nginx/*error.log'
+    tags:
+    - repo
+    - nginx
+    - nginx-error
+    - infrastructure
+
 
 filebeat_configuration_files:
   - { src: "filebeat.yml.j2", dest: "/etc/filebeat/filebeat.yml" }

--- a/rpcd/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/rpcd/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -1,2 +1,41 @@
 # {{ ansible_managed }}
-{{ filebeat_config_overrides | to_yaml }}
+filebeat:
+  prospectors:
+{% for service in filebeat_logging_paths %}
+    - paths: {{ service.paths }}
+{% if service.document_type is defined %}
+      document_type: {{ service.document_type }}
+{% endif %}
+      encoding: {{ service.encoding |default('utf-8') }}
+{% if service.tags is defined %}
+      fields_under_root: true
+{# NOTE(sigmavirus24): So... filebeats 5.0 will have proper tags support,
+ # at which point we can remove this hack. This little piece of trickery,
+ # however, needs explanation. In order to send tags so that logstash will
+ # process them and send them to ElasticSearch, we need to hide them in the
+ # fields attribute on a prospector below. In order to then send the tags as a
+ # top-level attribute, we set fields_under_root to be true. Then all is
+ # happy.
+ #}
+      fields:
+        tags: {{ service.tags }}
+{% endif %}
+{% if service.multiline is defined %}
+      multiline:
+        pattern: '{{ service.multiline.pattern }}'
+        match: {{ service.multiline.match }}
+        negate: {{ service.multiline.negate }}
+{% endif %}
+{% endfor %}
+  registry_file: {{ filebeat_registry_file |default('/var/lib/filebeat/registry') }}
+output:
+  logstash:
+    hosts:
+{% for host in filebeat_logstash_hosts.split(',') %}
+    - '{{ host }}'
+{% endfor %}
+shipper: null
+logging:
+  files:
+    rotateeverybytes: 10485760  # = 10MB
+    keepfiles: 7


### PR DESCRIPTION
Using more than one prospector allows us to configure the openstack
services with multiline log parsing. This prevents us from applying
that same logic to non-OpenStack services (which will mess up log
shipping). It also allows us to define multiline rules for each of
the services we hope to ship to logstash with multiline log messages.

Filebeat will ignore directories/paths that do not actually exist on
the host so we can safely enumerate all of the services we want to
apply multiline parsing to in one prospector.

We *do* have to, however, ensure that paths do not overlap with the
prospectors. Filebeat explicitly calls this out as "undefined"
behaviour.

Included near the multline configurations are play.golang.org links so
others can experiment with what we used to test the multiline regular
expressions. Also, given the complexity and widespread use of our
OpenStack multiline expression, we've attempted to thoroughly document
it.

Connects rcbops/u-suk-dev#261