### PR TITLE
Copy rpc-maas-tool to all nodes

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -17,6 +17,15 @@
   hosts: hosts
   user: root
   tasks:
+    - name: ensure remote directory
+      file:
+        path: "{{ maas_rpc_scripts_dir }}"
+        state: directory
+    - name: copy script to all hosts
+      copy:
+        src: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py"
+        dest: "{{ maas_rpc_scripts_dir }}/rpc-maas-tool.py"
+        mode: 0755
     - name: "Verify Checks & Alarms are registered"
       shell: |
         {% if maas_venv_enabled | bool %}


### PR DESCRIPTION
In order to run properly, rpc-maas-tool needs to be on the node on
which it is doing the checks, because it needs to be able to
interrogate the maas conf files that have been laid down. By default,
we assume that it's present in /opt/rpc-openstack/scripts - which is
fine for an AIO but not for a multinode deployment.

This commit copies the file to the same location on all hosts in a
deployment so that the verify-maas playbook (which calls this script)
can complete successfully.

Note, I did investigate an alternative approach using the script
module, but I was unable to get it to work properly due to the
complexities of trying to run the script inside a virtual environment
whilst also using jinja to prepare args. The fix in this commit seemed
like the least complex fix to a pretty simple problem.

Connected https://github.com/rcbops/rpc-openstack/issues/1306