### PR TITLE
Overrides wait for ssh delay time

### DIFF
--- a/releasenotes/notes/13.0.0-8158f0be466af558.yaml
+++ b/releasenotes/notes/13.0.0-8158f0be466af558.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - OSA Variable ssh_delay is now overriden to 60 from the osa default of 5.
+fixes:
+  - OSA Variable ssh_delay is now overriden to 60 from the osa default of 5,
+    This is to reduce failures when ansible is attempting to access a container
+    while it is (re)starting.

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -143,3 +143,7 @@ cinder_service_backup_program_enabled: false
 # We need to override the OpenStack upper constraint for Mitaka which is version 1.9.0, We should be able to remove this in Newton as the upper constraint moves to 2.3.0
 repo_build_upper_constraints_overrides:
   - "elasticsearch==2.3.0"
+
+# Increase interval between checks after container start.
+# Reduces the "Wait for container ssh" error.
+ssh_delay: 60


### PR DESCRIPTION
This patch overrides the wait for ssh delay time. This will give
containers longer to start before failing on ssh.

This is to reduce gate failures on "wait for container ssh" which occour
when ansible fails to connect to a container after creation or restart.

Connects rcbops/u-suk-dev#279