### PR TITLE
Enable cinder-backup service

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -73,6 +73,9 @@ keystone_token_driver: "sql"
 # Galera overrides
 galera_cluster_name: rpc_galera_cluster
 
+# Cinder overrides
+cinder_service_backup_program_enabled: True
+
 # Ceph overrides
 ceph_mons: >
   {% set _var = [] -%}


### PR DESCRIPTION
By default, cinder-backup is disabled in OSA. Recently, we fixed the
monitoring that we had in place for cinder-backups and discovered that
the cinder-backup service is not running.

This commit sets the necessary variable to ensure that the
cinder-backup service gets configured/deployed.

Note: by default, cinder will be configured to use swift as a backup
target. Further configuration would need to be done by the customer to
enable different backup targets.

Connected https://github.com/rcbops/rpc-openstack/issues/1308