### PR TITLE
Add the RPC plays for upgrading

### DIFF
--- a/rpcd/playbooks/run-upgrade.yml
+++ b/rpcd/playbooks/run-upgrade.yml
@@ -17,3 +17,21 @@
   hosts: all
   user: root
   tasks: []
+
+# Include RPC specific playbook runs to upgrade
+- include: rpc-support.yml
+
+- include: horizon_extensions.yml
+
+- include: setup-maas.yml
+
+- include: verify-maas.yml
+
+- include: setup-logging.yml
+
+- name: Post upgrade task
+  hosts: hosts
+  tasks:
+    file:
+      path: "/root/.auth_ref.json"
+      state: absent


### PR DESCRIPTION
Take the playbooks that were called as part of the old rpc-upgrade.sh
script and add them to the run-upgrade.yml playbook as includes.

Additionally, there is a final task that was run as part of the script
that should now run against "hosts" after the logging is setup.

Connects https://github.com/rcbops/u-suk-dev/issues/298