### PR TITLE
Add ELK upgrade support for L to M upgrades

### DIFF
--- a/releasenotes/notes/elasticsearch-upgrade-a56013c6aa97b718.yaml
+++ b/releasenotes/notes/elasticsearch-upgrade-a56013c6aa97b718.yaml
@@ -1,0 +1,14 @@
+---
+upgrade:
+  - The `elasticsearch-upgrade-pre.yml` play takes care
+    of upgrading the legacy elasticsearch data and preparing
+    the cluster for the upgrade of the elasticsearch packages.
+    Due to some inconsistencies in the legacy elasticsearch
+    mappings it is necessary to reindex all elasticsearch
+    data into indices with the updated 2.x compatible mappings.
+    Included with the upgrade tasks is a python wrapper to
+    monitor and control the reindexing process.  It is
+    recomended to reindex all indices prior to the current
+    day before beginning the upgrade.  Please check the upgrade
+    documentation for more information on how to reindex the
+    existing elasticsearch indices.

--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -13,6 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Used for upgrades
+elasticsearch_legacy_apt_repo_url: "http://packages.elasticsearch.org/elasticsearch/1.7/debian"
+
+# Used for upgrades
+elasticsearch_legacy_apt_repos:
+  - { repo: "deb {{ elasticsearch_legacy_apt_repo_url }} stable main", state: "present" }
+
+# use -e 'logging_upgrade=true' to upgrade logging components
+logging_upgrade: false
+
 elasticsearch_apt_repo_url: "http://packages.elastic.co/elasticsearch/2.x/debian"
 
 elasticsearch_apt_repos:
@@ -28,6 +38,10 @@ elasticsearch_apt_packages:
 elasticsearch_pip_packages:
   - elasticsearch>=2.0.0,<3.0.0
   - elasticsearch-curator==4.0.4
+  - httplib2
+
+elasticsearch_upgrade_pip_packages:
+  - requests
 
 # This sets the cluster name
 elasticsearch_cluster: openstack

--- a/rpcd/playbooks/roles/elasticsearch/files/reindex-liberty.py
+++ b/rpcd/playbooks/roles/elasticsearch/files/reindex-liberty.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from datetime import date
+from datetime import timedelta
+from elasticsearch import Elasticsearch
+import requests
+import sys
+import time
+
+
+def _calc_pct(es, parsed_args, stats, master, slave):
+    """Calculate the percentage complete of a reindex."""
+    master_count = _get_count(stats, master)
+    slave_count = _get_count(stats, slave)
+    reindex_pct = _percentage(slave_count, master_count)
+    out = []
+    out.append(master_count)
+    out.append(slave_count)
+    out.append(reindex_pct)
+    return out
+
+
+def _percentage(numerator, denominator):
+    try:
+        return (float(numerator) / float(denominator)) * 100
+    except ZeroDivisionError:
+        return float(0.00)
+
+
+def _check_index(es, parsed_args, index, stats):
+    """Check on the reindexing status of an index."""
+    slave_index = _return_slave(index, parsed_args)
+    if slave_index in stats['indices']:
+        return True
+    else:
+        return False
+
+
+def _get_count(stats, index):
+    """Return the document count for a given index."""
+    try:
+        return stats['indices'][index]['primaries']['docs']['count']
+    except KeyError:
+        return -1
+
+
+def _index_to_date(index):
+    """Converts and index name to a date object."""
+    (i_year, i_month, i_day) = index.split('-')[1].split('.')
+    return date(int(i_year), int(i_month), int(i_day))
+
+
+def _return_slave(index, parsed_args):
+    """Gives the slave index name."""
+    return index + parsed_args.suffix
+
+
+def get_indices(es, parsed_args, slaves=False):
+    """Fetch a list of all of the elasticsearch indices."""
+    indices = []
+
+    full_indices = es.indices.get_aliases(request_timeout=30).keys()
+    for index in full_indices:
+        if 'logstash' in index:
+            if parsed_args.suffix in index and slaves:
+                if index.replace(parsed_args.suffix, "") in full_indices:
+                    indices.append(index)
+            elif parsed_args.suffix not in index:
+                indices.append(index)
+
+    return indices
+
+
+def get_stats(es):
+    """Fetch the statistics for all of the elasticsearch indices."""
+    return es.indices.stats(request_timeout=30)
+
+
+def reindex(es, es_host, parsed_args):
+    """Create -liberty indices and start the reindex process."""
+    stats = get_stats(es)
+    if not parsed_args.index:
+        for index in get_indices(es, parsed_args):
+            if not _check_index(es, parsed_args, index, stats):
+                reindex_params = 'http://' + es_host + \
+                    '/' + index + '/_reindex/' + index + parsed_args.suffix + \
+                    '/'
+                print("Reindexing: {0} into: {1}".format(index, index +
+                                                         parsed_args.suffix))
+                if not parsed_args.dry_run:
+                    requests.post(reindex_params)
+            else:
+                print("Skipping: {} reindexing in progress".format(index))
+
+    else:
+        reindex_params = 'http://' + es_host + '/' + parsed_args.index + \
+            '/_reindex/' + parsed_args.index + parsed_args.suffix
+        print("Reindexing Single Index: {0} into: {1}".format(
+            parsed_args.index,
+            parsed_args.index + parsed_args.suffix))
+        if not parsed_args.dry_run:
+            requests.post(reindex_params)
+
+
+def clean_legacy(es, parsed_args):
+    """Drops the -liberty indices created by a previous reindex."""
+    if parsed_args.dry_run:
+        print("Dry run, no operations will be performed")
+    for index in get_indices(es, parsed_args, True):
+        if parsed_args.suffix in index:
+            if not parsed_args.dry_run:
+                es.indices.delete(index)
+            print ("Deleted: {}".format(index))
+
+
+def monitor_reindex(es, parsed_args):
+    """Monitor the reindexing process."""
+    total_count = 0
+    done_count = 0
+    stats = get_stats(es)
+    indices = get_indices(es, parsed_args, True)
+    counts = None
+    counts = {}
+    for index in indices:
+        if parsed_args.suffix in index:
+            master_name = index.replace(parsed_args.suffix, "")
+            counts[master_name] = _calc_pct(es,
+                                            parsed_args,
+                                            stats,
+                                            master_name,
+                                            index)
+
+    for master in counts.keys():
+        slave_index = master + parsed_args.suffix
+        master_count = counts[master][0]
+        slave_count = counts[master][1]
+        reindex_pct = counts[master][2]
+        if parsed_args.verbose:
+            print("Master Index: {0:15s} "
+                  "Slave Index: {1:15s} "
+                  "Master Count: {2:10d} "
+                  "Slave Count: {3:10d} "
+                  "Percentage Complete: {4:3.2f}%".format(master,
+                                                          slave_index,
+                                                          master_count,
+                                                          slave_count,
+                                                          reindex_pct))
+        total_count += master_count
+        done_count += slave_count
+    try:
+        pct_done = _percentage(done_count, total_count)
+    except ZeroDivisionError:
+        pct_done = float(0.00)
+    if parsed_args.verbose:
+        print("Total Docments: {0:20d} "
+              "Reindexed Documents: {1:20d} "
+              "Percentage complete: {2:3.2f}%".format(total_count,
+                                                      done_count,
+                                                      pct_done))
+    else:
+        print("Percent complete: {0:3.2f}%".format(pct_done))
+    if pct_done == 100:
+        sys.exit()
+    else:
+        return False
+
+
+def drop_legacy(es, parsed_args):
+    """Drop the legacy logstash-* indices."""
+    stats = get_stats(es)
+    for index in get_indices(es, parsed_args):
+        if _check_index(es, parsed_args, index, stats):
+            print("Dropping Legacy Index: {}".format(index))
+            if not parsed_args.dry_run:
+                es.indices.delete(index)
+
+
+def list_indices(es):
+    """List all indices."""
+    print(es.cat.indices(v=True))
+
+
+def batch(es, es_host, parsed_args):
+    """Batch Processing.
+
+    Batch processing, useful for performing re-indexing of old indices
+    prior to the actual upgrade.
+    """
+
+    today = date.today()
+    one_day = timedelta(days=1)
+    yesterday = today - one_day
+    indices = get_indices(es, parsed_args)
+    stats = get_stats(es)
+
+    if not parsed_args.start:
+        d_start = None  # Date object for start date
+        p_start = yesterday  # Previous first day for sort
+        for index in indices:
+            if 'logstash' in index:
+                s_date = _index_to_date(index)
+                if s_date < p_start:
+                    p_start = s_date
+        d_start = p_start
+    else:
+        (s_year, s_month, s_day) = parsed_args.start.split('.')
+        d_start = date(int(s_year), int(s_month), int(s_day))
+    if not parsed_args.end:
+        d_end = yesterday
+    else:
+        (e_year, e_month, e_day) = parsed_args.end.split('.')
+        d_end = date(int(e_year), int(e_month), int(e_day))
+
+    numdays = d_end - d_start + one_day
+    date_range = [d_end - timedelta(days=x) for x in range(0, numdays.days)]
+    print("Start: {0}\tEnd: {1}\n".format(d_start, d_end))
+
+    for index in indices:
+        parsed_args.index = index
+        i_date = _index_to_date(index)
+        if i_date in date_range:
+            if not _check_index(es, parsed_args, index, stats):
+                print("Batch Index: {}".format(index))
+                reindex(es, es_host, parsed_args)
+            else:
+                print("Skipping: {} reindexing in progress".format(index))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="localhost", help="Elasticsearch \
+                        host to connect to (default: localhost)")
+    parser.add_argument("--port", default="9200", help="Elasticsearch \
+                        port to connect to (default: 9200)")
+    parser.add_argument("--suffix", default="liberty", help="Suffix for \
+                        reindexed indices. (default: liberty)")
+    parser.add_argument("--clean", action="store_true", help="Clean previous \
+                        reindexed indices")
+    parser.add_argument("--list", action="store_true", dest="list_indices",
+                        help="List all elasticsearch indices")
+    parser.add_argument("--reindex", action="store_true", help="Reindex all \
+                        legacy indexes")
+    parser.add_argument("--index", default=None, help="Used with --reindex \
+                        to reindex a specific index.")
+    parser.add_argument("--batch", action="store_true", help="Batch \
+                        processing of old indices.  Defaults to oldest index \
+                        through previous days index.")
+    parser.add_argument("--start", help="Start index for batch processing \
+                        (YYYY.MM.DD) (default: beginning of indices)")
+    parser.add_argument("--end", help="End index for batch processing \
+                        (YYYY.MM.DD) (default: the Nth-1 index)")
+    parser.add_argument("--monitor", action="store_true", help="Progress of \
+                        reindexing")
+    parser.add_argument("--continuous", action="store_true", help="Continuous \
+                        monitoring")
+    parser.add_argument("--delay", default=10, type=int, help="Refresh delay \
+                        for continuous monitoring. (default: 10)")
+    parser.add_argument("--verbose", action="store_true", help="Verbose \
+                        output from monitoring functions")
+    parser.add_argument("--drop", action="store_true", help="Drop legacy \
+                        indices")
+    parser.add_argument("--dry-run", action="store_true", dest="dry_run",
+                        help="Prints what will happen for drop, clean and \
+                        batch operations")
+    args = parser.parse_args()
+
+    # Make sure we have hyphens in the correct places
+    if '-' not in list(args.suffix)[0]:
+        args.suffix = '-' + args.suffix
+
+    if args.dry_run:
+        print("Dry run, no operations will be performed.")
+
+    es_host = args.host + ":" + args.port
+    if args.verbose:
+        print("Connecting to elasticsearch at {}".format(es_host))
+    es = Elasticsearch(es_host)
+
+    if args.clean:
+        clean_legacy(es, args)
+    if args.batch:
+        batch(es, es_host, args)
+    if args.list_indices:
+        list_indices(es)
+    if args.reindex:
+        reindex(es, es_host, args)
+    if args.monitor:
+        monitor_reindex(es, args)
+    if args.drop:
+        drop_legacy(es, args)
+    if args.continuous:
+        # TODO(d34dh0r53) I hate this, need to figure out a better way.
+        while not monitor_reindex(es, args):
+            time.sleep(args.delay)
+        return 0
+
+if __name__ == "__main__":
+    main()

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
@@ -58,3 +58,21 @@
     cron_file: "elasticsearch_curator"
   tags:
     - elasticsearch-post-install
+
+- name: Get ElasticSearch version
+  uri:
+    url: "http://{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}:{{ elasticsearch_http_port }}/"
+    method: GET
+    status_code: 200
+  register: escontent
+  tags:
+    - elasticsearch-post-install
+    - elasticsearch-version
+
+- name: Verify ElasticSearch version
+  fail:
+    msg: "Incorrect version of ElasticSearch {{ escontent.json.version.number }} is installed."
+  when: escontent.json.version.number != '2.4.1'
+  tags:
+    - elasticsearch-post-install
+    - elasticsearch-version

--- a/rpcd/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/main.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: upgrade_elasticsearch_pre.yml
+  when:
+    - logging_upgrade | bool
 - include: elasticsearch_pre_install.yml
 - include: elasticsearch_install.yml
 - include: elasticsearch_post_install.yml

--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -1,0 +1,282 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add legacy apt repositories
+  apt_repository:
+    repo: "{{ item.repo }}"
+    state: "{{ item.state }}"
+  with_items: elasticsearch_legacy_apt_repos
+  register: add_repos
+  until: add_repos|success
+  retries: 5
+  delay: 2
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Upgrade elasticsearch to stable 1.7.x version
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+    dpkg_options: "force-confold"
+  register: install_apt_packages
+  until: install_apt_packages|success
+  retries: 5
+  delay: 2
+  with_items: elasticsearch_apt_packages
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Install pip packages for upgrade
+  pip:
+    name: "{{ item }}"
+    state: latest
+    extra_args: "{{ pip_install_options | default('') }}"
+  register: install_pip_packages
+  until: install_pip_packages|success
+  retries: 5
+  delay: 2
+  with_items: elasticsearch_upgrade_pip_packages
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Stop elasticsearch
+  service:
+    name: elasticsearch
+    state: stopped
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Make sure elasticsearch is stopped
+  command: 'pkill -f elasticsearch'
+  ignore_errors: true
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Wait for elasticsearch port to close
+  wait_for:
+    host: "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}"
+    port: 9200
+    state: stopped
+    timeout: 120
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Start elasticsearch
+  service:
+    name: elasticsearch
+    state: started
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Wait for elasticsearch to restart
+  wait_for:
+    host: "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}"
+    port: 9200
+    state: started
+    timeout: 300
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Drop log_test1 template
+  shell: 'curl -sk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+    - skip_ansible_lint
+
+- name: Place legacy liberty template script
+  template:
+    src: legacy-mapping.sh.j2
+    dest: /opt/legacy-mapping.sh
+    owner: root
+    group: root
+    mode: 0755
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Install legacy liberty template
+  shell: '/opt/legacy-mapping.sh'
+  register: legacy_template_result
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Remove legacy liberty template script
+  file:
+    name: '/opt/legacy-mapping.sh'
+    state: absent
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Install Reindexing Plugin
+  command: ./plugin -install {{ item }}
+  args:
+    chdir: /usr/share/elasticsearch/bin
+    creates: /usr/share/elasticsearch/plugins/reindexing
+  with_items:
+    - org.codelibs/elasticsearch-reindexing/1.7.0
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Stop elasticsearch
+  service:
+    name: elasticsearch
+    state: stopped
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Make sure elasticsearch is stopped
+  command: 'pkill -f elasticsearch'
+  ignore_errors: true
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Wait for elasticsearch port to close
+  wait_for:
+    host: "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}"
+    port: 9200
+    state: stopped
+    timeout: 120
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Start elasticsearch
+  service:
+    name: elasticsearch
+    state: started
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Wait for elasticsearch to restart
+  wait_for:
+    host: "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}"
+    port: 9200
+    state: started
+    timeout: 300
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Install reindexing wrapper script
+  copy:
+    src: reindex-liberty.py
+    dest: /opt/reindex-liberty.py
+    owner: root
+    group: root
+    mode: 0755
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-reindex
+    - reindex-wrapper
+
+- name: Reindex legacy elasticsearch indices
+  shell: /opt/reindex-liberty.py --host "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}" --reindex
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-reindex
+
+- name: Monitor reindexing process
+  shell: /opt/reindex-liberty.py --host "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}" --monitor --continuous
+  async: 259200
+  poll: 5
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-reindex
+
+- name: Drop legacy elasticsearch indeices
+  shell: /opt/reindex-liberty.py --host "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}" --drop
+  delegate_to: "{{ groups['elasticsearch_all'][0] }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-reindex
+
+- name: Remove Legacy Plugins
+  command: ./plugin --remove {{ item }}
+  args:
+    chdir: /usr/share/elasticsearch/bin
+    removes: /usr/share/elasticsearch/plugins/reindexing
+  with_items:
+    - bigdesk
+    - head
+    - HQ
+    - kopf
+    - reindexing
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Remove legacy apt repositories
+  apt_repository:
+    repo: "{{ item.repo }}"
+    state: absent
+  with_items: elasticsearch_legacy_apt_repos
+  register: add_repos
+  until: add_repos|success
+  retries: 5
+  delay: 2
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - reindex-wrapper
+
+- name: Flush apt cache
+  apt:
+    update_cache: yes

--- a/rpcd/playbooks/roles/elasticsearch/templates/legacy-mapping.sh.j2
+++ b/rpcd/playbooks/roles/elasticsearch/templates/legacy-mapping.sh.j2
@@ -1,0 +1,302 @@
+#!/bin/sh
+curl --retry 10 -XPUT 'http://{{ hostvars[inventory_hostname]['container_address'] }}:{{ elasticsearch_http_port }}/_template/legacy-liberty' -d '
+{
+  "template" : "*-liberty",
+  "order": 0,
+    "mappings" : {
+      "_default_" : {
+        "dynamic_templates" : [ {
+          "string_fields" : {
+            "mapping" : {
+              "index" : "analyzed",
+              "omit_norms" : true,
+              "type" : "string",
+              "fields" : {
+                "raw" : {
+                  "index" : "not_analyzed",
+                  "ignore_above" : 256,
+                  "type" : "string"
+                }
+              }
+            },
+            "match" : "*",
+            "match_mapping_type" : "string"
+          }
+        } ],
+        "properties" : {
+          "@version" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "geoip" : {
+            "dynamic" : "true",
+            "properties" : {
+              "location" : {
+                "type" : "geo_point"
+              }
+            }
+          }
+        }
+      },
+      "logs" : {
+        "dynamic_templates" : [ {
+          "string_fields" : {
+            "mapping" : {
+              "index" : "analyzed",
+              "omit_norms" : true,
+              "type" : "string",
+              "fields" : {
+                "raw" : {
+                  "index" : "not_analyzed",
+                  "ignore_above" : 256,
+                  "type" : "string"
+                }
+              }
+            },
+            "match" : "*",
+            "match_mapping_type" : "string"
+          }
+        } ],
+        "properties" : {
+          "@fields" : {
+            "properties" : {
+              "facility" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "processid" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "program" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "severity" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              }
+            }
+          },
+          "@message" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "@source" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "@source_host" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "@timestamp" : {
+            "type" : "date",
+            "format" : "dateOptionalTime"
+          },
+          "@version" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "facility" : {
+            "type" : "long"
+          },
+          "facility_label" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "geoip" : {
+            "dynamic" : "true",
+            "properties" : {
+              "location" : {
+                "type" : "geo_point"
+              }
+            }
+          },
+          "host" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_level" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_program" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_program_path" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_program_pid" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_timestamp" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "priority" : {
+            "type" : "long"
+          },
+          "severity" : {
+            "type" : "long"
+          },
+          "severity_label" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "tags" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'

--- a/rpcd/playbooks/roles/logstash/defaults/main.yml
+++ b/rpcd/playbooks/roles/logstash/defaults/main.yml
@@ -43,3 +43,6 @@ logstash_apt_packages:
 
 logstash_plugins:
   - logstash-input-beats
+
+# use -e 'logging_upgrade=true' to upgrade logging components
+logging_upgrade: false

--- a/rpcd/playbooks/roles/logstash/handlers/main.yml
+++ b/rpcd/playbooks/roles/logstash/handlers/main.yml
@@ -17,4 +17,5 @@
   service:
     name: logstash
     state: restarted
+    enabled: yes
     pattern: logstash

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
@@ -13,17 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Prevent logstash-web from starting on boot
-  copy:
-    dest: "/etc/init/logstash-web.override"
-    content: "manual\n"
-    owner: "root"
-    group: "root"
-    mode: 0644
-  tags:
-    - logstash-web-disable
-    - logstash-post-install
-
 - name: Create patterns directory
   file:
     name: "/opt/logstash/patterns"

--- a/rpcd/playbooks/roles/logstash/tasks/main.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/main.yml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: upgrade_logstash_pre.yml
 - include: logstash_pre_install.yml
 - include: logstash_install.yml
 - include: logstash_post_install.yml

--- a/rpcd/playbooks/roles/logstash/tasks/upgrade_logstash_pre.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/upgrade_logstash_pre.yml
@@ -1,0 +1,44 @@
+---
+- name: Remove existing logstash
+  apt:
+    package: logstash
+    state: absent
+    purge: yes
+  when:
+    - logging_upgrade | bool
+
+- name: Remove /etc/init/logstash-web.override
+  file:
+    name: "/etc/init/logstash-web.override"
+    state: absent
+  when:
+    - logging_upgrade | bool
+
+- name: Register legacy logstash configuration files
+  shell: "ls -1 /etc/logstash/conf.d"
+  register: logstash_legacy_conf
+  when:
+    - logging_upgrade | bool
+
+- name: Remove legacy logstash configuration files
+  file:
+    name: "/etc/logstash/conf.d/{{ item }}"
+    state: absent
+  with_items: "{{ logstash_legacy_conf.stdout_lines | default([]) }}"
+  when:
+    - logging_upgrade | bool
+
+- name: Register legacy logstash patterns
+  shell: "ls -1 /opt/logstash/patterns"
+  register: logstash_legacy_patterns
+  when:
+    - logging_upgrade | bool
+
+- name: Remove legacy logstash patterns
+  file:
+    name: "/opt/logstash/patterns/{{ item }}"
+    state: absent
+  with_items: "{{ logstash_legacy_conf.stdout_lines | default([]) }}"
+  when:
+    - logging_upgrade | bool
+

--- a/rpcd/playbooks/roles/logstash/templates/99-output.conf
+++ b/rpcd/playbooks/roles/logstash/templates/99-output.conf
@@ -1,6 +1,7 @@
 #===============================================================================
 output {
     elasticsearch {
+        template_overwrite => true
         hosts => ['{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}:{{ elasticsearch_tcp_port }}']
     }
 }


### PR DESCRIPTION
ElasticSearch, Logstash, Kibana (ELK) provides a single dashboard from which to view the logs on a deployment. The versions of these applications in the RPCO r12 series is out of date and affected by CVEs that need to be addressed by moving to newer versions. This change updates the deployment to use the versions supported in our r13 series releases.

ElasticSearch is upgraded from 1.7 to 2.x, as part of this change the data has been migrated because the format in 1.7 is not compatible with 2.x.

The migrated ElasticSearch data cannot currently be viewed in Kibana.

Connected rcbops/u-suk-dev#237
(cherry picked from commit d14f01c9ec62562cb5cb5212f268286e4567fff6)