### PR TITLE
Overrides wait for ssh delay time

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -137,3 +137,7 @@ lxc_container_template_main_apt_repo: "https://mirror.rackspace.com/ubuntu"
 lxc_container_template_security_apt_repo: "https://mirror.rackspace.com/ubuntu"
 
 cinder_service_backup_program_enabled: false
+
+# Increase interval between checks after container start.
+# Reduces the "Wait for container ssh" error.
+ssh_delay: 60


### PR DESCRIPTION
This patch overrides the wait for ssh delay time. This will give
containers longer to start before failing on ssh.

This is to reduce gate failures on "wait for container ssh" which occour
when ansible fails to connect to a container after creation or restart.

Connects rcbops/u-suk-dev#279

(cherry picked from commit c4fbcc4332b41998a8f60d5f0f0e6f01bc22db72)