### PR TITLE
Retry Maas Status Verification

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -38,6 +38,12 @@
       script: >
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status
         --entity {{ inventory_hostname }}{{ maas_fqdn_extension }}
+      register: verify_status
+      failed_when: verify_status.rc != 0
+      changed_when: False
+      until: verify_status.rc == 0
+      retries: 10
+      delay: 60
 
   vars_files:
     - "roles/rpc_maas/defaults/main.yml"


### PR DESCRIPTION
MaaS operations sometimes fail due to transient issues with the API.
This should not cause a gate run to fail, so MaaS operations should be
retried.

This bug is only present in kilo, but this is still a problem as we do
kilo deploys and upgrades from kilo.

This was fixed in master in rcbops/rpc-openstack#904
Connects rcbops/u-suk-dev#413