### PR TITLE
Set rpc_openstack_repo var using git_repo_info

### DIFF
--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -24,5 +24,16 @@
 - name: Install MaaS
   hosts: hosts:all_containers
   user: root
+  pre_tasks:
+    # This is needed to set the rpc_openstack_repo and rpc_release variables
+    # correctly
+    - name: Discover rpc-openstack version
+      git_repo_info:
+        path: "/opt/rpc-openstack"
+      delegate_to: localhost
+      run_once: true
+    - name: Display rpc_release variable
+      debug: var=rpc_release
+      run_once: true
   roles:
     - { role: "rpc_maas", tags: [ "maas-setup" ] }

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -17,6 +17,16 @@
   hosts: hosts
   user: root
   tasks:
+    # This is needed to set the rpc_openstack_repo and rpc_release variables
+    # correctly
+    - name: Discover rpc-openstack version
+      git_repo_info:
+        path: "/opt/rpc-openstack"
+      delegate_to: localhost
+      run_once: true
+    - name: Display rpc_release variable
+      debug: var=rpc_release
+      run_once: true
     - name: ensure remote directory
       file:
         path: "{{ maas_rpc_scripts_dir }}"


### PR DESCRIPTION
This commit updates setup-maas.yml and verify-maas.yml to discover and
set rpc_openstack_repo variable (which is used to set rpc_release).
This is needed by both playbooks (and the rpc_maas role) to correctly
create and use the maas venv in /openstack/venvs.  Unless these
playbooks are run in conjunction with rpc-support.yml (which runs
git_repo_info), the value of rpc_release will default to UNKNOWN.
By running in git_repo_info in all the necessary playbooks and roles
means that rpc-support.yml, setup-maas.yml, and verify-maas.yml can
all be run independently and still have the same values for
rpc_openstack_repo and rpc_release.

Connects https://github.com/rcbops/u-suk-dev/issues/397

(cherry picked from commit 2e10437fe437e51f328e6fbc49ce0f139f149183)