### PR TITLE
Add mitaka-13.0 to issue template branch list

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,6 +27,7 @@
 ###### Remove branches that are not impacted.
 ###### For each pull request, update the branch line to reference it.
 - [ ] master
+- [ ] mitaka-13.0
 - [ ] liberty-12.2
 - [ ] kilo
 


### PR DESCRIPTION
With the release of 13.0.0rc1 the branch mitaka-13.0 has been added to
rpc-openstack. This commit updates the issue template so that new issues
list mitaka-13.0 as a branch that potentially requires fixing.

Connected https://github.com/rcbops/rpc-openstack/issues/1319