### PR TITLE
[Backport] Remove ELK config before inventory is generated

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -142,6 +142,13 @@ fi
 ./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_osa_secrets.yml
 ./scripts/pw-token-gen.py --file $RPCD_SECRETS
 
+# ensure that the ELK containers aren't created if they're not
+# going to be used
+# NOTE: this needs to happen before ansible/openstack-ansible is first run
+if [[ "${DEPLOY_ELK}" != "yes" ]]; then
+  rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml
+fi
+
 # Apply any patched files.
 cd ${RPCD_DIR}/playbooks
 openstack-ansible -i "localhost," patcher.yml
@@ -166,12 +173,6 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   ansible repo_all -m file -a 'name=/root/.pip state=absent' 2>/dev/null ||:
 
   cd ${OA_DIR}/playbooks/
-
-  # ensure that the ELK containers aren't created if they're not
-  # going to be used
-  if [[ "${DEPLOY_ELK}" != "yes" ]]; then
-    rm -f /etc/openstack_deploy/env.d/{elasticsearch,logstash,kibana}.yml
-  fi
 
   # setup the haproxy load balancer
   if [[ "${DEPLOY_HAPROXY}" == "yes" ]]; then


### PR DESCRIPTION
Currently, we rm env.d/{elasticsearch,logstash,kibana}.yml after we run
openstack-ansible, resulting in ELK-related items being in the
inventory.  This commit updates scripts/deploy.sh to rm these files
before, which means you will no longer get ELK containers if
DEPLOY_ELK != "yes".

Connects https://github.com/rcbops/rpc-openstack/issues/1434

(cherry picked from commit 04d9a795335de71e2eae860575b020d5d3135b72)