### PR TITLE
Add upgrade playbook for r13.1

### DIFF
--- a/rpcd/playbooks/run-upgrade.yml
+++ b/rpcd/playbooks/run-upgrade.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Run upgrade from Liberty to Mitaka
+  hosts: all
+  user: root
+  tasks: []


### PR DESCRIPTION
All upgrade related playbooks and tasks will be launched from this one
over-arching playbook to make running and testing upgrades simpler.

Connects rcbops/u-suk-dev#292