### PR TITLE
Remove tag added to log events by logstash plugin

### DIFF
--- a/rpcd/playbooks/roles/logstash/templates/02-general.conf
+++ b/rpcd/playbooks/roles/logstash/templates/02-general.conf
@@ -8,4 +8,10 @@ filter {
       add_field => { "received_at" => "%{@timestamp}" }
     }
   }
+
+  mutate {
+    # TODO(sigmavirus24): Replace this mutate with configuration once
+    # https://github.com/logstash-plugins/logstash-input-beats/pull/114 merges
+    remove_tag => ["beats_input_codec_plain_applied"]
+  }
 }


### PR DESCRIPTION
The logstash-input-beats plugin is necessary to use filebeat to ship
logs to logstash. However, it defaults to always adding a tag to each
log event that indicates what codec it used to process the beats input.

Until https://github.com/logstash-plugins/logstash-input-beats/pull/114
is merged (in one shape or another) we need to just remove the tag from
all of our events.

Connects rcbops/u-suk-dev#261