### PR TITLE
Add release note regarding ElasticSearch upgrade

### DIFF
--- a/releasenotes/notes/always-set-logging_upgrade-true-c7c4f7ffe1551372.yaml
+++ b/releasenotes/notes/always-set-logging_upgrade-true-c7c4f7ffe1551372.yaml
@@ -1,0 +1,3 @@
+---
+issues:
+  - When upgrading ElasticSearch from RPCO r12 to r13, failure to set the Ansible var logging_upgrade=true may result in data corruption.


### PR DESCRIPTION
The ElasticSearch upgrade process, performed as part of a Liberty to
Mitaka upgrade, requires the Ansible var 'logging_upgrade' set to true.
Failure to do so may result in data corruption. This commit adds a
release note to document this issue for r13.1.0.

Connected https://github.com/rcbops/u-suk-dev/issues/550

(cherry picked from commit 74f832843f5997c9d6943d676727c2d99dd4fdee)