### PR TITLE
use correct location for maas plugins

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -464,7 +464,9 @@ maas_pip_dependencies:
   - python-novaclient
   - python-memcached
 
-maas_plugin_dir: /opt/rpc-openstack/maas/plugins/
+maas_source_plugin_dir: /opt/rpc-openstack/maas/plugins/
+
+maas_plugin_dir: /usr/lib/rackspace-monitoring-agent/plugins/
 
 maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
 #

--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -14,23 +14,30 @@
 # limitations under the License.
 
 - name: Install plugin dir
-  file: path=/usr/lib/rackspace-monitoring-agent/plugins/ state=directory owner=root group=root mode=0755
+  file:
+    path: "{{ maas_plugin_dir }}"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
 
 - name: Install MAAS Plugins
   synchronize:
-    src={{ maas_plugin_dir }} dest=/usr/lib/rackspace-monitoring-agent/plugins/ delete=yes
+    src: "{{ maas_source_plugin_dir }}"
+    dest: "{{ maas_plugin_dir }}"
+    delete: yes
 
 - name: Drop in wrapper script to run maas plugins in venv
   template:
     src: "run_plugin_in_venv.sh.j2"
-    dest: "/usr/lib/rackspace-monitoring-agent/plugins/run_plugin_in_venv.sh"
+    dest: "{{maas_plugin_dir}}run_plugin_in_venv.sh"
     owner: "root"
     group: "root"
     mode: "0755"
   when: maas_venv_enabled
 
 - name: List plugin files to chmod
-  shell: "ls -1 /usr/lib/rackspace-monitoring-agent/plugins/*.py"
+  shell: "ls -1 {{ maas_plugin_dir }}*.py"
   register: plugin_files
 
 - name: Chmod listed plugin files


### PR DESCRIPTION
With the switch to using maas from a venv, we moved to using the
maas_plugin_dir var as a reference for the location of the installed
plugins.  The value of this var, however, was the location of plugins
inside the git clone of rpc-openstack, rather than the location of
where the plugins get installed. This meant that only a deployment host
had the plugins in the correct location.

This commit switches the value of this var to point to the correct
installed location, whilst creating a new var to be used by the only
other task that was using the original value. It is done in this way to
minimise the amount of change needed to fix this issue.

Additionally, some areas where we were hardcoding the path to the
plugin location are now set to use the var value.

Connected https://github.com/rcbops/rpc-openstack/issues/1303