### PR TITLE
Move beaver restart to it's own play

### DIFF
--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
@@ -51,18 +51,3 @@
     state: started
   delegate_to: "{{ item }}"
   with_items: "{{ groups['rsyslog_container'] }}"
-
-- name: Check if beaver is installed
-  stat:
-    path: /etc/init.d/beaver
-  register: beaver_init_script
-  with_items: "{{ groups['all'] }}"
-  delegate_to: "{{ item }}"
-
-- name: Restart beaver if installed
-  service:
-    name: beaver
-    state: restarted
-  with_items: beaver_init_script.results
-  when: item.stat.exists
-  delegate_to: "{{ item.item }}"

--- a/rpcd/playbooks/rpc-pre-upgrades.yml
+++ b/rpcd/playbooks/rpc-pre-upgrades.yml
@@ -18,3 +18,19 @@
   user: root
   roles:
     - { role: "rpc_pre_upgrade", tags: [ "rpc-pre-upgrades" ] }
+
+- name: restart beaver
+  hosts: all
+  tags:
+    - rpc-pre-upgrades
+  tasks:
+    - name: Check if beaver is installed
+      stat:
+        path: /etc/init.d/beaver
+      register: beaver_init_script
+
+    - name: Restart beaver if installed
+      service:
+        name: beaver
+        state: restarted
+      when: beaver_init_script.stat.exists


### PR DESCRIPTION
The way we currently do the beaver restarts means that it takes an
inordinate amount of time to restart beaver across all hosts.

This commit moves the beaver restart tasks to their own play so that
they can be targeted at the correct hosts in the way that ansible is
designed to be used.

An example of the difference this makes to the timings, from an AIO:

OLD WAY:

```
PLAY RECAP ********************************************************************
rpc_pre_upgrade | Restart beaver if installed ------------------------- 445.65s
rpc_pre_upgrade | Check if beaver is installed ------------------------- 45.07s

real       8m13.294s
user       0m10.392s
sys        0m1.471s
```

NEW WAY:

```
PLAY RECAP ********************************************************************
Restart beaver if installed -------------------------------------------- 41.22s
Check if beaver is installed -------------------------------------------- 1.42s

real       0m51.494s
user       0m4.022s
sys        0m1.427s
```

Connected #1419