### PR TITLE
Enable active-active balancing of repo servers

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -326,7 +326,6 @@ POOL_PARTS = {
         'backend_port': 8181,
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO',
         'group': 'pkg_repo',
-        'priority': True,
         'hosts': []
     }
 }


### PR DESCRIPTION
Change f5-config.py to configure pools in least-connections mode
instead of fastest-node mode to avoid error where all traffic
goes to single node

Connects #190