### PR TITLE
Ensure filebeat (re)starts only once on install

### DIFF
--- a/rpcd/playbooks/roles/filebeat/tasks/filebeat_post_install.yml
+++ b/rpcd/playbooks/roles/filebeat/tasks/filebeat_post_install.yml
@@ -23,6 +23,9 @@
     - filebeat-configuration
     - filebeat-post-install
 
+- name: Flush handlers
+  meta: flush_handlers
+
 - name: Ensuring filebeat is started on boot
   service:
     name: filebeat


### PR DESCRIPTION
The filebeat playbooks were causing a start followed very quickly by a
restart of the filebeat service, which was causing the service to die.

This commit adds a 'flush_handlers' so that the service is (re)started
prior to the task where it is 'enabled' thereby removing the need for a
second restart.  This fixes the issue with the filebeat service
stopping.

Connected https://github.com/rcbops/rpc-openstack/issues/1310

Co-Authored-By: Ian Cordasco <ian.cordasco@rackspace.com>