### PR TITLE
Set proper default NIC of network_check_list

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -324,7 +324,7 @@ ceph_checks_list:
   - { name: "ceph_cluster_stats", group: "mons" }
 
 network_checks_list:
-  - { name: "eth0", group: "hosts", max_speed: "{{ net_max_speed }}", rx_pct_warn: "{{ net_rx_pct_warn }}", rx_pct_crit: "{{ net_rx_pct_crit }}", tx_pct_warn: "{{ net_tx_pct_warn }}", tx_pct_crit: "{{ net_tx_pct_crit }}"}
+  - { name: "{{ ansible_default_ipv4.interface }}", group: "hosts", max_speed: "{{ net_max_speed }}", rx_pct_warn: "{{ net_rx_pct_warn }}", rx_pct_crit: "{{ net_rx_pct_crit }}", tx_pct_warn: "{{ net_tx_pct_warn }}", tx_pct_crit: "{{ net_tx_pct_crit }}"}
 
 kernel_checks_list:
   - { name: "conntrack_count", group: "hosts" }


### PR DESCRIPTION
Default NIC of network_check_list is eth0 which is barely used and
always caused maas checks to fail. Now We only need to worry the
 state of bond interface. This change covers most of practical
  customer cases.

Connects #742
(cherry picked from commit e0f96706be580450af87bb816d2077bffc75d820)