### PR TITLE
Ensure ansible group exists before creating checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
@@ -23,6 +23,7 @@
   with_items:
     - "{{ checks }}"
   when:
+    - item.group in group_names
     - inventory_hostname in groups["{{ item.group }}"]
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
@@ -23,6 +23,7 @@
   with_items:
     - "{{ checks }}"
   when:
+    - item.group in group_names
     - groups["{{ item.group }}"]|length > 0
     - inventory_hostname in groups["{{ item.group }}"]
     - inventory_hostname != groups["{{ item.group }}"][0]

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
@@ -23,6 +23,7 @@
   with_items:
     - "{{ checks }}"
   when:
+    - item.group in group_names
     - groups["{{ item.group }}"]|length > 0
     - inventory_hostname == groups["{{ item.group }}"][0]
     - item.name not in maas_excluded_checks


### PR DESCRIPTION
This allows MaaS checks to be defined for optional components/groups. If the
service (and thus ansible group) was configured and deployed, the MaaS checks
are created.  Otherwise, they are skipped.

Connects https://github.com/rcbops/rpc-openstack/issues/1361