### PR TITLE
Add OSA upgrade script to test-upgrade.sh

### DIFF
--- a/releasenotes/notes/security-hardening-upgrade-69d0bca94fdc7df9.yaml
+++ b/releasenotes/notes/security-hardening-upgrade-69d0bca94fdc7df9.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - >
+    By default security hardening is applied on upgrade. If you wish to prevent its application you must ensure the openstack-ansible playbook security-hardening.yml
+    skips its tasks during an upgrade by adding 'apply_security_hardening: false' to /etc/openstack_deploy/user_osa_variables_overrides.yml.

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -54,7 +54,15 @@ cd ${OA_DIR}/playbooks
 openstack-ansible lxc-containers-destroy.yml --limit repo_all
 openstack-ansible setup-hosts.yml --limit repo_all
 
-# TASK #2 TODO: This task should be moved somewhere towards the bottom once
+# TASK #3
+# https://github.com/rcbops/u-suk-dev/issues/392
+# Upgrade openstack-ansible
+pushd ${OA_DIR}
+export I_REALLY_KNOW_WHAT_I_AM_DOING=true
+echo "YES" | ${OA_DIR}/scripts/run-upgrade.sh
+popd
+
+# TASK #4 TODO: This task should be moved somewhere towards the bottom once
 #               we get a more robust script going.
 # Bug: https://github.com/rcbops/u-suk-dev/issues/366
 # Description: Run post-upgrade tasks.


### PR DESCRIPTION
One of the steps when performing an upgrade from Liberty to Mitaka will
be to run OSA's upgrade script, run-upgrade.sh. To enable us to perform
a tested upgrade this commit adds run-upgrade.sh to the RPCO test script
test-upgrade.sh.

A release note is also added to ensure that security hardening is
disabled where necessary. Currently deploy.sh manages that with an
enviroment variable but that is not feasible in this situation.

Connected https://github.com/rcbops/u-suk-dev/issues/392