### PR TITLE
Cap tox at 2.4.0 to avoid env substitution bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 before_script:
-- pip install tox
+- pip install 'tox<2.4.0,>=2.0'
 
 script: tox
 


### PR DESCRIPTION
Tox 2.4.0 was released this morning and broke the ability to use
environment substitution. To avoid this and keep our continuous
integration happy while we complete our work, we prevent travis from
installing any version of tox 2.4.0 or later.

Related-to tox-dev/tox#380
Connects rcbops/u-suk-dev#512

(cherry picked from commit 3e18ce8b06ab64cf2d509abefbef5e33f6a0e39f)