### PR TITLE
Perform verification before starting ES upgrade

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -23,6 +23,9 @@ elasticsearch_legacy_apt_repos:
 # use -e 'logging_upgrade=true' to upgrade logging components
 logging_upgrade: false
 
+# use -e 'force_upgrade=true' for force the upgrade to happen regardless of the pre-flight checks
+force_upgrade: false
+
 elasticsearch_apt_repo_url: "http://packages.elastic.co/elasticsearch/2.x/debian"
 
 elasticsearch_apt_repos:
@@ -31,8 +34,16 @@ elasticsearch_apt_repos:
 elasticsearch_apt_keys:
   - { url: "http://packages.elastic.co/GPG-KEY-elasticsearch", state: "present" }
 
+elasticsearch_version: 2.4.1
+
+elasticsearch_reindex_version: 1.7.5
+
 elasticsearch_apt_packages:
-  - elasticsearch
+  - elasticsearch={{ elasticsearch_version }}
+  - openjdk-7-jre-headless
+
+elasticsearch_reindex_apt_packages:
+  - elasticsearch={{ elasticsearch_reindex_version }}
   - openjdk-7-jre-headless
 
 elasticsearch_pip_packages:

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -16,7 +16,7 @@
 - name: Install apt packages
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: present
     update_cache: yes
     cache_valid_time: 600
   register: install_apt_packages

--- a/rpcd/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/main.yml
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: upgrade_pre_flight.yml
+  when:
+    - logging_upgrade | bool
 - include: upgrade_elasticsearch_pre.yml
   when:
     - logging_upgrade | bool
+    - proceed_with_upgrade | bool
 - include: elasticsearch_pre_install.yml
 - include: elasticsearch_install.yml
 - include: elasticsearch_post_install.yml

--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -30,7 +30,7 @@
 - name: Upgrade elasticsearch to stable 1.7.x version
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: present
     update_cache: yes
     cache_valid_time: 600
     dpkg_options: "force-confold"
@@ -38,7 +38,7 @@
   until: install_apt_packages|success
   retries: 5
   delay: 2
-  with_items: elasticsearch_apt_packages
+  with_items: elasticsearch_reindex_apt_packages
   tags:
     - logging-upgrade
     - elasticsearch-upgrade
@@ -109,6 +109,7 @@
 
 - name: Drop log_test1 template
   shell: 'curl -sk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
+  retries: 5
   tags:
     - logging-upgrade
     - elasticsearch-upgrade

--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_pre_flight.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_pre_flight.yml
@@ -1,0 +1,92 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: "Set initial values"
+  set_fact:
+    latest_version: false
+    reindex_version: false
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- name: "Get ElasticSearch version"
+  command: "dpkg-query --show --showformat='${Version}' elasticsearch"
+  register: elasticsearch_installed_version
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- name: "Check for ElasticSearch version > 2.x"
+  set_fact:
+    proceed_with_upgrade: false
+    latest_version: true
+  when: "{{ elasticsearch_installed_version.stdout | version_compare(elasticsearch_version, '>=', strict=True) }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- name: "Check for ElasticSearch version 1.7.x"
+  set_fact:
+    proceed_with_upgrade: false
+    reindex_version: true
+  when:
+    - "{{ elasticsearch_installed_version.stdout | version_compare(elasticsearch_reindex_version, '>=', strict=True) }}"
+    - "{{ elasticsearch_installed_version.stdout | version_compare('1.7.9', '<=', strict=True) }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- name: "Check for ElasticSEarch version > 1.4.x"
+  set_fact:
+    proceed_with_upgrade: true
+  when:
+    - "{{ elasticsearch_installed_version.stdout | version_compare('1.4.0', '>=', strict=True) }}"
+    - "{{ elasticsearch_installed_version.stdout | version_compare('1.6.9', '<=', strict=True) }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- name: "Check for force_upgrade=true"
+  set_fact:
+    proceed_with_upgrade: true
+  when:
+    - "{{ force_upgrade | bool }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- debug:
+    msg: "ElasticSearch is at the latest version, skipping reindexing steps."
+  when: "{{ latest_version | bool }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight
+
+- fail:
+    msg: "ElasticSearch is at the reindexing version, there may be a reindexing in progress.  Aborting installation, use -e 'force_upgrade=true' to continue."
+  when:
+    - "{{ reindex_version | bool }}"
+    - "{{ not force_upgrade | bool }}"
+  tags:
+    - logging-upgrade
+    - elasticsearch-upgrade
+    - elasticsearch-pre-flight


### PR DESCRIPTION
We need to perform verification before starting upgrade tasks in order
to avoid errors on subsequent runs. This commit creates the
upgrade_pre_flight.yml task file which does the following:

* Gathers the version information of the installed Elasticsearch package.

* Does the following checks:

  1. If the version is greater than 2.x bypass the reindexing steps
  entirely

  2. If the version is in the 1.7.x branch abort the run. This is due
  to the fact that if an installation is sitting on the 1.7.x branch
  there is a chance that a pre-upgrade reindexing is underway. Continuing
  with the upgrade tasks or updated package installs at this point could
  be damaging.

  3. If the version is less that 1.7.0 proceed with the reindex and
  upgrade.

* The force_upgrade variable was added so that in the event of a
pre-upgrade reindexing the playbook can be carried forward once the
reindexing is completed.

I have also created variables elasticsearch_version and
elasticsearch_reindex_version so that we can specify the versions of
elasticsearch to be used. We were using assumed versions in several
places which could lead to issues when packages are updated in the
repositories.

Thirdly I have added retries to the curl command in order to skip a
transient error that we have occasionally seen.

Connects https://github.com/rcbops/rpc-openstack/issues/1512

(cherry picked from commit 92079c55793d8dd984c0f6d47946d46a211553da)