### PR TITLE
Introduce ceph upgrade release notes

### DIFF
--- a/releasenotes/notes/ceph-upgrade-434a53379d0db8f5.yaml
+++ b/releasenotes/notes/ceph-upgrade-434a53379d0db8f5.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - The ceph monitors and osds needs their configuration
+    file to be updated for the Mitaka release, to adapt
+    with the hostnames changes done in Mitaka. Please
+    backup, destroy, and re-create the monitors, and
+    make them rejoin the cluster in a serial way. The
+    osds also need to have their configuration file
+    updated.
+  - When re-created during the upgrade procedure, the
+    ceph monitors will now have bind mounts to the hosts.
+    This will make the backup of the mons easier in the
+    future.


### PR DESCRIPTION
Ceph upgrades requires changes in the containers, and will change
the bind mounts for the ceph monitors. This should be the record
of it for the deployers.

Connected rcbops/rpc-openstack#1478