### PR TITLE
[WIP] Update deploy.sh to write to overrides files

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -122,11 +122,11 @@ repo_build_pip_extra_indexes:
 
 ## Host security hardening
 # The openstack-ansible-security role provides security hardening for hosts
-# by applying security configurations from the STIG. Hardening is disabled by
-# default, but an option to opt-in is available by setting the following
-# variable to 'true'.
+# by applying security configurations from the STIG. Hardening is enabled by
+# default, but an option to opt-out is available by setting the following
+# variable to 'false' in /etc/openstack_deploy/user_osa_variables_overrides.yml.
 # Docs: http://docs.openstack.org/developer/openstack-ansible-security/
-# apply_security_hardening: true
+apply_security_hardening: true
 
 ## Enable Neutron l2_population
 # We are overriding the default value for neutron_l2_population. Please see

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,11 +20,22 @@ export UNAUTHENTICATED_APT=${UNAUTHENTICATED_APT:-no}
 
 export BASE_DIR='/opt/rpc-openstack'
 export OA_DIR='/opt/rpc-openstack/openstack-ansible'
+export OA_OVERRIDES='/etc/openstack_deploy/user_osa_variables_overrides.yml'
 export RPCD_DIR='/opt/rpc-openstack/rpcd'
-export RPCD_VARS='/etc/openstack_deploy/user_rpco_variables_defaults.yml'
+export RPCD_OVERRIDES='/etc/openstack_deploy/user_rpco_variables_overrides.yml'
 export RPCD_SECRETS='/etc/openstack_deploy/user_rpco_secrets.yml'
 
 source ${BASE_DIR}/scripts/functions.sh
+
+if [[ "$DEPLOY_AIO" != "yes" ]] && [[ "$DEPLOY_HARDENING" != "yes" ]]; then
+  echo "** DEPLOY_HARDENING should no longer be used **"
+  echo "To disable security hardening, please add the following line to"
+  echo "/etc/openstack_deploy/user_osa_variables_overrides.yml and then"
+  echo "re-run this script:"
+  echo ""
+  echo "apply_security_hardening: false"
+  exit 1
+fi
 
 # begin the bootstrap process
 cd ${OA_DIR}
@@ -66,17 +77,17 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
       done
     popd
     # ensure that the elasticsearch JVM heap size is limited
-    sed -i 's/# elasticsearch_heap_size_mb/elasticsearch_heap_size_mb/' $RPCD_VARS
+    echo "elasticsearch_heap_size_mb: 1024" >> $RPCD_OVERRIDES
     # set the kibana admin password
     sed -i "s/kibana_password:.*/kibana_password: ${ADMIN_PASSWORD}/" $RPCD_SECRETS
     # set the load balancer name to the host's name
-    sed -i "s/lb_name: .*/lb_name: '$(hostname)'/" $RPCD_VARS
+    echo "lb_name: '$(hostname)'" >> $RPCD_OVERRIDES
     # set the notification_plan to the default for Rackspace Cloud Servers
-    sed -i "s/maas_notification_plan: .*/maas_notification_plan: npTechnicalContactsEmail/" $RPCD_VARS
-    # the AIO needs this enabled to test the feature, but $RPCD_VARS defaults this to false
-    sed -i "s/cinder_service_backup_program_enabled: .*/cinder_service_backup_program_enabled: true/" /etc/openstack_deploy/user_osa_variables_defaults.yml
+    echo "maas_notification_plan: npTechnicalContactsEmail" >> $RPCD_OVERRIDES
+    # the AIO needs this enabled to test the feature, but user_rpco_variables_defaults.yml defaults this to false
+    echo "cinder_service_backup_program_enabled: true" >> $OA_OVERRIDES
     # set network speed for vms
-    echo "net_max_speed: 1000" >>$RPCD_VARS
+    echo "net_max_speed: 1000" >> $RPCD_OVERRIDES
 
     # set the necessary bits for ceph
     if [[ "$DEPLOY_CEPH" == "yes" ]]; then
@@ -86,22 +97,27 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
       # so the MONs think we have 3 OSDs on different hosts.
       sed -i 's/is_metal: true/is_metal: false/' /etc/openstack_deploy/env.d/ceph.yml
 
-      sed -i "s/journal_size:.*/journal_size: 1024/" $RPCD_VARS
-      echo "monitor_interface: eth1" | tee -a $RPCD_VARS
-      echo "public_network: 172.29.236.0/22" | tee -a $RPCD_VARS
-      sed -i "s/raw_multi_journal:.*/raw_multi_journal: false/" $RPCD_VARS
-      echo "osd_directory: true" | tee -a $RPCD_VARS
-      echo "osd_directories:" | tee -a $RPCD_VARS
-      echo "  - /var/lib/ceph/osd/mydir1" | tee -a $RPCD_VARS
-      echo "glance_default_store: rbd" | tee -a /etc/openstack_deploy/user_osa_variables_defaults.yml
-      echo "nova_libvirt_images_rbd_pool: vms" | tee -a $RPCD_VARS
+      echo "journal_size: 1024" >> $RPCD_OVERRIDES
+      echo "monitor_interface: eth1" >> $RPCD_OVERRIDES
+      echo "public_network: 172.29.236.0/22" >> $RPCD_OVERRIDES
+      echo "raw_multi_journal: false" >> $RPCD_OVERRIDES
+      echo "osd_directory: true" >> $RPCD_OVERRIDES
+      echo "osd_directories:" >> $RPCD_OVERRIDES
+      echo "  - /var/lib/ceph/osd/mydir1" >> $RPCD_OVERRIDES
+      echo "glance_default_store: rbd" >> $OA_OVERRIDES
+      echo "nova_libvirt_images_rbd_pool: vms" >> $OA_OVERRIDES
     else
       if [[ "$DEPLOY_SWIFT" == "yes" ]]; then
-        echo "glance_default_store: swift" | tee -a /etc/openstack_deploy/user_osa_variables_defaults.yml
+        echo "glance_default_store: swift" >> $OA_OVERRIDES
       else
-        echo "glance_default_store: file" | tee -a /etc/openstack_deploy/user_osa_variables_defaults.yml
+        echo "glance_default_store: file" >> $OA_OVERRIDES
       fi
     fi
+
+    if [[ "$DEPLOY_HARDENING" != "yes" ]]; then
+      echo "apply_security_hardening: false" >> $OA_OVERRIDES
+    fi
+
     # set the ansible inventory hostname to the host's name
     sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
     # set the affinity to 3 for infra cluster (necessary for maas testing)
@@ -122,22 +138,6 @@ if [[ ! -f /etc/openstack_deploy/user_osa_secrets.yml ]] && [[ -f /etc/openstack
   mv /etc/openstack_deploy/user_secrets.yml /etc/openstack_deploy/user_osa_secrets.yml
 fi
 
-# Apply host security hardening with openstack-ansible-security
-# The is applied as part of setup-hosts.yml
-if [[ "$DEPLOY_HARDENING" == "yes" ]]; then
-  if grep -q '^apply_security_hardening:' /etc/openstack_deploy/user_osa_variables_defaults.yml; then
-    sed -i "s/^apply_security_hardening:.*/apply_security_hardening: true/" /etc/openstack_deploy/user_osa_variables_defaults.yml
-  else
-    echo "apply_security_hardening: true" >> /etc/openstack_deploy/user_osa_variables_defaults.yml
-  fi
-else
-  if grep -q '^apply_security_hardening:' /etc/openstack_deploy/user_osa_variables_defaults.yml; then
-    sed -i "s/^apply_security_hardening:.*/apply_security_hardening: false/" /etc/openstack_deploy/user_osa_variables_defaults.yml
-  else
-    echo "apply_security_hardening: false" >> /etc/openstack_deploy/user_osa_variables_defaults.yml
-  fi
-fi
-
 # ensure all needed passwords and tokens are generated
 ./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_osa_secrets.yml
 ./scripts/pw-token-gen.py --file $RPCD_SECRETS
@@ -148,11 +148,11 @@ openstack-ansible -i "localhost," patcher.yml
 
 # set permissions and lay down overrides files
 chmod 0440 /etc/openstack_deploy/user_*_defaults.yml
-if [[ ! -f /etc/openstack_deploy/user_osa_variables_overrides.yml ]]; then
-  cp "${RPCD_DIR}"/etc/openstack_deploy/user_osa_variables_overrides.yml /etc/openstack_deploy/user_osa_variables_overrides.yml
+if [[ ! -f "$OA_OVERRIDES" ]]; then
+  cp "${RPCD_DIR}"/etc/openstack_deploy/user_osa_variables_overrides.yml $OA_OVERRIDES
 fi
-if [[ ! -f /etc/openstack_deploy/user_rpco_variables_overrides.yml ]]; then
-  cp "${RPCD_DIR}"/etc/openstack_deploy/user_rpco_variables_overrides.yml /etc/openstack_deploy/user_rpco_variables_overrides.yml
+if [[ ! -f "$RPCD_OVERRIDES" ]]; then
+  cp "${RPCD_DIR}"/etc/openstack_deploy/user_rpco_variables_overrides.yml $RPCD_OVERRIDES
 fi
 
 # begin the openstack installation


### PR DESCRIPTION
This commit makes four notable changes:

1. Replaces RPCD_VARS with RPCD_OVERRIDES since we only operate against
   the overrides file
2. Updates the DEPLOY_AIO block to write variables overrides to the
   respective overrides files, rather than updating/appending to the
   defaults files
3. Sets apply_security_hardening to True in
   user_osa_variables_defaults.yml, since this is the default value we
   wish to operate against.
4. Updates the DEPLOY_HARDENING block to exit if DEPLOY_HARDENING is
   not enabled on a non-AIO build.  This is done because our tooling
   (outside of an AIO deployment) should not be making modifications to
   the overrides files.  These files are specifically for
   support/deployer and if overrides are needed then these should be
   made manually.  We also move this block to the top of deploy.sh so
   we can exit early if this condition is met and also add a block to
   DEPLOY_AIO so that developers can still disable hardening when
   deploying on an AIO.

Connects https://github.com/rcbops/rpc-openstack/issues/1436