### PR TITLE
Added dashboards for kibana

### DIFF
--- a/releasenotes/notes/kibana-upgraded-to-v4-bf2e41cd6c6bfca4.yaml
+++ b/releasenotes/notes/kibana-upgraded-to-v4-bf2e41cd6c6bfca4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Kibana has been upgraded to v4. This update includes an update
+    to the default dashboard and includes all of the features that
+    Kibana added in v4.

--- a/rpcd/playbooks/roles/elasticsearch/templates/elasticsearch.yml
+++ b/rpcd/playbooks/roles/elasticsearch/templates/elasticsearch.yml
@@ -214,12 +214,12 @@ bootstrap.mlockall: {{ elasticsearch_bootstrap_mlockall }}
 
 # Set the bind address specifically (IPv4 or IPv6):
 #
-network.bind_host: {{ hostvars[inventory_hostname]['container_address'] }}
+network.bind_host: 127.0.0.1,{{ hostvars[inventory_hostname]['container_address'] }}
 
 # Set the address other nodes will use to communicate with this node. If not
 # set, it is automatically derived. It must point to an actual IP address.
 #
-network.publish_host: {{ hostvars[inventory_hostname]['container_address'] }}
+network.publish_host: 127.0.0.1,{{ hostvars[inventory_hostname]['container_address'] }}
 
 # Set both 'bind_host' and 'publish_host':
 #

--- a/rpcd/playbooks/roles/kibana/defaults/main.yml
+++ b/rpcd/playbooks/roles/kibana/defaults/main.yml
@@ -21,6 +21,9 @@ kibana_apt_repos:
 kibana_apt_keys:
   - { url: "http://packages.elastic.co/GPG-KEY-elasticsearch", state: "present" }
 
+kibana_pip_packages:
+  - httplib2  # NOTE(sigmavirus24): Need this for the uri module
+
 kibana_apt_packages:
   - kibana
   - apache2
@@ -34,6 +37,7 @@ kibana_apache_modules:
 
 elasticsearch_http_port: 9200
 elasticsearch_vip: "{{ internal_lb_vip_address }}"
+kibana_index_on_elasticsearch: "http://{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_http_port}}/.kibana"
 
 kibana_debug: False
 kibana_verbose: True

--- a/rpcd/playbooks/roles/kibana/files/dashboard/Home-dashboard.json
+++ b/rpcd/playbooks/roles/kibana/files/dashboard/Home-dashboard.json
@@ -1,0 +1,13 @@
+{
+  "title": "Home dashboard",
+  "hits": 0,
+  "description": "",
+  "panelsJSON": "[{\"col\":1,\"id\":\"Hint\",\"panelIndex\":1,\"row\":1,\"size_x\":12,\"size_y\":1,\"type\":\"visualization\"},{\"col\":1,\"columns\":[\"beat.hostname\",\"module\",\"logmessage\"],\"id\":\"default-search\",\"panelIndex\":2,\"row\":12,\"size_x\":12,\"size_y\":6,\"sort\":[\"@timestamp\",\"desc\"],\"type\":\"search\"},{\"col\":1,\"id\":\"Log-Level-Severity\",\"panelIndex\":3,\"row\":5,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Top-5-Event-Sources\",\"panelIndex\":4,\"row\":5,\"size_x\":5,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"API-Operations\",\"panelIndex\":5,\"row\":2,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"OpenStack-Events-Histogram\",\"panelIndex\":6,\"row\":2,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Infrastructure-Events-Histogram\",\"panelIndex\":8,\"row\":2,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"OpenStack-API-response-time\",\"panelIndex\":10,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"OpenStack-API-comparing-response-time\",\"panelIndex\":11,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"}]",
+  "optionsJSON": "{\"darkTheme\":false}",
+  "uiStateJSON": "{\"P-3\":{\"spy\":{\"mode\":{\"fill\":false,\"name\":null}},\"vis\":{\"legendOpen\":true}},\"P-4\":{\"vis\":{\"legendOpen\":true}},\"P-5\":{\"vis\":{\"legendOpen\":true}},\"P-6\":{\"spy\":{\"mode\":{\"fill\":false,\"name\":null}},\"vis\":{\"legendOpen\":true}},\"P-8\":{\"spy\":{\"mode\":{\"fill\":false,\"name\":null}},\"vis\":{\"legendOpen\":false}}}",
+  "version": 1,
+  "timeRestore": false,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/search/default-search.json
+++ b/rpcd/playbooks/roles/kibana/files/search/default-search.json
@@ -1,0 +1,18 @@
+{
+  "sort": [
+    "@timestamp",
+    "desc"
+  ],
+  "hits": 0,
+  "description": "Searching accross everything",
+  "title": "All events",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
+  },
+  "columns": [
+    "beat.hostname",
+    "module",
+    "logmessage"
+  ]
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/API-Operations.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/API-Operations.json
@@ -1,0 +1,11 @@
+{
+  "title": "API Operations",
+  "visState": "{\"title\":\"API Operations\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"verb.raw\",\"exclude\":{\"flags\":[\"CASE_INSENSITIVE\"],\"pattern\":\"\"},\"include\":{\"pattern\":\"(GET|PUT|POST|PATCH|OPTIONS|HEAD|DELETE)\",\"flags\":[\"CASE_INSENSITIVE\"]},\"size\":0,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"API Operations\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/Hint.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/Hint.json
@@ -1,0 +1,10 @@
+{
+  "title": "Hint",
+  "visState": "{\"title\":\"Hint\",\"type\":\"markdown\",\"params\":{\"markdown\":\"you can replace the traditional `grep -R instancename * ` by simply typing the instance name in the search field above. Same goes for request ids.\"},\"aggs\":[],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/Infrastructure-Events-Histogram.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/Infrastructure-Events-Histogram.json
@@ -1,0 +1,11 @@
+{
+  "title": "Infrastructure Events Histogram",
+  "visState": "{\"title\":\"Infrastructure Events Histogram\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":true,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"2\",\"type\":\"filters\",\"schema\":\"group\",\"params\":{\"filters\":[{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: infrastructure*\",\"analyze_wildcard\":true}}},\"label\":\"Infrastructure\"}]}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":true,\"index\":\"logstash-*\",\"key\":\"tags\",\"negate\":false,\"value\":\"nova\"},\"query\":{\"match\":{\"tags\":{\"query\":\"nova\",\"type\":\"phrase\"}}}},{\"meta\":{\"negate\":false,\"index\":\"logstash-*\",\"key\":\"loglevel\",\"value\":\"DEBUG\",\"disabled\":true,\"alias\":null},\"query\":{\"match\":{\"loglevel\":{\"query\":\"DEBUG\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/Log-Level-Severity.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/Log-Level-Severity.json
@@ -1,0 +1,11 @@
+{
+  "title": "Log Level Severity",
+  "visState": "{\"title\":\"Log Level Severity\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"loglevel.raw\",\"size\":0,\"order\":\"desc\",\"orderBy\":\"_term\",\"customLabel\":\"Log Level Severity\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/OpenStack-API-comparing-response-time.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/OpenStack-API-comparing-response-time.json
@@ -1,0 +1,11 @@
+{
+  "title": "OpenStack API Response Times (Median vs Average vs Min)",
+  "visState": "{\"title\":\"OpenStack API Response Times\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"overlap\",\"times\":[],\"addTimeMarker\":true,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"httptime\"}},{\"id\":\"3\",\"type\":\"filters\",\"schema\":\"split\",\"params\":{\"filters\":[{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: openstack*\",\"analyze_wildcard\":true}}},\"label\":\"\"}],\"row\":false}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"httptime\",\"percents\":[50]}},{\"id\":\"5\",\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"httptime\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/OpenStack-API-response-time.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/OpenStack-API-response-time.json
@@ -1,0 +1,11 @@
+{
+  "title": "OpenStack API Response Times",
+  "visState": "{\"title\":\"OpenStack API Response Times\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"httptime\",\"percents\":[50,95,99],\"json\":\"\"}},{\"id\":\"3\",\"type\":\"filters\",\"schema\":\"split\",\"params\":{\"filters\":[{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: openstack*\",\"analyze_wildcard\":true}}},\"label\":\"\"}],\"row\":false}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/OpenStack-Events-Histogram.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/OpenStack-Events-Histogram.json
@@ -1,0 +1,11 @@
+{
+  "title": "OpenStack Events Histogram",
+  "visState": "{\"title\":\"OpenStack Events Histogram\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":true,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"2\",\"type\":\"filters\",\"schema\":\"group\",\"params\":{\"filters\":[{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: nova*\",\"analyze_wildcard\":true}}},\"label\":\"nova\"},{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: cinder*\",\"analyze_wildcard\":true}}},\"label\":\"cinder\"},{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: neutron*\",\"analyze_wildcard\":true}}},\"label\":\"neutron\"},{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: keystone*\",\"analyze_wildcard\":true}}},\"label\":\"keystone\"},{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: swift*\",\"analyze_wildcard\":true}}},\"label\":\"swift\"},{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: horizon*\",\"analyze_wildcard\":true}}},\"label\":\"horizon\"},{\"input\":{\"query\":{\"query_string\":{\"query\":\"tags: heat*\",\"analyze_wildcard\":true}}},\"label\":\"heat\"}]}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/files/visualization/Top-5-Event-Sources.json
+++ b/rpcd/playbooks/roles/kibana/files/visualization/Top-5-Event-Sources.json
@@ -1,0 +1,11 @@
+{
+  "title": "Top 5 Event Sources (Pie Chart)",
+  "visState": "{\"title\":\"Top 5 Event Sources (Pie Chart)\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"module.raw\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Event Sources\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "default-search",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }
+}

--- a/rpcd/playbooks/roles/kibana/meta/main.yml
+++ b/rpcd/playbooks/roles/kibana/meta/main.yml
@@ -26,3 +26,6 @@ galaxy_info:
   categories:
     - rackspace
     - kibana
+
+dependencies:
+  - pip_lock_down

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_dashboards.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_dashboards.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Guessing current kibana version
+  shell: cat package.json | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["version"];'
+  args:
+    chdir: "/opt/kibana/"
+  register: kibana_version
+  tags:
+    - kibana-post-install
+
+- name: Import Kibana's LS index configuration in ES
+  uri:
+    method: "PUT"
+    url: "{{ kibana_index_on_elasticsearch }}{{ item.where }}"
+    # NOTE(sigmavirus24): There's a bug in Ansible < 2.1.x where without the
+    # leading ' ' this will be interpreted as a dictionary (EVEN WITH to_json)
+    # and so the only way to unbreak this is to use a leading ' '. ಠ_ಠ
+    body: " {{ item.what }}"
+    body_format: "json"
+    # NOTE(sigmavirus24): The first request we make may return a 409 status
+    # code. This is fine because it means we've already configured this once.
+    status_code: 200,201,409
+  with_items:
+    - where: "/index-pattern/logstash-*?op_type=create"
+      what: '{"title" : "logstash-*",  "timeFieldName": "@timestamp"}'
+    - where: "/config/{{ kibana_version.stdout }}"
+      what: '{"defaultIndex" : "logstash-*"}'
+  tags:
+    - kibana-post-install
+
+- name: Uploading JSON configuration files
+  uri:
+    method: "PUT"
+    url: "{{ kibana_index_on_elasticsearch }}/{{ (item | dirname).split('/')[-1] }}/{{ (item | basename ).split('.')[0] }}"
+    # NOTE(sigmavirus24): There's a bug in Ansible < 2.1.x where without the
+    # leading ' ' this will be interpreted as a dictionary (EVEN WITH to_json)
+    # and so the only way to unbreak this is to use a leading ' '. ಠ_ಠ
+    body: " {{ lookup('file', item) }}"
+    body_format: "json"
+    status_code: 200,201
+  with_fileglob:
+    - "search/*.json"
+    - "visualization/*.json"
+    - "dashboard/*.json"
+  tags:
+    - kibana-post-install
+    - kibana-rax-dashboard

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
@@ -28,6 +28,20 @@
     - kibana-apt-packages
     - kibana-install
 
+- name: Install pip packages
+  pip:
+    name: "{{ item }}"
+    state: latest
+    extra_args: "{{ pip_install_options |default('') }}"
+  register: install_pip_packages
+  until: install_pip_packages |success
+  retries: 5
+  delay: 2
+  with_items: kibana_pip_packages
+  tags:
+    - kibana-pip-packages
+    - kibana-install
+
 - name: Enable Kibana Service
   service:
     name: kibana

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_post_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_post_install.yml
@@ -127,15 +127,3 @@
   tags:
     - kibana-apache
     - kibana-post-install
-
-# TODO(shep): this needs to be ported to kibana-4
-#- name: Install Dashboards
-#  template:
-#    src: "{{ item }}"
-#    dest: "/opt/kibana/app/dashboards/{{ item }}"
-#    owner: "root"
-#    group: "root"
-#  with_items:
-#    - Event-Dashboard.json
-#  tags:
-#    - kibana-post-install

--- a/rpcd/playbooks/roles/kibana/tasks/main.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/main.yml
@@ -16,3 +16,4 @@
 - include: kibana_pre_install.yml
 - include: kibana_install.yml
 - include: kibana_post_install.yml
+- include: kibana_dashboards.yml

--- a/rpcd/playbooks/roles/kibana/templates/kibana.yml
+++ b/rpcd/playbooks/roles/kibana/templates/kibana.yml
@@ -23,7 +23,7 @@ elasticsearch.url: "http://{{ elasticsearch_vip }}:{{ elasticsearch_http_port}}"
 # kibana.index: ".kibana"
 
 # The default application to load.
-# kibana.defaultAppId: "discover"
+kibana.defaultAppId: "dashboard/Home-dashboard"
 
 # If your Elasticsearch is protected with basic auth, these are the user credentials
 # used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana


### PR DESCRIPTION
Kibana4 can't import our old json file anymore.
To keep the same features as the previous kibana role, we have to
recreate for kibana 4:
- Visualisations
- Dashboard
- Logstash
- Default Index
- Default Search

This cannot be done by creating json files and uploading them in a
folder.

Two choices were possible: use elasticdump (a third party cli in
js running with node) or do manual http calls.

This commit implements the latest by:

- Discovering the latest version of Kibana installed
- Exporting a version of the items listed above after manual generation
- Enabled the binding of ES on localhost for debugging purposes
- Importing the items above by directly reaching ES from the kibana
  nodes.

Connects rcbops/u-suk-dev#179

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>