### PR TITLE
Add playbook for post-upgrade tasks

### DIFF
--- a/releasenotes/notes/add-post-upgrade-role-3821a510f5be4aae.yaml
+++ b/releasenotes/notes/add-post-upgrade-role-3821a510f5be4aae.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - A new role has been created, rpc_post_upgrade, to assist
+    operators with capturing the state of an environment
+    after an upgrade.
+upgrade:
+  - A new role has been created, rpc_post_upgrade, to assist
+    operators with capturing the state of an environment
+    after an upgrade

--- a/rpcd/playbooks/roles/rpc_post_upgrade/README.rst
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/README.rst
@@ -1,0 +1,31 @@
+=======================
+Post Upgrade Procedures
+=======================
+
+An Ansible role that runs operational post-upgrade procedures.
+
+These procedures include:
+
+* Verify ``wsrep_cluster_size`` is equal to the number of Galera hosts in inventory.
+
+* Verify ``wsrep_cluster_status`` for all Galera hosts is ``Primary``.
+
+* Verify the RabbitMQ cluster does not have `network partitions <https://www.rabbitmq.com/partitions.html>`_.
+
+* Verify Nova, Cinder, and Neutron services are reporting in the ``up`` or ``:-)`` status.
+
+* Verify the md5sums of the Swift rings and configuration files have no errors.
+
+* Verify Elasticsearch indexes are reporting ``green`` as their health.
+
+.. note:
+  
+  This role is intentionally littered with debug tasks. This is to help the operator
+  with any questions they may have about the values being checked.
+
+Adding tasks to this role
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If at any point you would like to see a task added to this role, please submit an issue to
+rpc-openstack explaining what you would like to add, and why. Issues can be submitted
+`here <https://github.com/rcbops/rpc-openstack/issues>`_.

--- a/rpcd/playbooks/roles/rpc_post_upgrade/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+elasticsearch_http_port: 9200
+swift_venv_tag: "{{ openstack_release }}"
+swift_venv_bin: "/openstack/venvs/swift-{{ swift_venv_tag }}/bin"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run galera post upgrade tasks
+- include: post-upgrade-galera.yml
+  when: inventory_hostname in groups['galera_all']
+  tags:
+    - galera
+
+# Run rabbitmq post upgrade tasks
+- include: post-upgrade-rabbitmq.yml
+  when: inventory_hostname in groups['rabbitmq']
+  tags:
+    - rabbitmq
+
+# Run openstack services verification tasks
+- include: post-upgrade-utility.yml
+  when: inventory_hostname in groups['utility'][0]
+  tags:
+    - openstack_services
+
+# Run swift verification tasks
+- include: post-upgrade-swift-proxy.yml
+  when: inventory_hostname in groups['swift_proxy']
+  tags:
+    - swift
+
+# Run elasticsearch verification tasks
+- include: post-upgrade-elasticsearch.yml
+  when: inventory_hostname in groups['elasticsearch_container']
+  tags:
+    - elasticsearch

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-elasticsearch.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-elasticsearch.yml
@@ -1,0 +1,48 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check if all elasticsearch indices are "green"
+- name: Grab elastic search URL
+  set_fact:
+    esurl: "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}:{{ elasticsearch_http_port }}"
+
+- name: debug esurl
+  debug: var=esurl
+
+- name: Make sure httplib2 is installed on ES containers
+  pip:
+    name: httplib2
+
+- name: Get elastic search indicies
+  uri:
+    url: "http://{{ esurl }}/_cat/indices?v"
+    return_content: "yes"
+  register: es_indicies
+
+- name: debug es_indicies
+  debug: var=es_indicies
+
+- name: Set ES indicies fact for processing
+  set_fact:
+    es_indicies_list: "{{ es_indicies['content'].split('\n')[1:-1] }}"
+
+- name: debug es_indicies_list
+  debug: var=es_indicies_list
+
+- name: Check ES for green health status
+  debug:
+    var: "{{ item }}"
+  failed_when: "'green' not in \"{{ item }}\""
+  with_items: "{{ es_indicies_list|default([]) }}"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-galera.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-galera.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Confirm wsrep_cluster_size is equal to the amount of galera containers
+  shell: "mysql -e \"show status like 'wsrep_cluster_size'\" | grep wsrep_cluster_size | awk '{print $2}'"
+  register: wsrep_cluster_size
+  failed_when: "'{{ groups['galera_all']|length }}' not in wsrep_cluster_size.stdout or wsrep_cluster_size.rc != 0"
+
+- name: Display wsrep_cluster_size
+  debug: var=wsrep_cluster_size
+
+- name: Confirm wsrep_cluster_status
+  shell: "mysql -e \"show status like 'wsrep_cluster_status'\" | grep wsrep_cluster_status | awk '{print $2}'"
+  register: wsrep_cluster_status
+  failed_when: "'Primary' not in wsrep_cluster_status.stdout or wsrep_cluster_status.rc != 0"
+
+- name: Display wsrep_cluster_status
+  debug: var=wsrep_cluster_status
+

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-rabbitmq.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-rabbitmq.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Grab full output of rabbitmqctl cluster_status
+  command: "rabbitmqctl cluster_status"
+  register: rabbitmqctl_output
+  failed_when: "rabbitmqctl_output.rc != 0"
+
+- name: Display output of rabbitmqctl cluster_status
+  debug: var=rabbitmqctl_output
+
+# Verify rabbit is not partitioned
+# Here we check to see if partitions is empty
+- name: Fail if network partitions are detected
+  fail:
+    msg: "Rabbitmq network partitions have been detected."
+  when: "' {partitions,[]},' not in rabbitmqctl_output.stdout_lines"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-swift-proxy.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-swift-proxy.yml
@@ -1,0 +1,37 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: verify it's OK to check for errors, and that it won't cause
+# this playbook to fail in the case of failures happening under normal circumstances
+
+- name: Grab output of swift-recon --md5
+  shell: |
+    . {{ swift_venv_bin }}/activate
+    swift-recon --md5
+  register: swift_recon_output
+  failed_when: "swift_recon_output.rc != 0"
+
+- name: Display output of swift-recon
+  debug: var=swift_recon_output
+
+- name: Check swift md5s
+  shell: |
+    . {{ swift_venv_bin }}/activate
+    swift-recon --md5 | grep '[1-9][0-9]* error'
+  register: swift_recon
+  failed_when: swift_recon.stdout_lines|length > 0
+
+
+

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -1,0 +1,67 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify services are up and checking in
+- name: Grab relevant output of openstack compute service list
+  shell: |
+    . ~/openrc
+    openstack compute service list -c Binary -c Host -c State -f value
+  register: openstack_output
+  failed_when: "openstack_output.rc != 0"
+
+- name: Display output of openstack compute service list
+  debug: var=openstack_output
+
+- name: Fail if any compute service is in the down state
+  fail:
+    msg: "One or more compute services are in the down state. Check the output above for more detail."
+  when: "'down' in '{{ item.split(' ')[-1] }}'"
+  with_items: openstack_output.stdout_lines|default([])
+
+- name: Grab relevant output of neutron agent-list
+  shell: |
+    . ~/openrc
+    neutron agent-list -c agent_type -c host -c alive -f value
+  register: neutron_output
+  failed_when: "neutron_output.rc != 0"
+
+- name: Display output of neutron agent-list
+  debug: var=neutron_output
+
+- name: Fail if any of the neutron agents are down
+  fail:
+    msg: "One or more of the neutron agents are down. Check the output above for more detail."
+  when: "'xxx' in '{{ item.split(' ')[-1] }}'"
+  with_items: neutron_output.stdout_lines|default([])
+
+# Note: As part of https://github.com/rcbops/u-suk-dev/issues/348,
+# it has been realized that cinder services with the old hostname
+# cannot be deleted. Because of this, any services
+# with '_' in their hostnames must be disregarded as part of this check.
+- name: Grab relevant output of cinder service-list
+  shell: |
+    . ~/openrc
+    cinder service-list | grep -vE 'Status|\+|_' | awk '{print $2, $4, $10}'
+  register: cinder_output
+  failed_when: "cinder_output.rc != 0"
+
+- name: Display output of cinder service-list
+  debug: var=cinder_output
+
+- name: Fail if any of the cinder services are down
+  fail:
+    msg: "One or more of the cinder services are in the down state. Check the output above for more detail."
+  when: "'down' in '{{ item.split(' ')[-1] }}'"
+  with_items: cinder_output.stdout_lines|default([])

--- a/rpcd/playbooks/rpc-post-upgrades.yml
+++ b/rpcd/playbooks/rpc-post-upgrades.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Run post-upgrade tasks
+  hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container
+  user: root
+  any_errors_fatal: true
+  roles:
+    - rpc_post_upgrade

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -45,3 +45,12 @@ rm /etc/openstack_deploy/user_extra_variables.yml /etc/openstack_deploy/user_var
 cd ${OA_DIR}/playbooks
 openstack-ansible lxc-containers-destroy.yml --limit repo_all
 openstack-ansible setup-hosts.yml --limit repo_all
+
+# TASK #2 TODO: This task should be moved somewhere towards the bottom once
+#               we get a more robust script going.
+# Bug: https://github.com/rcbops/u-suk-dev/issues/366
+# Description: Run post-upgrade tasks.
+#              For a detailed description, please see the README in
+#              the rpc_post_upgrade role directory.
+cd ${RPCD_DIR}/playbooks
+openstack-ansible rpc-post-upgrades.yml


### PR DESCRIPTION
This playbooks automates common operational tasks that are usally
performed by support after an upgrade.

Connects https://github.com/rcbops/u-suk-dev/issues/366