### PR TITLE
Set correct user in rpc-pre-upgrades.yml

### DIFF
--- a/rpcd/playbooks/rpc-pre-upgrades.yml
+++ b/rpcd/playbooks/rpc-pre-upgrades.yml
@@ -21,6 +21,7 @@
 
 - name: remove beaver
   hosts: all
+  user: root
   tags:
     - rpc-pre-upgrades
     - remove-beaver


### PR DESCRIPTION
We're seeing some inconsistent $HOME references when the pip_lock_down
role runs, and suspect it may have something to do with this playbook
not using the correct user.

Connects rcbops/u-suk-dev#488