### PR TITLE
Add link to RPC Gating Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,6 @@ version specification:
 ```
 ANSIBLE_VERSION='>=2.0' tox -e ansible-lint
 ```
+
+# Gating
+Please see the documentation in [jenkins-rpc/README.md](https://github.com/rcbops/jenkins-rpc/blob/master/README.md)


### PR DESCRIPTION
Adds a link to the gating documentation in jenkins-rpc.

Connects rcbops/u-suk-dev#224