### PR TITLE
Add monitoring for holland backups

### DIFF
--- a/maas/plugins/holland_local_check.py
+++ b/maas/plugins/holland_local_check.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import datetime
+import shlex
+import subprocess
+
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+
+def run_command(arg):
+    proc = subprocess.Popen(shlex.split(arg),
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=False)
+
+    out, err = proc.communicate()
+    ret = proc.returncode
+    return ret, out, err
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Check holland backup completion')
+    parser.add_argument('galera_container_name',
+                        help='Name of the Galera container running holland')
+    parser.add_argument('holland_binary', nargs='?',
+                        help='Absolute path to the holland binary',
+                        default='/usr/local/bin/holland')
+    parser.add_argument('holland_backupset', nargs='?',
+                        help='Name of the holland backupset',
+                        default='rpc_support')
+    return parser.parse_args()
+
+
+def print_metrics(name, size):
+    metric('hollabd_backup_size', 'double', size, 'Megabytes')
+
+
+def container_holland_lb_check(container, binary, backupset):
+    backupsets = []
+
+    # Call holland directly inside container
+    retcode, output, err = run_command('lxc-attach -n %s -- %s lb' %
+                                       (container, binary))
+
+    if retcode > 0:
+            status_err('Could not list holland backupsets: %s' % (err))
+
+    for line in output.split():
+        if backupset + '/' in line:
+            backupname = line.split('/')[-1]
+            disksize = 0
+
+            # Determine size of the backup
+            retcode, output, err = \
+                run_command('lxc-attach -n %s -- '
+                            'du -ks /var/backup/holland_backups/%s/%s' %
+                            (container, backupset, backupname))
+            if retcode == 0:
+                disksize = output.split()[0]
+
+            # Populate backupset informations
+            backupsets.append([backupname, disksize])
+
+    return backupsets
+
+
+def main():
+    args = parse_args()
+    galera_container = args.galera_container_name
+    holland_bin = args.holland_binary
+    holland_bs = args.holland_backupset
+
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    yesterday = yesterday.strftime('%Y%m%d')
+
+    # Get completed Holland backup set
+    backupsets = \
+        container_holland_lb_check(galera_container, holland_bin, holland_bs)
+
+    if len([backup for backup in backupsets if yesterday in backup[0]]) > 0:
+        status_ok()
+        metric_bool('holland_backup_status', True)
+    else:
+        status_err('Could not find Holland backup from %s' % (yesterday))
+        metric_bool('holland_backup_status', False)
+
+    # Print metric about last backup
+    print_metrics('holland_backup_size', float(backupsets[-1][1]) / 1024)
+
+
+if __name__ == '__main__':
+    with print_output():
+        main()

--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -28,3 +28,8 @@ migrations_dir: /etc/openstack_deploy/migrations
 
 # Ceph Conf Directory Mode
 conf_directory_mode: 755
+
+# Cross roles configurations
+holland_venv_enabled: True
+holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
+holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -453,6 +453,7 @@ infra_service_local_checks_list:
   - { name: "rabbitmq_status", group: "rabbitmq" }
   - { name: "galera_check", group: "galera" }
   - { name: "memcached_status", group: "memcached" }
+  - { name: "holland_local_check", group: "galera" }
 
 # Set this to 'false' to set the lb checks against ALL service infra hosts.
 # Checks will be setup but disabled on all but host[0] when this is 'true'.
@@ -540,6 +541,13 @@ verify_maas_delay: 20
 # verify_maas_retries: How many times to retry on failure
 #
 verify_maas_retries: 5
+
+#
+# verify_local_maas_excluded_checks: Exclude checks by name from verify-local task.
+#                                    Multiple entries are allowed as list.
+#
+verify_local_maas_excluded_checks:
+ - "holland_local_check"
 
 #
 # maas_use_api: Allow operations that make use of the MaaS api, set to false

--- a/rpcd/playbooks/roles/rpc_maas/templates/holland_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/holland_local_check.yaml.j2
@@ -1,0 +1,17 @@
+type: agent.plugin
+label: "holland_local_check--{{ ansible_hostname }}"
+disabled    : false
+period      : "{{ maas_check_period }}"
+timeout     : "{{ maas_check_timeout }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}holland_local_check.py", "{{ container_name }}", "{{ holland_venv_enabled | bool | ternary(holland_venv_bin + '/', '/usr/local/bin/') }}holland"]
+alarms      :
+     holland_backup_status:
+        label                   : holland_backup_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["holland_backup_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "Could not find holland backup from yesterday");
+            }

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -45,7 +45,9 @@
         {% if maas_venv_enabled | bool %}
         . {{ maas_venv_bin }}/activate
         {% endif %}
-        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-local
+        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-local \
+        {% for ec in verify_local_maas_excluded_checks %} --excludeverifycheck {{ec}}
+        {% endfor %}
       register: verify_maas
       failed_when: verify_maas.rc != 0
       changed_when: False


### PR DESCRIPTION
The MaaS plugin `holland_local_check.py` is added to
monitor the status of previous holland backups.
The plugin expects at least one completed backupset
for the previous day. Holland is running local Galera
Backups on each container once daily.
The metrics `holland_backup_size` (Mega Bytes) and
`holland_backup_status` (Boolean) are provided to
monitor holland.

Connects #1506
