### PR TITLE
Handle cases where beaver/swift are not installed

### DIFF
--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
@@ -52,9 +52,17 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['rsyslog_container'] }}"
 
-- name: Restart beaver
+- name: Check if beaver is installed
+  stat:
+    path: /etc/init.d/beaver
+  register: beaver_init_script
+  with_items: "{{ groups['all'] }}"
+  delegate_to: "{{ item }}"
+
+- name: Restart beaver if installed
   service:
     name: beaver
     state: restarted
-  delegate_to: "{{ item }}"
-  with_items: "{{ groups['all'] }}"
+  with_items: beaver_init_script.results
+  when: item.stat.exists
+  delegate_to: "{{ item.item }}"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/main.yml
@@ -25,6 +25,7 @@
 
 # Gather swift-recon md5 output
 - include: gather_swift_stats.yml
+  when: groups['swift_proxy']|default([])|length > 0
 
 # Perform log rotation and cleanup
 - include: log_rotation.yml


### PR DESCRIPTION
This commit updates rpc_pre_upgrade to only run gather_swift_stats.yml
when swift is installed (groups['swift_proxy']|length > 0).
Additionally, we update log_rotation.yml to first check if beaver is
installed, and then only restart it if the init script exists.

Connects https://github.com/rcbops/u-suk-dev/issues/407