### PR TITLE
Modify the order that verify-maas.yml is run

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -241,7 +241,6 @@ run_ansible horizon_extensions.yml
 # deploy and configure RAX MaaS
 if [[ "${DEPLOY_MAAS}" == "yes" ]]; then
   run_ansible setup-maas.yml
-  run_ansible verify-maas.yml
 fi
 
 # deploy and configure the ELK stack
@@ -252,4 +251,9 @@ if [[ "${DEPLOY_ELK}" == "yes" ]]; then
   if [[ "${DEPLOY_HAPROXY}" == "yes" ]]; then
     run_ansible haproxy.yml
   fi
+fi
+
+# verify RAX MaaS
+if [[ "${DEPLOY_MAAS}" == "yes" ]]; then
+  run_ansible verify-maas.yml
 fi


### PR DESCRIPTION
This moves the running of verify-maas.yml to the last item run so
that it ensures that everything is set up before checking.

Connects #1502