### PR TITLE
Set neutron_l2_population default True

### DIFF
--- a/releasenotes/notes/override-l2pop-default-d7426c07d8b72f2e.yaml
+++ b/releasenotes/notes/override-l2pop-default-d7426c07d8b72f2e.yaml
@@ -1,0 +1,10 @@
+---
+issues:
+  - The default value for `neutron_l2_population` has been
+    overridden, which will require deployers to recreate
+    any VXLAN interfaces created with `neutron_l2_population`
+    set `False`. Not recreating these interfaces will lead to
+    connectivity issues for virtual machines.
+upgrade:
+  - Based on feedback from Support, the default value for
+    `neutron_l2_population` has been overridden to `True`.

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -128,6 +128,11 @@ repo_build_pip_extra_indexes:
 # Docs: http://docs.openstack.org/developer/openstack-ansible-security/
 # apply_security_hardening: true
 
+## Enable Neutron l2_population
+# We are overriding the default value for neutron_l2_population. Please see
+# https://github.com/rcbops/rpc-openstack/issues/973 for further details.
+neutron_l2_population: True
+
 # Based on https://github.com/rcbops/rpc-openstack/issues/1149
 # L3HA has to be disabled until all major issues are fixed.
 neutron_neutron_conf_overrides:


### PR DESCRIPTION
Support has found that the new default value of False is causing issues with
stability in customer environments. Given this fact, we are no loger accepting
the default value.

Connects #973