### PR TITLE
Fix up and modify logstash filters for new environment

### DIFF
--- a/rpcd/playbooks/roles/filebeat/defaults/main.yml
+++ b/rpcd/playbooks/roles/filebeat/defaults/main.yml
@@ -50,6 +50,13 @@ filebeat_logstash_hosts: "{% for host in groups['logstash_all'] %}{{ hostvars[ho
 #
 #                              Date        Time       PID     Level   Python Module   Id
 multiline_openstack_pattern: '^[0-9-]{10} +[0-9:\.]+ +[0-9]+ +[A-Z]+ +[A-Za-z0-9\._]+ \[|Traceback'
+# NOTE(sigmavirus24): The logs in the keystone-apache-error logs are just
+# *slightly* different from the regular openstack logs. They have much greater
+# sub-second precision and a second time attribute.
+# See also https://play.golang.org/p/CKZXMOiwoi
+#
+#                                  Date        Time      Date         Time     PID     Level   Python Module   Request Id
+multiline_keystone_error_pattern: '[0-9-]{10} +[0-9:\.]+ [0-9-]{10} +[0-9:\.]+ [0-9]+ +[A-Z]+ +[A-Za-z0-9\._]+ \[|Traceback'
 
 filebeat_logging_paths:
   - paths:
@@ -109,12 +116,22 @@ filebeat_logging_paths:
       match: after
   - paths:
     - '/var/log/keystone/ssl_access.log'
-    - '/var/log/keystone/keystone-apache-error.log'
     tags:
     - openstack
     - apache
     - apache-access
     - keystone
+  - paths:
+    - '/var/log/keystone/keystone-apache-error.log'
+    tags:
+    - openstack
+    - apache
+    - apache-error
+    - keystone
+    multiline:
+      pattern: "{{ multiline_keystone_error_pattern }}"
+      negate: 'true'
+      match: after
   - paths:
     - '/var/log/neutron/*.log'
     document_type: openstack
@@ -191,7 +208,6 @@ filebeat_logging_paths:
     - '/var/log/libvirt/*/*.log'
     tags:
     - libvirt
-    - nova
   - paths:
     - '/var/log/lxc/*.log'
     tags:

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
@@ -73,6 +73,7 @@
     - 17-rabbitmq.conf
     - 18-ceph.conf
     - 19-nginx.conf
+    - 98-traceback.conf
     - 99-output.conf
   notify: Restart Logstash
   tags:

--- a/rpcd/playbooks/roles/logstash/templates/04-neutron.conf
+++ b/rpcd/playbooks/roles/logstash/templates/04-neutron.conf
@@ -6,9 +6,22 @@ filter {
           gsub => ['logmessage',"\"",""]
         }
         grok {
-          match => { "logmessage" => "\[(req\-%{NOTSPACE:requestid} |\-)\] %{NOTSPACE:requesterip} \- \- \[%{NOTSPACE:req_date} %{NOTSPACE:req_time}\] %{NOTSPACE:verb} %{NOTSPACE:url_path} %{NOTSPACE:http_ver} %{NUMBER:response} %{NUMBER:bytes:int} %{BASE10NUM:httptime:float}" }
+          match => { "logmessage" => "\[(%{NOTSPACE:requestid} %{NOTSPACE:user_id} %{NOTSPACE:tenant} \- \- \-|\-)\] %{NOTSPACE:requesterip} \- \- \[%{NOTSPACE:req_date} %{NOTSPACE:req_time}\] %{NOTSPACE:verb} %{NOTSPACE:url_path} %{NOTSPACE:http_ver} %{NUMBER:response} %{NUMBER:bytes:int} %{BASE10NUM:httptime:float}" }
           add_tag => ["apimetrics"]
         }
+      }
+    } else if "neutron-ha-tool" in [source] {
+      mutate {
+        add_tag => ["neutron-ha-tool"]
+        remove_tag => ["_grokparsefailure"]
+      }
+    }
+    if "starting" in [message] and "_grokparsefailure" in [tags] {
+      grok {
+        match => { "logmessage" => "\[(%{NOTSPACE:requestid}|\-)\](%{SPACE}\(%{NUMBER:pid}\)) %{GREEDYDATA:servicemessage}" }
+      }
+      mutate {
+        remove_tag => ["_grokparsefailure"]
       }
     }
   }

--- a/rpcd/playbooks/roles/logstash/templates/06-cinder.conf
+++ b/rpcd/playbooks/roles/logstash/templates/06-cinder.conf
@@ -1,6 +1,6 @@
 filter {
   if "cinder" in [tags] {
-    if [module] == "eventlet.wsgi.server" {
+    if [module] == "cinder.eventlet.wsgi.server" {
       if "accepted" not in [logmessage] {
         mutate {
           gsub => ['logmessage',"\"",""]

--- a/rpcd/playbooks/roles/logstash/templates/09-heat.conf
+++ b/rpcd/playbooks/roles/logstash/templates/09-heat.conf
@@ -6,12 +6,17 @@ filter {
           gsub => ['logmessage',"\"",""]
         }
         grok {
-          match => { "logmessage" => "\[(%{NOTSPACE:requestid} %{NOTSPACE:user_id} %{NOTSPACE:tenant} \- \- \-|\-)\] %{NOTSPACE:requesterip} \- \- \[%{NOTSPACE:req_date} %{NOTSPACE:req_time}\] %{NOTSPACE:verb} %{NOTSPACE:url_path} %{NOTSPACE:http_ver} %{NUMBER:response} %{NUMBER:bytes:int} %{BASE10NUM:httptime:float}" }
+          match => { "logmessage" => "\[%{NOTSPACE:requestid} %{NOTSPACE:user_id} %{NOTSPACE:tenant} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE}\] %{NOTSPACE:requesterip} %{NOTSPACE} %{NOTSPACE} \[%{NOTSPACE:req_date} %{NOTSPACE:req_time}\] %{NOTSPACE:verb} %{NOTSPACE:url_path} %{NOTSPACE:http_ver} %{NUMBER:response} %{NUMBER:bytes} %{BASE10NUM:httptime}" }
           add_tag => ["apimetrics"]
         }
       }
       mutate {
         replace => { "module" => "heat.%{module}" }
+      }
+    } else if [module] == "heat.engine.service" {
+      grok {
+        match => { "logmessage" => "\[%{NOTSPACE:requestid} %{NOTSPACE:user_id} %{NOTSPACE:tenant} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{GREEDYDATA:servicemessage}" }
+        add_tag => ["apimetrics"]
       }
     }
   }

--- a/rpcd/playbooks/roles/logstash/templates/14-keystone.conf
+++ b/rpcd/playbooks/roles/logstash/templates/14-keystone.conf
@@ -11,7 +11,8 @@ filter {
       }
     } else if "apache-error" in [tags] {
       grok {
-        match => { "message" => "\[%{APACHE_ERROR_TIMESTAMP:timestamp}\] \[%{DATA:module}:%{DATA:loglevel}\] \[pid %{POSINT:apache_pid}\:tid %{POSINT:apache_tid}\] ?(?:\[client %{IP:clientip}:%{POSINT:clientport}\] )?%{GREEDYDATA:logmessage}" }
+       patterns_dir => ["/opt/logstash/patterns"]
+        match => { "message" => "%{KEYSTONE_SUBSECOND_TIMESTAMP:keystone_subsecond_timestamp} %{STANDARD_TIMESTAMP:standard_timestamp} %{NUMBER:pid} %{DATA:loglevel} %{DATA:module} \[%{DATA:requestid}\] %{WORD:verb} %{NOTSPACE:request}" }
       }
       mutate {
         replace => { "module" => "keystone.error.%{module}" }

--- a/rpcd/playbooks/roles/logstash/templates/98-traceback.conf
+++ b/rpcd/playbooks/roles/logstash/templates/98-traceback.conf
@@ -1,0 +1,8 @@
+filter {
+  if "Traceback" in [message] {
+    mutate {
+      add_tag => ["traceback"]
+      remove_tag => ["_grokparsefailure"]
+    }
+  }
+}

--- a/rpcd/playbooks/roles/logstash/templates/extras
+++ b/rpcd/playbooks/roles/logstash/templates/extras
@@ -4,3 +4,6 @@ NGINX_ERROR_TIMESTAMP %{YEAR}/%{MONTHNUM}/%{MONTHDAY} %{TIME}
 SWIFTPROXY_DATE %{MONTHDAY}/%{MONTH}/%{YEAR}/%{HOUR}/%{MINUTE}/%{SECOND}
 
 SWIFTPROXY_ACCESS %{DATA:clientip} %{DATA:serverip} %{SWIFTPROXY_DATE:timestamp} %{WORD:verb} %{NOTSPACE:request} HTTP/%{NUMBER:httpversion} %{NUMBER:response} %{DATA:referrer} %{DATA:agent} %{DATA:swift_auth_token} %{DATA:swift_request_bytes} %{DATA:swift_response_bytes} %{DATA:swift_etag} %{DATA:swift_txn} %{DATA:swift_logged_headers} %{BASE10NUM:swift_trans_time}
+
+KEYSTONE_SUBSECOND_TIMESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{TIME}
+STANDARD_TIMESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{TIME}


### PR DESCRIPTION
This commit modifies existing logstash filters to work with the updated
logging stack.  This patch creates a new field called servicemessage
where the requestid and additional fields are stripped from a meaningful
message.

Connects rcbops/u-suk-dev#235