### PR TITLE
Install virtualenv pip package for rpc-maas role

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -442,6 +442,12 @@ maas_apt_packages:
   - mariadb-client
 
 #
+# maas_requires_pip_packages: Pip packages needed outside the virtualenv
+#
+maas_requires_pip_packages:
+  - virtualenv
+
+#
 # maas_pip_packages: Packages we need but are not built by openstack-ansible
 #
 maas_pip_packages:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -21,6 +21,17 @@
     cache_valid_time: 600
   with_items: maas_apt_packages
 
+- name: Install requires pip packages
+  pip:
+    name: "{{ item }}"
+    state: latest
+    extra_args: "{{ pip_install_options | default('') }}"
+  register: install_packages
+  until: install_packages|success
+  retries: 5
+  delay: 2
+  with_items: maas_requires_pip_packages
+
 - name: Update pip
   pip:
     name: pip


### PR DESCRIPTION
In order to install the maas environment inside a virtualenv, we need to
ensure we are actually installing the virtualenv pip package. In an AIO
this is done by the nova role on the compute 'container', meaning it
actually gets installed on the host, but in a multinode we need to do
this explicitly.

Connected https://github.com/rcbops/rpc-openstack/issues/1301