### PR TITLE
Overrides wait for ssh delay time

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -76,3 +76,7 @@ ceph_mons: >
   {{ _var }}
 
 cinder_service_backup_program_enabled: false
+
+# Increase interval between checks after container start.
+# Reduces the "Wait for container ssh" error.
+ssh_delay: 60


### PR DESCRIPTION
This patch overrides the wait for ssh delay time. This will give
containers longer to start before failing on ssh.

This is to reduce gate failures on "wait for container ssh" which occour
when ansible fails to connect to a container after creation or restart.

Connects rcbops/u-suk-dev#279