### PR TITLE
Set MTU on existing networks before upgrade

### DIFF
--- a/releasenotes/notes/neutron-upgrade-requires-manual-intervention-b1db98ad8bcade6a.yaml
+++ b/releasenotes/notes/neutron-upgrade-requires-manual-intervention-b1db98ad8bcade6a.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - Existing networks on a Liberty deployment using the
+    ML2 plug-in will require manually updating the MTU
+    value in the neutron.networks table before the upgrade
+    begins.  Failure to do this may result in new
+    instances on existing networks and rebooting existing
+    instances to boot with an incorrect MTU, causing the
+    instances to be inaccessible.  Please see the RPC v13
+    upgrade documentation for more detailed information on
+    how to avoid this situation.


### PR DESCRIPTION
This commit updates test-upgrade.sh to correctly set the correct MTUs
for a gate environment on existing neutron networks.  This needs to be
done /before/ the upgrade starts so that no further restarts are needed
to accomodate this change.

Connects https://github.com/rcbops/u-suk-dev/issues/374