### PR TITLE
Disable L3HA as a default setting

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -96,7 +96,11 @@ swift_ceilometer_enabled: False
 keystone_ceilometer_enabled: False
 tempest_service_available_ceilometer: False
 
+# L3HA has to be disabled until all major issues are fixed
+# Based on https://github.com/rcbops/rpc-openstack/issues/1149
 neutron_neutron_conf_overrides:
+  DEFAULT:
+    l3_ha: False
   nova:
     endpoint_type: internal
 


### PR DESCRIPTION
Based on many open Neutron issues around L3HA RPC-O currently
disables L3HA until the known issues like:
https://bugs.launchpad.net/neutron/+bug/1590845
are addressed by the Neutron community.

The HA functionality will be still served by the neutron-ha-tool script.

Connects #1149
Docs Patch https://github.com/rackerlabs/docs-rpc/pull/493