### PR TITLE
Serialise the setup of RabbitMQ containers

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -1,5 +1,8 @@
 [defaults]
 gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /etc/openstack_deploy/ansible_facts
+fact_caching_timeout = 86400
 host_key_checking = False
 
 # Setting forks should be based on your system. The Ansible defaults to 5,


### PR DESCRIPTION
RabbitMQ deployment can fail due to a race condition when adding nodes
to a cluster. In OpenStack-Ansible this is addressed from Liberty
onwards by serialising the running of the rabbitmq_server role. Kilo is
no longer supported upstream, to work around the issue this change
updates deploy.sh to use the ansible-playbook option --limit so that the
playbook can be restricted to running on one container at a time.

Connected https://github.com/rcbops/u-suk-dev/issues/517