### PR TITLE
Added RPCO bits to test-upgrade and..

### DIFF
--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e -u -x
+set -o pipefail
+
+source ${BASE_DIR}/scripts/functions.sh
+
+# begin the RPC installation
+cd ${RPCD_DIR}/playbooks/
+
+# configure everything for RPC support access
+run_ansible rpc-support.yml
+
+# configure the horizon extensions
+run_ansible horizon_extensions.yml
+
+# deploy and configure RAX MaaS
+if [[ "${DEPLOY_MAAS}" == "yes" ]]; then
+  run_ansible setup-maas.yml
+  run_ansible verify-maas.yml
+fi
+
+# deploy and configure the ELK stack
+if [[ "${DEPLOY_ELK}" == "yes" ]]; then
+  run_ansible setup-logging.yml
+
+  # deploy the LB required for the ELK stack
+  if [[ "${DEPLOY_HAPROXY}" == "yes" ]]; then
+    run_ansible haproxy.yml
+  fi
+fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-''}
+export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
+
+function run_ansible {
+  openstack-ansible ${ANSIBLE_PARAMETERS} --forks ${FORKS} $@
+}

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -18,34 +18,68 @@
 
 set -eux -o pipefail
 
-BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
-OA_DIR="$BASE_DIR/openstack-ansible"
-RPCD_DIR="$BASE_DIR/rpcd"
+export BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
+export OA_DIR="$BASE_DIR/openstack-ansible"
+export RPCD_DIR="$BASE_DIR/rpcd"
+
+source ${BASE_DIR}/scripts/functions.sh
 
 # TASK #0
 # Bug: https://github.com/rcbops/u-suk-dev/issues/347
 # Issue: Variables files have been reorganized, run a migration script to move
 #        them to the new location.
-"${BASE_DIR}"/scripts/migrate-yaml.py --for-testing-take-new-vars-only \
-    --defaults "${RPCD_DIR}"/etc/openstack_deploy/user_rpco_variables_defaults.yml \
-    --overrides /etc/openstack_deploy/user_extras_variables.yml \
-    --output-file /etc/openstack_deploy/user_rpco_variables_overrides.yml
-"${BASE_DIR}"/scripts/migrate-yaml.py --for-testing-take-new-vars-only \
-  --defaults "${RPCD_DIR}"/etc/openstack_deploy/user_osa_variables_defaults.yml \
-  --overrides /etc/openstack_deploy/user_variables.yml \
-  --output-file /etc/openstack_deploy/user_osa_variables_overrides.yml
+# WARNING: In no way should the migrate-yaml.py script be run with
+#          --for-testing-take-new-vars-only in production environments.
+if [[ ! -f "/etc/openstack_deploy/user_rpco_variables_overrides.yml" ]]; then
+  "${BASE_DIR}"/scripts/migrate-yaml.py --for-testing-take-new-vars-only \
+      --defaults "${RPCD_DIR}"/etc/openstack_deploy/user_rpco_variables_defaults.yml \
+      --overrides /etc/openstack_deploy/user_extras_variables.yml \
+      --output-file /etc/openstack_deploy/user_rpco_variables_overrides.yml
+  rm -f /etc/openstack_deploy/user_extras_variables.yml
+fi
+if [[ ! -f "/etc/openstack_deploy/user_osa_variables_overrides.yml" ]]; then
+  "${BASE_DIR}"/scripts/migrate-yaml.py --for-testing-take-new-vars-only \
+    --defaults "${RPCD_DIR}"/etc/openstack_deploy/user_osa_variables_defaults.yml \
+    --overrides /etc/openstack_deploy/user_variables.yml \
+    --output-file /etc/openstack_deploy/user_osa_variables_overrides.yml
+  rm -f /etc/openstack_deploy/user_variables.yml
+fi
+# TODO: We need to eventually find a proper way to migrate these secret variables.
+#       For now, we just copy existing secret variables defined previously on the
+#       liberty install. This won't cause any problems since there aren't any new
+#       secret variables in mitaka that are not defined in liberty.
+if [[ -f "/etc/openstack_deploy/user_extras_secrets.yml" ]]; then
+  mv /etc/openstack_deploy/user_extras_secrets.yml \
+     /etc/openstack_deploy/user_rpco_secrets.yml
+fi
+if [[ -f "/etc/openstack_deploy/user_secrets.yml" ]]; then
+  mv /etc/openstack_deploy/user_secrets.yml \
+     /etc/openstack_deploy/user_osa_secrets.yml
+fi
 cp -a ${RPCD_DIR}/etc/openstack_deploy/*defaults* /etc/openstack_deploy
-rm /etc/openstack_deploy/user_extras_variables.yml /etc/openstack_deploy/user_variables.yml
 
 # TASK #1
-# Bug: https://github.com/rcbops/u-suk-dev/issues/293
+# Update Ansible
+if [[ -f "/root/.pip/pip.conf" ]]; then
+  rm /root/.pip/pip.conf
+fi
+cd ${OA_DIR}
+bash scripts/bootstrap-ansible.sh
+
+# TASK #2
+# Update the rpc-openstack galaxy modules
+ansible-galaxy install --role-file=${BASE_DIR}/ansible-role-requirements.yml --force \
+--roles-path=${RPCD_DIR}/playbooks/roles
+
+# TASK #3
+# Bug:   https://github.com/rcbops/u-suk-dev/issues/293
 # Issue: We need to analyze support's maintenance plan to determine which
 # pieces we can orchestrate with ansible. This should be added to a
 # pre-upgrade task list.
 cd ${RPCD_DIR}/playbooks
 openstack-ansible rpc-pre-upgrades.yml
 
-# TASK #2
+# TASK #4
 # Bug: https://github.com/rcbops/u-suk-dev/issues/199
 # Issue: To avoid any dependency issues that have occured in the past, the
 #        repo_server containers are re-built. This was done as part of the
@@ -55,8 +89,8 @@ cd ${OA_DIR}/playbooks
 openstack-ansible lxc-containers-destroy.yml --limit repo_all
 openstack-ansible setup-hosts.yml --limit repo_all
 
-# TASK #3
-# Bug: https://github.com/rcbops/u-suk-dev/issues/374
+# TASK #5
+# Bug:   https://github.com/rcbops/u-suk-dev/issues/374
 # Issue: Neutron has no migration to correctly set the MTU on existing networks
 #        created in liberty or below.  This work-around sets the MTU on these
 #        networks before the upgrade starts so that instances booted on these
@@ -71,7 +105,7 @@ cd ${OA_DIR}/playbooks
 ansible galera_all[0] -m shell -a "mysql --verbose -e \"${VLAN_FLAT}\" neutron"
 ansible galera_all[0] -m shell -a "mysql --verbose -e \"${VXLAN}\" neutron"
 
-# TASK #4
+# TASK #6
 # https://github.com/rcbops/u-suk-dev/issues/392
 # Upgrade openstack-ansible
 pushd ${OA_DIR}
@@ -79,8 +113,17 @@ export I_REALLY_KNOW_WHAT_I_AM_DOING=true
 echo "YES" | ${OA_DIR}/scripts/run-upgrade.sh
 popd
 
-# TASK #5 TODO: This task should be moved somewhere towards the bottom once
-#               we get a more robust script going.
+# TASK #7
+# https://github.com/rcbops/u-suk-dev/issues/393
+# Run deploy-rpc-playbooks.sh
+# Ultimitely, this will run the RPCO playbooks.
+cd ${BASE_DIR}
+export DEPLOY_HAPROXY=${DEPLOY_HAPROXY:-"no"}
+export DEPLOY_ELK=${DEPLOY_ELK:-"yes"}
+export DEPLOY_MAAS=${DEPLOY_MAAS:-"yes"}
+bash scripts/deploy-rpc-playbooks.sh
+
+# TASK #8
 # Bug: https://github.com/rcbops/u-suk-dev/issues/366
 # Description: Run post-upgrade tasks.
 #              For a detailed description, please see the README in


### PR DESCRIPTION
Also moved the rpc playbook bits from deploy.sh into
it's own script, deploy-rpc-playbooks.sh. This is so
those bits can be easily included in test-upgrades.sh and in
deploy.sh.
I moved the run_ansible function previously defined in deploy.sh to a new file, ``functions.sh``, that is
then sourced by both ``deploy.sh`` and ``test-upgrades.sh``.
The bash environment variables is another matter. For now, I just exported what seemed necessary into the environment so the variables can be carried over to the next script. However, we should look into creating a more streamlined way to manage these variables later. Perhaps move the variables into their own file, that other scripts can then source.

Connects https://github.com/rcbops/u-suk-dev/issues/393