### PR TITLE
Remove trailing comma and leading space in match

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-rabbitmq.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-rabbitmq.yml
@@ -26,4 +26,4 @@
 - name: Fail if network partitions are detected
   fail:
     msg: "Rabbitmq network partitions have been detected."
-  when: "' {partitions,[]},' not in rabbitmqctl_output.stdout_lines"
+  when: "'{partitions,[]}' not in rabbitmqctl_output.stdout_lines"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-rabbitmq.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-rabbitmq.yml
@@ -26,4 +26,4 @@
 - name: Fail if network partitions are detected
   fail:
     msg: "Rabbitmq network partitions have been detected."
-  when: "'{partitions,[]}' not in rabbitmqctl_output.stdout_lines"
+  when: "'{partitions,[]}' not in rabbitmqctl_output.stdout"


### PR DESCRIPTION
@mancdaz Opened issue #1407 but then closed it since it occurred due to a failed rabbitmq installation/upgrade. However, I noticed that the reason why this string match failed is because it assumes the "partitions" variable in the cluster_status output will be the last item in the JSON array, thus it looks for a closing "]". It also assumes a leading space. The broken environment @mancdaz was testing against instead had a trailing "," as the partitions item wasn't the last in the array.

This PR trims down the match string so it will be suitable for more situations.

Fixes #1414