### PR TITLE
Branding release note

### DIFF
--- a/releasenotes/notes/branding-de80e7d9c1392e69.yaml
+++ b/releasenotes/notes/branding-de80e7d9c1392e69.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - This release fixes a race condition where the
+    branding could be overriden depending on the playbook
+    execution order. Deployers have to make sure the
+    `horizon_custom_uploads` and the
+    `rackspace_static_files_folder` from
+    `rpcd/etc/user_variables.yml` are properly copied
+    into `/etc/openstack_deploy/user_variables.yml`.


### PR DESCRIPTION
Our 12.2 branch is lacking release notes for its branding.

Connected #1088

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>