### PR TITLE
Do not install binary pycparser packages

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,8 @@ pep8==1.5.7
 pyflakes==0.8.1
 mccabe==0.2.1 # capped for flake8
 bashate>=0.2 # Apache-2.0
+# Fix for https://waffle.io/rcbops/u-suk-dev/cards/57f258cd31f3e3f8009eb355
+--no-binary pycparser
 
 
 # this is required for the docs build jobs


### PR DESCRIPTION
pycparser's 2.14 wheel package on PyPI is broken and has been causing
breakage with cryptography and OpenStack in general. For rpc-openstack
in particular, ansible relies on cryptography and that dependency adds a
dependency on pycparser which has been breaking our gating.

Connects rcbops/u-suk-dev#474