### PR TITLE
[Backport] Ceph hostname change during upgrade

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -1,5 +1,8 @@
 [defaults]
 gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /etc/openstack_deploy/ansible_facts
+fact_caching_timeout = 86400
 host_key_checking = False
 
 # Setting forks should be based on your system. The Ansible defaults to 5,

--- a/rpcd/playbooks/ceph-mon.yml
+++ b/rpcd/playbooks/ceph-mon.yml
@@ -17,8 +17,60 @@
   hosts: mons
   user: root
   max_fail_percentage: 0
+  gather_facts: True
+  pre_tasks:
+    #Upgrades safety net
+    - name: Checking if container has ceph content
+      stat:
+        path: "/var/lib/ceph/"
+      register: container_ceph_dir
+      ignore_errors: True
+    - name: Checking if the ceph folder is a bind mount
+      shell: egrep 'lxc.mount.entry.*/openstack/{{ inventory_hostname }}.*ceph.*bind' /var/lib/lxc/{{ inventory_hostname }}/config
+      ignore_errors: True
+      delegate_to:  "{{ physical_host }}"
+      when: container_ceph_dir.stat.exists | bool
+      register: container_ceph_bind_mount
+    - name: If ceph is not in a bind-mount, create a backup folder
+      file:
+        state: directory
+        path: /backup/
+      when: container_ceph_bind_mount | failed
+    - name: If ceph is not in a bind-mount, backup it
+      shell: cp -r /var/lib/ceph/* /backup/
+      when: container_ceph_bind_mount | failed
+    - name: Fetch the backups
+      local_action: shell "scp -r {{ inventory_hostname }}:/backup/ /openstack/backup/{{ inventory_hostname }}/ceph/"
+      when: container_ceph_bind_mount | failed
+    - fail:
+        msg: |
+          You don't have bind mounts and want to upgrade to bind mounts
+          without doing the proper steps. Terrible idea. I'm stopping you
+          right now. Please check the documentation on how to upgrade
+          if you are willing to take the risk.
+      when:
+        - container_ceph_dir.stat.exists | bool
+        - container_ceph_bind_mount | failed
+
+    #Greenfields
+    - name: Mons extra lxc config
+      lxc_container:
+        name: "{{ container_name }}"
+        container_command: |
+          [[ ! -d "/var/lib/ceph" ]] && mkdir -p "/var/lib/ceph"
+        container_config:
+          - "lxc.mount.entry=/openstack/{{ container_name }} var/lib/ceph none bind 0 0"
+      delegate_to: "{{ physical_host }}"
+      when: not is_metal | bool
+      register: container_extra_config
   roles:
     - ceph.ceph-mon
+  vars:
+    is_metal: "{{ properties.is_metal|default(false) }}"
+
+- name: Remove rbd pool
+  hosts: mons[0]
+  user: root
   tasks:
     - name: Check if rbd pool exists and is empty
       shell: rados -p rbd df | egrep '^rbd( +0){9}$'

--- a/rpcd/playbooks/ceph-osd.yml
+++ b/rpcd/playbooks/ceph-osd.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather mons facts for ceph.conf template
-  hosts: mons
+  include: gen-facts.yml
 
 - name: Deploy osds
   hosts: osds

--- a/rpcd/playbooks/gen-facts.yml
+++ b/rpcd/playbooks/gen-facts.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Generate facts
+  hosts: "{{ hosts | default('mons') }}"
+  gather_facts: True

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather mons facts for ceph.conf template
-  hosts: mons
+  include: gen-facts.yml
 
 - name: Install Ceph dependencies
   hosts: osds_all:mons_all:&hosts


### PR DESCRIPTION
L>M has changed the hostname of our containers, therefore we
need to adapt this everywhere. Ceph was left behind, and this
is fixing the hostnames by shutting down the monitors, removing the mons,
deleting the containers, recreating them, and rejoining the cluster, all
of this in a serial way.

The ceph-mon playbook was adapted to verify the bind mount is there, in
order to avoid data loss.

Comments are added explaining what is done, and what is needed
when upgrading an environment with ceph.

This commit also ensures the generation of the facts used in the
setup-maas is properly done (explicitly asking the generation of
the facts by including our new gen-facts playbook).

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>
Connected rcbops/u-suk-dev#383

(cherry picked from commit acb2491e89e163c78fe776524f31925bd008de54)