### PR TITLE
Blacklist tox 2.4.0 which breaks our tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 before_script:
-- pip install tox
+- pip install 'tox!=2.4.0,>=2.3'
 
 script: tox
 


### PR DESCRIPTION
Version 2.4.0 of tox was released yesterday and broke environment
substitution (which we use in our tox.ini). 2.4.1 was released today
fixing this problem for us. We just need to blacklist the broken version
to ensure it doesn't break us again.

Connects rcbops/u-suk-dev#512

(cherry picked from commit 0b0948f82603f13c6dbefc82b81289bf127ed40f)