### PR TITLE
Do not install binary pycparser packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
 
 before_script:
-- pip install tox
+- pip install -U tox pip
+# NOTE(sigmavirus24): pycparser 2.14's wheel on PyPI is broken. Using
+# --no-binary below ignores the wheel, downloads the source distribution and
+# avoids the issue when installing cryptography for ansible.
+# This is a temporary workaround and should be removed in due time.
+- pip2 install --no-binary ':all:' pycparser
 - pip2 install --force-reinstall 'ansible===1.9.4'
 - ansible-galaxy install --role-file=ansible-role-requirements.yml --force --roles-path=/home/travis/build/rcbops/rpc-openstack/rpcd/playbooks/roles
 


### PR DESCRIPTION
pycparser's 2.14 wheel package on PyPI is broken and has been causing
breakage with cryptography and OpenStack in general. For rpc-openstack
in particular, ansible relies on cryptography and that dependency adds a
dependency on pycparser which has been breaking our gating.

Connects rcbops/u-suk-dev#474