### PR TITLE
verify-maas delay and retry now configurable

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -512,3 +512,13 @@ horizon_site_name: "openstack dashboard"
 #                             cinder-backup service should be deployed
 #
 maas_monitor_cinder_backup: false
+
+#
+# verify_maas_delay: How long to wait between failures if there is one
+#
+verify_maas_delay: 20
+
+#
+# verify_maas_retries: How many times to retry on failure
+#
+verify_maas_retries: 5

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -49,8 +49,8 @@
       failed_when: verify_maas.rc != 0
       changed_when: False
       until: verify_maas.rc == 0
-      retries: 8
-      delay: 60
+      retries: "{{ verify_maas_retries }}"
+      delay: "{{ verify_maas_delay }}"
 
     - name: "Allow MAAS time to run checks before verifying their status"
       pause:
@@ -67,8 +67,8 @@
       failed_when: verify_status.rc != 0
       changed_when: False
       until: verify_status.rc == 0
-      retries: 8
-      delay: 60
+      retries: "{{ verify_maas_retries }}"
+      delay: "{{ verify_maas_delay }}"
 
   vars_files:
     - "roles/rpc_maas/defaults/main.yml"


### PR DESCRIPTION
Currently, the values set were chosen because alarms and
checks needed time to return to a healthy status after an
upgrade[1]. However, such a high amount of time isn't needed
for the AIOs in gate. I've decreased the default number of
retries and delay, but also moved them to defaults/main.yml.
This commit makes two variables ``verify_maas_delay`` and
``verify_maas_retries``.

[1] https://github.com/rcbops/rpc-openstack/commit/033027b6b52342a870be94344914391e0db2887c

Connects https://github.com/rcbops/u-suk-dev/issues/451