### PR TITLE
Conditionally monitor cinder-backup service

### DIFF
--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -79,6 +79,8 @@ maas_filesystem_critical_threshold: 90.0
 #    warning_threshold: 80.0
 #    critical_threshold: 90.0
 
+maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled }}"
+
 # overrides for the nova_cloud_stats  maas plugin
 cloud_resource_cpu_allocation_ratio: "{{ nova_cpu_allocation_ratio }}"
 cloud_resource_mem_allocation_ratio: "{{ nova_ram_allocation_ratio }}"

--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -122,3 +122,5 @@ horizon_custom_uploads:
   favicon:
     src: "{{ rackspace_static_files_folder }}/favicon.ico"
     dest: img/favicon.ico
+
+cinder_service_backup_program_enabled: false

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -362,7 +362,6 @@ kernel_checks_list:
 openstack_service_local_checks_list:
   - { name: "cinder_api_local_check", group: "cinder_api" }
   - { name: "cinder_scheduler_check", group: "cinder_scheduler" }
-  - { name: "cinder_backup_check", group: "cinder_backup" }
   - { name: "glance_api_local_check", group: "glance_api" }
   - { name: "glance_registry_local_check", group: "glance_registry" }
   - { name: "heat_api_local_check", group: "heat_api" }
@@ -388,6 +387,17 @@ openstack_service_local_checks_list:
 
 cinder_vg_checks_list:
   - { name: "cinder_vg_check", group: "cinder_volume", cinder_vg_name: "{{ cinder_vg_name }}" }
+
+#
+# cinder_backup_checks_list: A list of checks for the cinder-backup service
+#
+#   This check was originally part of openstack_service_local_checks_list, but
+#   as cinder-backup is enabled/disabled via
+#   cinder_service_backup_program_enabled in the os_cinder role we have pulled
+#   it out so we can make a separate task conditional on that variable.
+#
+cinder_backup_checks_list:
+  - { name: "cinder_backup_check", group: "cinder_backup" }
 
 swift_checks_list:
   - { name: "swift_object_server_check", group: "swift_obj" }
@@ -479,3 +489,9 @@ openrc_insecure: "{{ (keystone_service_adminuri_insecure | bool or keystone_serv
 # Default horizon site name
 #
 horizon_site_name: "openstack dashboard"
+
+#
+# maas_monitor_cinder_backup: This variable determines if the check for the
+#                             cinder-backup service should be deployed
+#
+maas_monitor_cinder_backup: false

--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -23,4 +23,11 @@
 
 - include: ensure_local_checks.yml
   vars:
+    checks: "{{ cinder_backup_checks_list }}"
+  when:
+    - inventory_hostname in groups["cinder_backup"]
+    - maas_monitor_cinder_backup | bool
+
+- include: ensure_local_checks.yml
+  vars:
     checks: "{{ infra_service_local_checks_list }}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -72,6 +72,8 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
     sed -i "s/lb_name: .*/lb_name: '$(hostname)'/" $RPCD_VARS
     # set the notification_plan to the default for Rackspace Cloud Servers
     sed -i "s/maas_notification_plan: .*/maas_notification_plan: npTechnicalContactsEmail/" $RPCD_VARS
+    # the AIO needs this enabled to test the feature, but $RPCD_VARS defaults this to false
+    sed -i "s/cinder_service_backup_program_enabled: .*/cinder_service_backup_program_enabled: true/" /etc/openstack_deploy/user_variables.yml
     # set network speed for vms
     echo "net_max_speed: 1000" >>$RPCD_VARS
 


### PR DESCRIPTION
The cinder-backup service behaves a little differently as the group
will always exist but the service is only started when the
cinder_service_backup_program_enabled variable is set to True.  As a
result, we remove the cinder-backup check from
openstack_service_local_checks_list and add it to a new variable called
cinder_backup_checks_list.  We then add a new task that adds the checks
in cinder_backup_checks_list conditional on a variable called
maas_monitor_cinder_backup.  The variable maas_monitor_cinder_backup
is assigned the value of cinder_service_backup_program_enabled.
Lastly, we update the deploy script to set
cinder_service_backup_program_enabled to true for testing purposes.

NOTE: the OSA AIO already sets cinder_service_backup_program_enabled to
true, however that user variable file is read first and has a lower
precedence than the other variable files.

Connected #1308

(cherry picked from commit f17699eef729f466861c93c30fb34317cb421404)

Conflicts:
      rpcd/etc/openstack_deploy/user_variables.yml
      scripts/deploy.sh