### PR TITLE
Update openstack-ansible SHA

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -133,3 +133,7 @@ repo_build_pip_extra_indexes:
 neutron_neutron_conf_overrides:
   DEFAULT:
     l3_ha: False
+
+# Container repos
+lxc_container_template_main_apt_repo: "https://mirror.rackspace.com/ubuntu"
+lxc_container_template_security_apt_repo: "https://mirror.rackspace.com/ubuntu"


### PR DESCRIPTION
This commit updates the openstack-ansible SHA in preparation for
r13.0.0rc1.

This commit includes overriding an OSA change introduced by this commit
so that RPCO continue to use Rackspace's APT mirror.

Connected https://github.com/rcbops/u-suk-dev/issues/282