### PR TITLE
Add rpc-pre-upgrades playbook

### DIFF
--- a/releasenotes/notes/rpc-pre-upgrade-93d419ae17c5e495.yaml
+++ b/releasenotes/notes/rpc-pre-upgrade-93d419ae17c5e495.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - A new role has been created, ``rpc_pre_upgrade`` to
+    assist operators with capturing the state of an
+    environment prior to an upgrade.
+upgrade:
+  - The ``rpc_pre_upgrade`` playbook performs the pre-upgrade
+    steps as outlined in the RPC-O Maintenance Template. Output
+    from the various steps are stored in 
+    ``$HOME/rpc13-upgrade-<date-stamp>`` on the deployment server.
+    These files should be closely examined prior to proceeding
+    with the upgrade.

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pre_upgrade_original_playbook_dir: "/opt/rpc-openstack/"
+
+date_stamp: "{{ ansible_date_time.date }}"
+time_stamp: "{{ ansible_date_time.time }}"
+datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
+local_home: "{{ lookup('env', 'HOME') }}"
+backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/backup.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/backup.yml
@@ -1,0 +1,38 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create upgrade backup directory
+  file:
+    path: "{{ backup_dir }}"
+    state: directory
+
+- name: Backup the /etc/openstack_deploy directory
+  command: "tar czf {{ backup_dir }}/openstack_deploy-{{ datetime_stamp }}.tar.gz /etc/openstack_deploy"
+  tags:
+    - skip_ansible_lint
+
+# Commenting this out for now - I think this is a pointless task, this should be done before anything else happens.
+#- name: Backup original playbooks
+#  command: "tar czf {{ backup_dir }}/rpc-openstack-{{ datetime_stamp }}.tar.gz {{ backup_dir }}"
+
+- name: Perform a DB backup (using xtrabackup)
+  shell: "innobackupex --stream=xbstream --compress - > /var/backup/galera-backup-{{ datetime_stamp }}.xbstream"
+  delegate_to: "{{ groups['galera_all'][0] }}"
+
+- name: Copy xtrabackup
+  synchronize:
+    mode: pull
+    src: "{{ groups['galera_all'][0] }}:/var/backup/galera-backup-{{ datetime_stamp }}.xbstream"
+    dest: "{{ backup_dir }}/galera-backup-{{ datetime_stamp }}.xbstream"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -1,0 +1,75 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Check rabbit cluster status
+  shell: "rabbitmqctl cluster_status"
+  register: rabbitmqctl_result
+  delegate_to: "{{ groups['rabbitmq_all'][0] }}"
+
+- name: Check mysql cluster status
+  shell: "mysql -e \"show status like 'wsrep_clu%'\""
+  register: mysqlstatus_result
+  delegate_to: "{{ groups['galera_all'][0] }}"
+
+- name: Gather nova service-list
+  shell: "source ~/openrc; nova service-list"
+  args:
+    executable: /bin/bash
+  register: nova_servicelist_result
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Gather cinder service-list
+  shell: "source ~/openrc; cinder service-list"
+  register: cinder_servicelist_result
+  args:
+    executable: /bin/bash
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Gather neutron agent-list
+  shell: "source ~/openrc; neutron agent-list"
+  args:
+    executable: /bin/bash
+  register: neutron_agentlist_result
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Gather openstack endpoint list
+  shell: "source ~/openrc; openstack endpoint list"
+  args:
+    executable: /bin/bash
+  register: endpointlist_result
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Gather running instances from mysql
+  shell: "mysql -BN -e \"select uuid from instances where deleted=0 and vm_state='active' order by uuid\" nova"
+  args:
+    executable: /bin/bash
+  register: running_instances_result
+  delegate_to: "{{ groups['galera_all'][0] }}"
+
+- name: Gather instance-volume mappings from mysql
+  shell: "mysql -e \"select v.id,v.provider_location,va.attached_host,va.instance_uuid,va.mountpoint from volumes v join volume_attachment va on v.id = va.volume_id where v.deleted = 0 and v.attach_status='attached'\" cinder"
+  args:
+    executable: /bin/bash
+  register: instance_volume_mappings_result
+  delegate_to: "{{ groups['galera_all'][0] }}"
+
+- name: Output into text file
+  template:
+    src: "{{ item }}.txt.j2"
+    dest: "{{ backup_dir }}/{{ item }}-{{ datetime_stamp }}.txt"
+  with_items:
+    - status
+    - instance-volume-mappings
+    - running-instances

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_swift_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_swift_stats.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Determine running version of swift
+  shell: "pgrep -fao swift | sed -r 's_.*(swift-[0-9.]+).*_\\1_'"
+  register: running_swift
+  delegate_to: "{{ groups['swift_proxy'][0] }}"
+
+- name: Gather swift recon output
+  shell: "/openstack/venvs/{{ running_swift.stdout }}/bin/swift-recon -arul --md5"
+  register: swiftrecon_result
+  delegate_to: "{{ groups['swift_proxy'][0] }}"
+
+- name: Output swift recon stats into text
+  template:
+    src: "swift_recon.txt.j2"
+    dest: "{{ backup_dir }}/swift_recon-{{ datetime_stamp }}.txt"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Rotate openstack aggregate logs
+  shell: 'find /openstack/log -name *\.log -size 64M -ls -exec gzip --suffix -$$.gz {} \;'
+  register: large_logs
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['hosts'] }}"
+
+- name: Compressed logs
+  debug: var=large_logs.stdout_lines
+
+- name: Stop rsyslog
+  service:
+    name: rsyslog
+    state: stopped
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['rsyslog_container'] }}"
+
+- name: Clean up rsyslog forward and state files
+  shell: 'rm -rf /var/spool/rsyslog/srvr* /var/spool/rsyslog/state*'
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['rsyslog_container'] }}"
+  tags:
+    - skip_ansible_lint
+
+- name: Verify directories are empty before proceeding
+  shell: 'du -hcs /var/spool/rsyslog'
+  register: spool_count
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['rsyslog_container'] }}"
+
+- name: Spool directory file counts
+  debug: var=spool_count
+
+- name: Start rsyslog
+  service:
+    name: rsyslog
+    state: started
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['rsyslog_container'] }}"
+
+- name: Restart beaver
+  service:
+    name: beaver
+    state: restarted
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['all'] }}"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Backup database/repository/vars_files
+- include: backup.yml
+
+# Gather info on:
+# OpenStack service status
+# Rabbit/galera cluster status
+# Running instances
+# Volume mappings
+- include: gather_stats.yml
+
+# Gather swift-recon md5 output
+- include: gather_swift_stats.yml
+
+# Perform log rotation and cleanup
+- include: log_rotation.yml
+

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/templates/instance-volume-mappings.txt.j2
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/templates/instance-volume-mappings.txt.j2
@@ -1,0 +1,5 @@
+Instance - volume mappings from mysql as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in instance_volume_mappings_result.stdout_lines %}
+{{ line }}
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/templates/running-instances.txt.j2
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/templates/running-instances.txt.j2
@@ -1,0 +1,5 @@
+Running instances from database as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in running_instances_result.stdout_lines %}
+{{ line }}
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/templates/status.txt.j2
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/templates/status.txt.j2
@@ -1,0 +1,41 @@
+RabbitMQ Cluster status as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in rabbitmqctl_result.stdout_lines %}
+{{ line }}
+{% endfor %}
+
+
+MySQL wsrep var status as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in mysqlstatus_result.stdout_lines %}
+{{ line }}
+{% endfor %}
+
+
+nova service-list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in nova_servicelist_result.stdout_lines %}
+{{ line }}
+{% endfor %}
+
+
+cinder service-list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in cinder_servicelist_result.stdout_lines %}
+{{ line }}
+{% endfor %}
+
+
+neutron agent-list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in neutron_agentlist_result.stdout_lines %}
+{{ line }}
+{% endfor %}
+
+
+openstack endpoint list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+Compare output to external_lb_vip_address: {{ external_lb_vip_address }}
+
+{% for line in endpointlist_result.stdout_lines %}
+{{ line }}
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/templates/swift_recon.txt.j2
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/templates/swift_recon.txt.j2
@@ -1,0 +1,5 @@
+swift-recon output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in swiftrecon_result.stdout_lines %}
+{{ line }}
+{% endfor %}

--- a/rpcd/playbooks/rpc-pre-upgrades.yml
+++ b/rpcd/playbooks/rpc-pre-upgrades.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Setup hosts for rpc-pre-upgrades
+  hosts: localhost
+  user: root
+  roles:
+    - { role: "rpc_pre_upgrade", tags: [ "rpc-pre-upgrades" ] }

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -37,6 +37,14 @@ RPCD_DIR="$BASE_DIR/rpcd"
 rm /etc/openstack_deploy/user_extra_variables.yml /etc/openstack_deploy/user_variables.yml
 
 # TASK #1
+# Bug: https://github.com/rcbops/u-suk-dev/issues/293
+# Issue: We need to analyze support's maintenance plan to determine which
+# pieces we can orchestrate with ansible. This should be added to a
+# pre-upgrade task list.
+cd ${RPCD_DIR}/playbooks
+openstack-ansible rpc-pre-upgrades.yml
+
+# TASK #2
 # Bug: https://github.com/rcbops/u-suk-dev/issues/199
 # Issue: To avoid any dependency issues that have occured in the past, the
 #        repo_server containers are re-built. This was done as part of the


### PR DESCRIPTION
Perform backups of openstack_deploy and the database.
Gather stats of the following:
neutron agent-list
cinder service-list
nova service-list
openstack endpoint list
database output showing running instances
database output showing volume to instance mappings
swift-recon md5

This is based on the maintenance plan set aside by support, and is a
first effort at adding the steps that happen prior to the actual upgrade
happening.

Connects rcbops/u-suk-dev#293