### PR TITLE
Workaround MaaS failure to correctly update checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/restart_raxmon.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/restart_raxmon.yml
@@ -21,3 +21,23 @@
     - maas-setup
     - rackspace-monitoring-agent-setup
     - rackspace-monitoring-agent-restart
+
+# https://github.com/rcbops/u-suk-dev/issues/481
+# For Liberty to Mitaka upgrades the checks are not getting properly registered.
+# Restarting the agent seems to clear out the problematic checks.
+- name: Wait for checks to register
+  pause:
+    minutes: 1
+  tags:
+    - maas-setup
+    - rackspace-monitoring-agent-setup
+    - rackspace-monitoring-agent-restart
+
+- name: Restart rackspace-monitoring-agent service a second time
+  service:
+    name: rackspace-monitoring-agent
+    state: restarted
+  tags:
+    - maas-setup
+    - rackspace-monitoring-agent-setup
+    - rackspace-monitoring-agent-restart


### PR DESCRIPTION
When upgrading from Liberty to Mitaka the MaaS templates are updated.
The agent appears to be failing to correctly register the modifications
to the checks. Restarting the agent a second time appears to resolve the
issue.

This commit modifies the MaaS role so that the agent is restarted twice.

Connected https://github.com/rcbops/u-suk-dev/issues/481