### PR TITLE
Update versions of Elasticsearch pip packages

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -136,3 +136,7 @@ secure_cluster: true
 # List of secure flags to set on for a pool (options for the list are nodelete, nopgchange, nosizechange - prevents deletion, pg from changing and size from changing respectively).
 secure_cluster_flags:
   - nodelete
+
+# We need to override the OpenStack upper constraint for Mitaka which is version 1.9.0, We should be able to remove this in Newton as the upper constraint moves to 2.3.0
+repo_build_upper_constraints_overrides:
+  - "elasticsearch==2.3.0"

--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -26,8 +26,8 @@ elasticsearch_apt_packages:
   - openjdk-7-jre-headless
 
 elasticsearch_pip_packages:
-  - elasticsearch<2.1.0
-  - elasticsearch-curator<3.5.0
+  - elasticsearch>=2.0.0,<3.0.0
+  - elasticsearch-curator==4.0.4
 
 # This sets the cluster name
 elasticsearch_cluster: openstack


### PR DESCRIPTION
The elasticsearch pip package for the new version of Elasticsearch that
we are using should be updated to 2.3.0.

In order to utilise 2.3.0 we have to override the mitaka default upper
constraint for OpenStack which is version 1.9.0

Additionally, the elasticsearch-curator pip package should be updated to
keep up to date, and to ensure everything remains compatible.

Connected https://github.com/rcbops/u-suk-dev/issues/262