### PR TITLE
DO NOT MERGE TESTING JENKINS

### DIFF
--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -21,6 +21,8 @@ set -eux -o pipefail
 export BASE_DIR=$( cd "$( dirname ${0} )" && cd ../ && pwd )
 export OA_DIR="$BASE_DIR/openstack-ansible"
 export RPCD_DIR="$BASE_DIR/rpcd"
+# Something like this can go into the jenkins job
+export HOME=/root
 
 source ${BASE_DIR}/scripts/functions.sh
 


### PR DESCRIPTION
Jenkins does not set the HOME variable to /root, which causes pip configurations to be dropped in /jenkins on some containers and in turn, causing errors in gate. This PR is just a test to see what exactly will fix that.