### PR TITLE
Move repo_build_upper_constraints_overrides

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -139,3 +139,7 @@ lxc_container_template_main_apt_repo: "https://mirror.rackspace.com/ubuntu"
 lxc_container_template_security_apt_repo: "https://mirror.rackspace.com/ubuntu"
 
 cinder_service_backup_program_enabled: false
+
+# We need to override the OpenStack upper constraint for Mitaka which is version 1.9.0, We should be able to remove this in Newton as the upper constraint moves to 2.3.0
+repo_build_upper_constraints_overrides:
+  - "elasticsearch==2.3.0"

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -138,7 +138,3 @@ secure_cluster: true
 # List of secure flags to set on for a pool (options for the list are nodelete, nopgchange, nosizechange - prevents deletion, pg from changing and size from changing respectively).
 secure_cluster_flags:
   - nodelete
-
-# We need to override the OpenStack upper constraint for Mitaka which is version 1.9.0, We should be able to remove this in Newton as the upper constraint moves to 2.3.0
-repo_build_upper_constraints_overrides:
-  - "elasticsearch==2.3.0"


### PR DESCRIPTION
The ``repo_build_upper_constraints_overrides`` was defined in the
wrong user_*_variables_defaults.yml file. This fix moves that variable
over to ``user_osa_variables_defaults.yml`` file.

Connects #1363