### PR TITLE
Set neutron_l2_population default True

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -96,6 +96,11 @@ swift_ceilometer_enabled: False
 keystone_ceilometer_enabled: False
 tempest_service_available_ceilometer: False
 
+## Enable Neutron l2_population
+# We are overriding the default value for neutron_l2_population. Please see
+# https://github.com/rcbops/rpc-openstack/issues/973 for further details.
+neutron_l2_population: True
+
 # L3HA has to be disabled until all major issues are fixed
 # Based on https://github.com/rcbops/rpc-openstack/issues/1149
 neutron_neutron_conf_overrides:


### PR DESCRIPTION
Support has found that the new default value of False is causing issues with
stability in customer environments. Given this fact, we are no loger accepting
the default value.

Connects #973