### PR TITLE
Remove Holland from outside venv

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
@@ -19,6 +19,11 @@
   tags:
     - galera
 
+- include: post-upgrade-holland.yml
+  when: inventory_hostname in groups['galera_all']
+  tags:
+    - galera
+
 # Run rabbitmq post upgrade tasks
 - include: post-upgrade-rabbitmq.yml
   when: inventory_hostname in groups['rabbitmq']

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
@@ -19,7 +19,7 @@
   tags:
     - galera
 
-- include: post-upgrade-holland.yml
+- include: remove-holland.yml
   when: inventory_hostname in groups['galera_all']
   tags:
     - galera

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-holland.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-holland.yml
@@ -1,0 +1,30 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Check if holland is installed outside venv
+  shell: pip show -q holland
+  register: is_holland_installed
+  failed_when: false
+  changed_when: false
+
+- name: Uninstall holland pip package from outside venv
+  pip:
+    name: "{{ item }}"
+    state: absent
+  when: is_holland_installed.rc == 0
+  with_items:
+    - holland
+    - holland.lib.common
+    - holland.lib.mysql

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/remove-holland.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/remove-holland.yml
@@ -28,3 +28,4 @@
     - holland
     - holland.lib.common
     - holland.lib.mysql
+    - holland.backup.xtrabackup


### PR DESCRIPTION
In mitaka, holland gets installed inside a venv, which means that we end
up with lingering holland pip packages outside the venv. To remove any
confusion, here we remove those packages as part of the post-upgrade.

Note, the pattern of '_check if holland is installed, then remove the pip
package if it is_' is used only because in ansible 1.9.4, the pip module
is broken and it won't just "do the right thing" if you declare the
package as absent (it will actually fail with an rc of 1 if the package
has already been uninstalled)

Connected https://github.com/rcbops/u-suk-dev/issues/266