### PR TITLE
set OS_INTERFACE=internal for openstack commands

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -16,6 +16,7 @@
 # Verify services are up and checking in
 - name: Grab relevant output of openstack compute service list
   shell: |
+    export OS_INTERFACE=internal
     . ~/openrc
     openstack compute service list -c Binary -c Host -c State -f value
   register: openstack_output
@@ -32,6 +33,7 @@
 
 - name: Grab relevant output of neutron agent-list
   shell: |
+    export OS_INTERFACE=internal
     . ~/openrc
     neutron agent-list -c agent_type -c host -c alive -f value
   register: neutron_output


### PR DESCRIPTION
The "openstack compute service list" command will default to use the
publicURL, this will be addressed in OSA - but as a workaround for now
we can export the value to ensure this works.

Connects https://github.com/rcbops/u-suk-dev/issues/417