### PR TITLE
Improve role reusability for logstash and filebeat

### DIFF
--- a/rpcd/playbooks/roles/filebeat/meta/main.yml
+++ b/rpcd/playbooks/roles/filebeat/meta/main.yml
@@ -11,3 +11,5 @@ galaxy_info:
     - trusty
 
   galaxy_tags: []
+
+dependencies: []

--- a/rpcd/playbooks/roles/logstash/meta/main.yml
+++ b/rpcd/playbooks/roles/logstash/meta/main.yml
@@ -26,3 +26,5 @@ galaxy_info:
   categories:
     - rackspace
     - logstash
+
+dependencies: []


### PR DESCRIPTION
ansible-galaxy will not install roles that do not contain a dependencies list in the meta file. Even if there are no dependencies there should be an empty list defined.
