### PR TITLE
Remove horizon-extensions cache from repo_all

### DIFF
--- a/releasenotes/notes/rm-horizon-extensions-from-repo-server-3d441a4d0d1c6ad0.yaml
+++ b/releasenotes/notes/rm-horizon-extensions-from-repo-server-3d441a4d0d1c6ad0.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - As the horizon-extensions repo changed in v13.0.0, operators
+    should run ``ansible -m file -a
+    "path=/var/www/repo/openstackgit/horizon-extensions state=absent"
+    repo_all`` prior to upgrading to this release.

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -14,5 +14,18 @@
 # limitations under the License.
 #
 # (c) 2015, Nolan Brubaker <nolan.brubaker@rackspace.com>
-echo 'This release does not support upgrading from Liberty.'
-exit 1
+
+set -eux -o pipefail
+
+BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
+OA_DIR="$BASE_DIR/openstack-ansible"
+RPCD_DIR="$BASE_DIR/rpcd"
+
+# TASK #1
+# Bug: https://github.com/rcbops/rpc-openstack/issues/1345
+# Issue: horizon-extensions now gets pulled from a different location; the
+#        git cache on the repo_all containers needs to be deleted so we can
+#        grab the new repo.  Failing to do this will cause repo-install.yml
+#        to fail to run.
+cd ${RPCD_DIR}/playbooks
+ansible -m file -a "path=/var/www/repo/openstackgit/horizon-extensions state=absent" repo_all


### PR DESCRIPTION
This commit does the following:

1. Removes the horizon-extensions clone from the repo servers as the
   repo has changed and cannot be updated using the method implemented
   in repo-install.yml.
2. Renames upgrade.sh to test-upgrade.sh.  This script will be used for
   testing and gating purposes only, and should not be used for
   production upgrades from Liberty->Mitaka.
3. Adds a new release note outlining step required to clean up repo
   server.

Connected https://github.com/rcbops/rpc-openstack/issues/1345