### PR TITLE
Disable L3HA as default setting

### DIFF
--- a/releasenotes/notes/turn-off-l3ha-18274d19d54a6315.yaml
+++ b/releasenotes/notes/turn-off-l3ha-18274d19d54a6315.yaml
@@ -1,0 +1,20 @@
+---
+upgrade:
+  - |
+    If upgrading from an environment that has L3HA on,
+    please keep the following in mind:
+    
+    * HA routers, networks, and ports will linger.
+      Manually deleting these resources could cause
+      the router namespaces to disappear, which would
+      in turn cause network downtime.
+
+    For more information, see:
+    `bug 1149 <https://github.com/rcbops/rpc-openstack/issues/1149>`_
+    or the known issues section in the v13.0 RPCO documentation.
+fixes:
+  - Fixed `bug 1149 <https://github.com/rcbops/rpc-openstack/issues/1149>`_
+other:
+  - Neutron L3HA as a default has been disabled.
+    The default now is to use the neutron_ha_tool for backing up
+    l3 routers.

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -127,3 +127,9 @@ repo_build_pip_extra_indexes:
 # variable to 'true'.
 # Docs: http://docs.openstack.org/developer/openstack-ansible-security/
 # apply_security_hardening: true
+
+# Based on https://github.com/rcbops/rpc-openstack/issues/1149
+# L3HA has to be disabled until all major issues are fixed.
+neutron_neutron_conf_overrides:
+  DEFAULT:
+    l3_ha: False


### PR DESCRIPTION
Based on many open Neutron issues around L3HA RPC-O currently
disables L3HA until the known issues like
https://bugs.launchpad.net/neutron/+bug/1590845
Neutron community.

The HA functionality will be still served by the neutron-ha-tool script.

Connects #1149
Docs Patch https://github.com/rackerlabs/docs-rpc/pull/496