### PR TITLE
DO NOT MERGE - Testing RabbitMQ fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "openstack-ansible"]
 	path = openstack-ansible
-	url = https://git.openstack.org/openstack/openstack-ansible
+	#url = https://git.openstack.org/openstack/openstack-ansible
+	url = https://github.com/git-harry/os-ansible-deployment


### PR DESCRIPTION
The failure rate to 'Join Rabbitmq cluster' on master upgrades appears
to be approximately 4%. This patch needs to have the upgrade job
continuously rechecked to see if the failure occurs.

Connected https://github.com/rcbops/u-suk-dev/issues/517