### PR TITLE
Allow unauthenticated APT Mirror

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,6 +18,7 @@ export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-""}
 export ANSIBLE_FORCE_COLOR=${ANSIBLE_FORCE_COLOR:-"true"}
 export BOOTSTRAP_OPTS=${BOOTSTRAP_OPTS:-""}
+export UNAUTHENTICATED_APT=${UNAUTHENTICATED_APT:-no}
 
 OA_DIR='/opt/rpc-openstack/openstack-ansible'
 RPCD_DIR='/opt/rpc-openstack/rpcd'
@@ -180,8 +181,13 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
     run_ansible haproxy-install.yml
   fi
 
-  # setup the hosts and build the basic containers
-  run_ansible setup-hosts.yml
+  # We have to skip V-38462 when using an unauthenticated mirror
+  # V-38660 is skipped for compatibility with Ubuntu Xenial
+  if [[ ${UNAUTHENTICATED_APT} == "yes" && ${DEPLOY_HARDENING} == "yes" ]]; then
+    run_ansible setup-hosts.yml --skip-tags=V-38462,V-38660
+  else
+    run_ansible setup-hosts.yml
+  fi
 
   # ensure correct pip.conf
   pushd ${RPCD_DIR}/playbooks/


### PR DESCRIPTION
Openstack infra provide APT mirrors, but they are not signed. In order
to make use of these for gating it is necessary to disable security
hardening rule V-38462.

Connects rcbops/u-suk-dev#300

(cherry picked from commit 72a51b435cefeacb1e851209d9ed4b66dd931475)