### PR TITLE
Use proper entity name in verify_maas.yml

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -20,7 +20,7 @@
     - name: "Verify Checks & Alarms are registered"
       script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-created
-        --entity {{ inventory_hostname }}
+        --entity {{ inventory_hostname }}{{ maas_fqdn_extension }}
         {% for ec in maas_excluded_checks %} --excludedcheck {{ec}}
         {% endfor %}
       register: verify_maas
@@ -37,7 +37,7 @@
     - name: "Verify Check & Alarm Status"
       script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status
-        --entity {{ inventory_hostname }}
+        --entity {{ inventory_hostname }}{{ maas_fqdn_extension }}
 
   vars_files:
     - "roles/rpc_maas/defaults/main.yml"


### PR DESCRIPTION
verify_maas.yml uses the entity name in a call to the maas
tool to verify the configuration of maas checks. Prior
to this commit verify_mass.yml used the inventory_hostname
fact to set the entity name it would check. However, the
host_setup.yml rpc_mass task would use a concatination of
inventory_hostname and the maas_fqdn_extension facts to
set the entity name on creatiion. This means that if
mass_fqdn_extension is non-empty the verify maas playbook
would fail.

This commit fixes this issue by changing the entity name
variable in verify_maas.yml to match how it is set up in
the host_setup.yml task.

Backport for commit d2be00a

Connects #941