### PR TITLE
Always lay down pip.conf on RPCD plays

### DIFF
--- a/rpcd/playbooks/horizon_extensions.yml
+++ b/rpcd/playbooks/horizon_extensions.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: pip-lockdown.yml
+
 - hosts: horizon_all
   user: root
   roles:

--- a/rpcd/playbooks/rpc-support.yml
+++ b/rpcd/playbooks/rpc-support.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: pip-lockdown.yml
+
 - name: Setup hosts for rpc-support
   hosts: hosts:all_containers
   user: root

--- a/rpcd/playbooks/setup-logging.yml
+++ b/rpcd/playbooks/setup-logging.yml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: pip-lockdown.yml
 - include: elasticsearch.yml
 - include: logstash.yml
 - include: kibana.yml

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: pip-lockdown.yml
+
 - name: Gather mons facts for ceph.conf template
   hosts: mons
 


### PR DESCRIPTION
This fix ensures that a proper pip.conf is layed down
before installing RPC-O components.
This furthermore ensures that upon deploy/upgrade.sh script errors
manual continued playbook installation will install the right pip
packages based on the correct OSA version.

Closes-Bug: #1391