### PR TITLE
Enable active-active balancing of repo servers

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -326,7 +326,6 @@ POOL_PARTS = {
         'backend_port': 8181,
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO',
         'group': 'pkg_repo',
-        'priority': True,
         'hosts': []
     }
 }


### PR DESCRIPTION
Prior to this commit repo servers were configured in an F5 pool
which assigns a unique priority to each server. This means
that all requests are forwarded to the first server in the pool
until that server become unavailible. This is active-passive
load balancing.

This commit disables prioritization of of repo servers, which
enables active-active load balancing and forwards connections
under the fastest-connection policy. All servers in the pool
are now treated equally. This change is benificial in that the
load is now spread throughout the repo servers and the
deployment can benifit from the combined power.

Connects #190

(cherry picked from commit 5340c58d8574873901638c3968c2e86d2b12d34e)