### PR TITLE
Overrides wait for ssh delay time

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -144,3 +144,7 @@ lxc_container_template_main_apt_repo: "https://mirror.rackspace.com/ubuntu"
 lxc_container_template_security_apt_repo: "https://mirror.rackspace.com/ubuntu"
 
 cinder_service_backup_program_enabled: false
+
+# Increase interval between checks after container start.
+# Reduces the "Wait for container ssh" error.
+ssh_delay: 60


### PR DESCRIPTION
This patch overrides the wait for ssh delay time. This will give
containers longer to start before failing on ssh.

This is to reduce gate failures on "wait for container ssh" which occour
when ansible fails to connect to a container after creation or restart.

Connects rcbops/u-suk-dev#279

(cherry picked from commit d4ae2b1ee2169a86b5e009e212d1ee39384c3eb3)

Conflicts:
	rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml