### PR TITLE
Use ansible_hostname in verify_maas.yml

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -23,7 +23,7 @@
         . {{ maas_venv_bin }}/activate
         {% endif %}
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-created \
-        --entity {{ inventory_hostname }} \
+        --entity {{ inventory_hostname }}{{ maas_fqdn_extension }} \
         {% for ec in maas_excluded_checks %} --excludedcheck {{ec}}
         {% endfor %}
       register: verify_maas
@@ -43,7 +43,7 @@
         . {{ maas_venv_bin }}/activate
         {% endif %}
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status \
-        --entity {{ inventory_hostname }}
+        --entity {{ inventory_hostname }}{{ maas_fqdn_extension }}
       register: verify_status
       failed_when: verify_status.rc != 0
       changed_when: False


### PR DESCRIPTION
All of the maas check templates use ansible_hostname to generate
check names, and prior to this commit verify_maas.yml used
inventory_hostname to generate the check names to verify.
This led to an error where verify_maas.yml would fail when
ansible_hostname and inventory_hostname were different

This commit fixes this by using ansible_hostname within
verify_maas.yml to be consistent with the check templates.

Connects #941