### PR TITLE
Add MaaS checks for processes status (#1366)

### DIFF
--- a/maas/plugins/process_check.py
+++ b/maas/plugins/process_check.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import os
+
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+
+def get_process_name(pid):
+    process_exe_path = os.path.join('/proc', pid, 'exe')
+    process_comm_path = os.path.join('/proc', pid, 'comm')
+
+    try:
+        process_exe = os.readlink(process_exe_path)
+        with open(process_comm_path, mode='r') as f:
+            comm = f.read().rstrip('\n')
+    except OSError as ex:
+        if ex.errno == os.errno.ENOENT:
+            return set()
+        status_err('Could not read process information.', exception=ex)
+    except IOError as ex:
+        # The path we are checking for a PID list does not exist.
+        # This is probably caused by an invalid container name.
+        status_err('No such process exists. {}', exception=ex)
+
+    # Return the "exe" path and the baesname of the "exe" path, and
+    # the value contained in comm to make matching easier
+    return set([comm, process_exe, os.path.basename(process_exe)])
+
+
+def get_processes(procs_path):
+    process_names = set()
+    try:
+        with open(procs_path, mode='r') as f:
+            for pid in f.read().splitlines():
+                process_names.update(get_process_name(pid))
+    except OSError as ex:
+        # Could not read the PID list file, probably due to a permission
+        # error. This is different from an IOError, so we handle the two
+        # types differently.
+        status_err('Could not read PID list file. {}', exception=ex)
+    except IOError as ex:
+        # The path we are checking for a PID list does not exist.
+        # This is probably caused by an invalid container name.
+        status_err('No such container exists. {}', exception=ex)
+
+    # Return a set() of potential process names resolved from their PID
+    return process_names
+
+
+def check_process_running(process_names, container_name=None):
+    """Check to see if processes are running.
+
+       Check if each of the processes in process_names are in a list
+       of running processes in the specified container name, or on
+       this host.
+    """
+
+    if not process_names:
+        # The caller has not provided a value for process_names, which gives us
+        # nothing to do. Return an error for the check.
+        status_err('No process names provided')
+
+    procs_path = '/sys/fs/cgroup/cpu/cgroup.procs'
+    if container_name is not None:
+        # Checking for processes in a container, not the parent host
+        procs_path = os.path.join('/sys/fs/cgroup/cpu/lxc', container_name,
+                                  'cgroup.procs')
+    procs = get_processes(procs_path)
+
+    if not procs:
+        # Unable to get a list of process names for the container or host.
+        status_err('Could not get a list of running processes')
+
+    # Since we've fetched a process list, report status_ok.
+    status_ok()
+
+    # Report the presence of each process from the command line in the
+    # running process list for the host or specified container.
+    for process_name in process_names:
+        metric_bool('%s_process_status' % process_name,
+                    process_name in procs)
+
+
+def main(args):
+    if not args.processes:
+        # The command line does not have any process names specified
+        status_err('No executable names supplied')
+
+    check_process_running(container_name=args.container,
+                          process_names=args.processes)
+
+
+if __name__ == "__main__":
+    with print_output():
+        parser = argparse.ArgumentParser(
+            description='Check a host or container for running processes')
+        parser.add_argument('-c', '--container', action='store')
+        parser.add_argument('processes', nargs=argparse.REMAINDER)
+        args = parser.parse_args()
+        main(args)

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -318,6 +318,24 @@ cpu_memory_checks_list:
 disk_utilisation_checks_list:
   - { name: "disk_utilisation", group: "hosts" }
 
+rsyslogd_process_names:
+  - rsyslogd
+
+elasticsearch_process_names:
+  # NOTE(cjloader): Unlike rsyslog and filebeat, elasticsearch does not have a
+  # process name that includes "elasticsearch". The process running
+  # elasticsearch is actually named "java" so we search for that here. This is
+  # less than ideal, but the best we can do right now.
+  - java 
+
+beaver_process_names:
+  - beaver
+
+process_checks_list:
+  - { name: "rsyslogd_process_check", group: "rsyslog_all" }
+  - { name: "elasticsearch_process_check", group: "elasticsearch_all" }
+  - { name: "beaver_process_check", group: "all" }
+
 ceph_checks_list:
   - { name: "ceph_osd_stats", group: "osds" }
   - { name: "ceph_mon_stats", group: "mons" }
@@ -446,8 +464,6 @@ maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
 #
 maas_excluded_checks: []
 
-
-#
 # openrc definitions from OSA
 # This is necessary until LP #1537117 is implemented
 openrc_os_endpoint_type: internalURL

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -39,6 +39,8 @@
 
 - include: kernel.yml
 
+- include: process.yml
+
 - include: local.yml
   vars:
     internal_vip_address: "{{ internal_lb_vip_address }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: Install process checks
+  template:
+    src: "{{ item.name }}.yaml.j2"
+    dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}-{{ inventory_hostname }}.yaml"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  with_items:
+    - "{{ process_checks_list }}"
+  when:
+    - inventory_hostname in groups[ '{{ item.group }}' ]
+    - item.name not in maas_excluded_checks
+  delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/beaver_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/beaver_process_check.yaml.j2
@@ -1,0 +1,19 @@
+type: agent.plugin
+label: "beaver_process_check--{{ ansible_hostname }}"
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : process_check.py
+    args    : [{% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ beaver_process_names|join(",") }}"]
+alarms      :
+{% for process in beaver_process_names %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "Beaver process {{ process }} not running on {{ ansible_hostname }}");
+            }
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
@@ -1,0 +1,19 @@
+type: agent.plugin
+label: "elasticsearch_process_check--{{ ansible_hostname }}"
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : process_check.py
+    args    : [{% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ elasticsearch_process_names|join(",") }}"]
+alarms      :
+{% for process in elasticsearch_process_names %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "Elasticsearch process {{ process }} not running on {{ ansible_hostname }}");
+            }
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
@@ -1,0 +1,19 @@
+type: agent.plugin
+label: "rsyslogd_process_check--{{ ansible_hostname }}"
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : process_check.py
+    args    : [{% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ rsyslogd_process_names|join(",") }}"]
+alarms      :
+{% for process in rsyslogd_process_names %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "Rsyslogd process {{ process }} not running on {{ ansible_hostname }}.");
+            }
+{% endfor %}


### PR DESCRIPTION
This adds a MaaS check script to check by fully qualified or basename
if processes are running on a host or within a container on a host.
Additionally, MaaS checks for beaver, elasticsearch and rsyslog are
added using the process check script.

Connects #1236
(cherry picked from commit 2870f4e)
