### PR TITLE
Resolve pip_lock_down and maas_common issues

### DIFF
--- a/maas/plugins/maas_common.py
+++ b/maas/plugins/maas_common.py
@@ -195,7 +195,7 @@ else:
         return nova
 
 try:
-    from keystoneclient.openstack.common.apiclient import exceptions as k_exc
+    from keystoneclient import exceptions as k_exc
     from keystoneclient.v2_0 import client as k2_client
     from keystoneclient.v3 import client as k3_client
 except ImportError:

--- a/rpcd/playbooks/roles/horizon_extensions/meta/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/meta/main.yml
@@ -15,3 +15,6 @@ galaxy_info:
     - heat
     - development
     - openstack
+
+dependencies:
+  - pip_lock_down

--- a/rpcd/playbooks/roles/rpc_maas/meta/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/meta/main.yml
@@ -29,3 +29,6 @@ galaxy_info:
     - MaaS
     - development
     - openstack
+
+dependencies:
+  - pip_lock_down

--- a/rpcd/playbooks/roles/rpc_support/meta/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/meta/main.yml
@@ -27,3 +27,6 @@ galaxy_info:
     - support
     - rackspace
     - backups
+
+dependencies:
+  - pip_lock_down


### PR DESCRIPTION
The rpc_maas role needs to depend on the pip_lock_down role, otherwise
the openstack clients and other pip packages are not installed from the
repo server.

To prevent this issue occuring on other roles that perform pip installs,
and to keep the roles consistent, this PR adds the pip_lock_down
dependency to the rpc_support and horizon_extensions roles.

This will prevent us from having to run "pip-lockdown" against hosts
unnecessarily.

Additionally, in the next version of python-keystoneclient
apiclient.exceptions will be removed, as per:
https://review.openstack.org/#/c/257127/ - we can fix this in advance by
following the recommendation and use keystoneclient.exceptions. This
won't affect current releases but will future proof for upgrades to the
Newton cycle (and above).

Connects #1404