### PR TITLE
Remove pattern from Apache2 restart handler

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/handlers/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: Restart apache2
-  service: name=apache2 state=restarted pattern=apache2
+  service:
+    name: apache2
+    state: restarted


### PR DESCRIPTION
We are seeing periodic failures where the Apache2 restart handler is
triggered but is unable to restart Apache2 successfully as it's already
running.

Reproducing this infrequent failure is difficult, but I suspect the
failure is due to the handler's service being defined with the pattern
parameter present, which does a process listing to determine the status
of the service.  The Apache2 service reports status correctly via the
init script itself, so using pattern is unnecessary.  Additionally, the
upstream os_horizon role's Apache2 restart handler has no pattern
present.

This commit simply removes pattern, and updates how the handler itself
is defined.

Connects https://github.com/rcbops/u-suk-dev/issues/518

(cherry picked from commit 166eddd07861371a73a7a4ce7b999f5dec64f530)