### PR TITLE
Check swift for bad rings

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_secrets.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_secrets.yml
@@ -18,3 +18,4 @@ rpc_support_holland_password:
 kibana_password:
 maas_rabbitmq_password:
 fsid_uuid:
+swift_accesscheck_password:

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -360,7 +360,7 @@ elasticsearch_process_names:
   # process name that includes "elasticsearch". The process running
   # elasticsearch is actually named "java" so we search for that here. This is
   # less than ideal, but the best we can do right now.
-  - java 
+  - java
 
 filebeat_process_names:
   - filebeat
@@ -443,7 +443,8 @@ openstack_service_remote_checks_list:
   - { name: "lb_api_check_heat_api", group: "heat_api" }
   - { name: "lb_api_check_heat_cfn", group: "heat_api_cfn" }
   - { name: "lb_api_check_heat_cloudwatch", group: "heat_api_cloudwatch" }
-  - { name: "lb_api_check_swift_proxy", group: "swift_proxy" }
+  - { name: "lb_api_check_swift_healthcheck", group: "swift_proxy" }
+  - { name: "lb_api_check_swift_access", group: "swift_proxy" }
 
 ssl_cert_checks_list:
   - { name: "lb_ssl_cert_expiry_check", group: "utility"}
@@ -545,3 +546,11 @@ verify_maas_retries: 5
 #               for offline testing
 #
 maas_use_api: true
+
+# Swift object access check
+swift_accesscheck_enabled: true
+swift_accesscheck_container: "accesscheck"
+swift_accesscheck_file: "index.html"
+swift_accesscheck_user_name: "accesscheck"
+swift_operator_role: "swiftoperator"
+swift_service_project_name: "service"

--- a/rpcd/playbooks/roles/rpc_maas/files/index.html
+++ b/rpcd/playbooks/roles/rpc_maas/files/index.html
@@ -1,0 +1,1 @@
+<html><body><p>OK</p></body></html>

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -45,6 +45,11 @@
   vars:
     internal_vip_address: "{{ internal_lb_vip_address }}"
 
+- include: swift_access_check.yml
+  when:
+    - swift_accesscheck_enabled | bool
+    - inventory_hostname == groups['swift_proxy'][0]
+
 - include: remote.yml
   vars:
     ip_address: "{{ external_lb_vip_address }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
@@ -27,7 +27,6 @@
   when:
     - inventory_hostname in groups['swift_hosts']
 
-
 # Setup Swift Server healthchecks
 - include: ensure_local_checks.yml
   vars:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/swift_access_check.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/swift_access_check.yml
@@ -1,0 +1,109 @@
+---
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Add a swift user for file checking
+- name: Create a keystone user for swift filecheck
+  keystone:
+    command: "ensure_user"
+    endpoint: "{{ keystone_service_adminurl }}"
+    login_user: "{{ keystone_admin_user_name }}"
+    login_password: "{{ keystone_auth_admin_password }}"
+    login_project_name: "{{ keystone_admin_tenant_name }}"
+    user_name: "{{ swift_accesscheck_user_name }}"
+    tenant_name: "{{ swift_service_project_name }}"
+    password: "{{ swift_accesscheck_password }}"
+    insecure: "{{ keystone_service_adminuri_insecure }}"
+  register: add_user
+  when:
+    - not swift_service_in_ldap | bool
+  until: add_user | success
+  retries: 5
+  delay: 10
+
+# Assign the swiftoperator role to the file checking user
+- name: Add swift role to user
+  keystone:
+    command: "ensure_user_role"
+    endpoint: "{{ keystone_service_adminurl }}"
+    login_user: "{{ keystone_admin_user_name }}"
+    login_password: "{{ keystone_auth_admin_password }}"
+    login_project_name: "{{ keystone_admin_tenant_name }}"
+    user_name: "{{ swift_accesscheck_user_name }}"
+    tenant_name: "{{ swift_service_project_name }}"
+    role_name: "{{ swift_operator_role }}"
+    insecure: "{{ keystone_service_adminuri_insecure }}"
+  register: add_user_role
+  when:
+    - not swift_service_in_ldap | bool
+  until: add_user_role | success
+  retries: 5
+  delay: 10
+
+# Copy test HTML file to the swift proxy for uploading
+- name: Create index file
+  copy:
+    dest: "/tmp/{{ swift_accesscheck_file }}"
+    src: "index.html"
+
+# Place an HTML file in a swift container
+- name: Upload check file to swift
+  shell: >
+    source /root/openrc;
+    /openstack/venvs/swift-{{ openstack_release }}/bin/swift upload
+    --object-name {{ swift_accesscheck_file }}
+    {{ swift_accesscheck_container }}
+    /tmp/{{ swift_accesscheck_file }}
+  args:
+    executable: "/bin/bash"
+  changed_when: false
+
+# Set global read permission on the swift container
+- name: Configure check container ACL
+  shell: >
+    source /root/openrc;
+    /openstack/venvs/swift-{{ openstack_release }}/bin/swift post -r '.r:*'
+    {{ swift_accesscheck_container }}
+  args:
+    executable: "/bin/bash"
+  changed_when: false
+
+# Configure the container to return an index file by default
+- name: Configure check container index file
+  shell: >
+    source /root/openrc;
+    /openstack/venvs/swift-{{ openstack_release }}/bin/swift post -m 'web-index:{{ swift_accesscheck_file }}'
+    {{ swift_accesscheck_container }}
+  args:
+    executable: "/bin/bash"
+  changed_when: false
+
+# Fetch the swift account token to build the URL
+- name: Retrieve check file key
+  shell: >
+    source /root/openrc;
+    /openstack/venvs/swift-{{ openstack_release }}/bin/swift stat {{ swift_accesscheck_container }}
+    {{ swift_accesscheck_file }} |
+    grep "Account:" |
+    awk '{ print $2 }'
+  args:
+    executable: "/bin/bash"
+  register: swift_url_key
+  changed_when: false
+
+# Set the full check URL as a fact
+- name: Set URL fact
+  set_fact:
+    swift_accesscheck_url: "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ external_lb_vip_address }}:8080/v1/{{ swift_url_key.stdout }}/{{ swift_accesscheck_container }}/{{ swift_accesscheck_file }}"
+    swift_access_url_key: "{{ swift_url_key.stdout }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_access.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_access.yaml.j2
@@ -1,0 +1,22 @@
+type              : remote.http
+label             : lb_api_check_swift_access--{{ lb_name }}
+disabled          : "{{ check_disabled }}"
+period            : "{{ maas_check_period }}"
+timeout           : "{{ maas_check_timeout }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ ip_address }}"
+details           :
+    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ ip_address }}:8080/v1/{{ hostvars[groups['swift_proxy'][0]]['swift_access_url_key'] }}/{{ swift_accesscheck_container }}/{{ swift_accesscheck_file }}"
+monitoring_zones_poll:
+{% for zone in maas_monitoring_zones %}
+  - {{ zone }}
+{% endfor %}
+alarms            :
+    lb_api_alarm_swift_access:
+        notification_plan_id: "{{ maas_notification_plan }}"
+        label               : lb_api_alarm_swift_access
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'Data unavailable.');
+            }

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_healthcheck.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_healthcheck.yaml.j2
@@ -1,5 +1,5 @@
 type              : remote.http
-label             : lb_api_check_swift_proxy--{{ lb_name }}
+label             : lb_api_check_swift_healthcheck--{{ lb_name }}
 disabled          : "{{ check_disabled }}"
 period            : "{{ maas_check_period }}"
 timeout           : "{{ maas_check_timeout }}"
@@ -12,9 +12,9 @@ monitoring_zones_poll:
   - {{ zone }}
 {% endfor %}
 alarms            :
-    lb_api_alarm_swift_proxy:
+    lb_api_alarm_swift_healthcheck:
         notification_plan_id: "{{ maas_notification_plan }}"
-        label               : lb_api_alarm_swift_proxy
+        label               : lb_api_alarm_swift_healthcheck
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -86,3 +86,4 @@
 - include: autocompletion.yml
 
 - include: configure_unattended_upgrades.yml
+


### PR DESCRIPTION
These changes create a swift object within a container which is checked by a MaaS check (lb_api_check_swift_access) to confirm swift is operating properly. If a return code other than 200 is received, swift is not returning object data. Generally, a 500 indicates the swift ring is corrupt in some way.

Support may want to take action given the result of this check to remove swift nodes from the ring, but we do not believe this process should be automated without confirmation.

Additionally, a load balancer check could be created on an F5 to verify access to this file. Any proxy not able to access the file properly could be removed, though again this may not be the most appropriate way to resolve the issue.

Connects #800 
