### PR TITLE
Add release process script and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ matrix:
       env: TOXENV=releasenotes
     - python: 2.7
       env: TOXENV=bashate
+    - python: 2.7
+      env: TOXENV=release-script
 
 sudo: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,33 @@
+# Release Process
+- [ ] Create the tag.
+
+  ```
+  git tag -a -m 'Release VERSION' VERSION COMMIT
+  git push REMOTE VERSION
+  ```
+- [ ] If creating an rc1 tag (the first release candidate) for a major or minor release:
+  - [ ] Create a new branch.
+
+    ```
+    git branch RELEASE-MAJOR.MINOR NEW_TAG
+    git push REMOTE RELEASE-MAJOR.MINOR
+    ```
+  - [ ] [Make the branch protected](https://github.com/rcbops/rpc-openstack/settings/branches). Copy the settings from one of the other protected branches. Access to settings is restricted, speak to a manager to get this step completed.
+
+- [ ] If tagging the first version of a minor release, i.e. rX.Y.0, there will no longer be patch releases for the previous minor:
+  - [ ] [Disable branch protection](https://github.com/rcbops/rpc-openstack/settings/branches) on the previous minor branch. Access to settings is restricted, speak to a manager to get this step completed.
+  - [ ] Delete the old branch.
+
+     ```
+    git push REMOTE --delete OLD_BRANCH
+    ```
+- [ ] If creating or deleting a branch, update the [issue template](https://github.com/rcbops/rpc-openstack/blob/master/.github/ISSUE_TEMPLATE.md) to include it in the list.
+- [ ] Update the [GitHub release notes](https://github.com/rcbops/rpc-openstack/releases) with output from rpc-differ, remember to tick pre-release if the tag is for a release candidate.
+
+  ```
+  rpc-differ --update PREVIOUS_TAG NEW_TAG | pandoc --from rst --to markdown_github
+  ```
+- [ ] [Close the old milestone](https://github.com/rcbops/rpc-openstack/milestones).
+- [ ] [Create a new milestone](https://github.com/rcbops/rpc-openstack/milestones) and set a target date of 14 days from the date of the new tag.
+- [ ] If this is a patch release, [create a docs issue](https://github.com/rackerlabs/docs-rpc) to get the release notes updated.
+- [ ] Announce the release on opc mailing list.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,3 +31,24 @@
 - [ ] [Create a new milestone](https://github.com/rcbops/rpc-openstack/milestones) and set a target date of 14 days from the date of the new tag.
 - [ ] If this is a patch release, [create a docs issue](https://github.com/rackerlabs/docs-rpc) to get the release notes updated.
 - [ ] Announce the release on opc mailing list.
+
+# Using the release script
+
+The python script ``release.py`` in the scripts directory can be used to automate
+the release process for patch releases and release candidates after the first one has
+been made.
+
+To release a patch release or a release candidate after rc1, run the ``release.py``
+script like so:
+```
+./release.py --github-token <YOUR-TOKEN> --tag <TAG> --commit <COMMIT>
+```
+
+To test the ``release.py`` script, override the repo URLs so the tag and the release
+is not created in the offical repository, but rather a forked version of it.
+For example:
+```
+./release.py --github-token YOUR_TOKEN --tag TAG --commit COMMIT \
+    --repo-url 'ssh://git@github.com/git-harry/rpc-openstack.git' \
+    --docs-repo-url 'ssh://git@github.com/git-harry/docs-rpc.git'
+```

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import datetime
+import errno
+import os
+import re
+import sys
+
+import github3
+import sh
+
+
+class Repo(object):
+    def __init__(self, url='', cache_dir='', bare=False):
+        valid_url = re.match(
+            r'(?P<url>^ssh://git@github.com/(?P<owner>[a-zA-Z0-9-]+)/'
+            r'(?P<name>[a-zA-Z0-9-]+).git$)',
+            url
+        )
+        if not valid_url:
+            raise ValueError('"%s" is not a valid URL.' % url)
+
+        self.url = valid_url.group('url')
+        self.owner = valid_url.group('owner')
+        self.name = valid_url.group('name')
+        self.cache_dir = os.path.expanduser(cache_dir)
+        self.bare = bare
+        self.dir = self.bare and '%s.git' % self.name or self.name
+        self.path = os.path.join(self.cache_dir, self.dir)
+        self.git = sh.git.bake(_cwd=self.path)
+
+        try:
+            self.remote = self._get_remote()
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                self.remote = 'origin'
+            else:
+                raise e
+
+        self._configure_repo()
+
+        self.tags = self._get_tags()
+
+    def _get_remote(self):
+        remote_output = self.git.remote(verbose=True).stdout
+        for line in remote_output.splitlines():
+            name, rest = line.split('\t')
+            if rest.startswith(self.url):
+                break
+        else:
+            name = self.owner
+            self.git.remote.add(name, self.url)
+
+        return name
+
+    def _configure_repo(self):
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir)
+        if not os.path.exists(self.path):
+            sh.git.clone(
+                self.url, self.dir, _cwd=self.cache_dir, bare=self.bare
+            )
+        if self.bare:
+            self.git.fetch(
+                self.remote, '+refs/heads/*:refs/heads/*', tags=True
+            )
+        else:
+            self.git.fetch()
+
+    def _get_tags(self):
+        all_tags = self.git.tag('-l')
+        valid_tags = []
+        for tag_str in all_tags:
+            try:
+                tag_obj = Tag(tag_str.strip(), repo=self)
+            except ValueError:
+                continue
+            else:
+                valid_tags.append(tag_obj)
+
+        valid_tags.sort()
+        return valid_tags
+
+    def create_tag(self, tag_str=None, major=None, minor=None, patch=None,
+                   rc=None, commit=None, message=None):
+        tag = Tag(tag_str=tag_str, major=major, minor=minor, patch=patch,
+                  rc=rc, repo=self)
+        self.git.tag(tag, commit, a=True, m=message)
+        self.git.push(self.remote, tag)
+        self.tags.append(tag)
+        self.tags.sort()
+        return tag
+
+
+class Tag(object):
+    """rpc-openstack Git repository tag object."""
+
+    def __init__(self, tag_str=None, major=None, minor=None, patch=None,
+                 rc=None, repo=None):
+        validate_tag = re.compile(
+            r'^r(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)'
+            r'(rc(?P<rc>[1-9][0-9]*))?$'
+        )
+        if tag_str:
+            valid_tag = validate_tag.match(tag_str)
+            if not valid_tag:
+                raise ValueError('%s is not a valid tag.' % tag_str)
+            _major = valid_tag.group('major')
+            _minor = valid_tag.group('minor')
+            _patch = valid_tag.group('patch')
+            _rc = valid_tag.group('rc')
+        elif None not in (major, minor, patch):
+            _major = major
+            _minor = minor
+            _patch = patch
+            _rc = rc
+        else:
+            raise ValueError('Insufficient data to construct tag.')
+
+        self.major = int(_major)
+        self.minor = int(_minor)
+        self.patch = int(_patch)
+        self.rc = _rc and int(_rc)
+        self.rc_for = self.rc and 'r%s.%s.%s' % (_major, _minor, _patch)
+        self.repo = repo
+
+    def __repr__(self):
+        tag_str = 'r%s.%s.%s' % (self.major, self.minor, self.patch)
+
+        if self.rc:
+            return '%src%s' % (tag_str, self.rc)
+        else:
+            return tag_str
+
+    def __lt__(self, other):
+        both_rc = all((self.rc, other.rc))
+        self_rc = (both_rc and self.rc) or (not bool(self.rc))
+        other_rc = (both_rc and other.rc) or (not bool(other.rc))
+
+        return ((self.major, self.minor, self.patch, self_rc) <
+                (other.major, other.minor, other.patch, other_rc))
+
+    def __le__(self, other):
+        return self < other or self == other
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __gt__(self, other):
+        return not self <= other
+
+    def __ge__(self, other):
+        return self > other or self == other
+
+    @property
+    def previous(self):
+        """Return the previous tag.
+
+        Determine the previous tag based on version numbers and return it. If
+        self is not a release candidate tag the previous tag cannot be either.
+        The previous tag does not examine the tags' timestamps and so the
+        previous tag returned may have been created after self.
+        :returns: :class: `__main__.Tag`, None
+        """
+        for tag in reversed(self.repo.tags):
+            if tag >= self:
+                continue
+            elif tag.rc and not self.rc:
+                continue
+            else:
+                previous = tag
+                break
+        else:
+            previous = None
+
+        return previous
+
+    @property
+    def next_revision(self):
+        """Return the next revision tag.
+
+        Calculate the next tag. The returned tag will be either the next patch
+        tag or the next release candidate tag depending on whether or not self
+        is release candidate.
+
+        The returned tag object is not associated with a repo to prevent it
+        from being mistaken for an actual Git tag on the repo.
+        :returns: :class: `__main__.Tag`, None
+        """
+        if self.rc:
+            patch = self.patch
+            rc = self.rc + 1
+        else:
+            patch = self.patch + 1
+            rc = self.rc
+
+        return Tag(major=self.major, minor=self.minor, patch=patch, rc=rc)
+
+
+class Release(object):
+    def __init__(self, tag, github_token=None):
+        self.tag = tag
+        self.repo = tag.repo
+        self.github_token = github_token
+        self.gh = self._get_github_session()
+        self.release_date = datetime.datetime.today()
+        self.next_release_date = self._calculate_next_due_date()
+        self.pre_release = bool(self.tag.rc)
+        self.diff = self._generate_release_diff()
+
+    def _get_github_session(self):
+        gh = github3.GitHub(token=self.github_token)
+        return gh.repository(self.repo.owner, self.repo.name)
+
+    def _calculate_next_due_date(self):
+        return self.release_date + datetime.timedelta(days=14)
+
+    def _generate_release_diff(self):
+        diff = sh.rpc_differ(self.tag.previous, self.tag, update=True).stdout
+        return sh.pandoc(
+            '--from', 'rst',
+            '--to', 'markdown_github',
+            _in=diff
+        ).stdout
+
+    def publish_release(self):
+        """Create GitHub release page for tag"""
+        try:
+            self.gh.create_release(tag_name=str(self.tag),
+                                   name='Release %s' % self.tag,
+                                   body=self.diff,
+                                   prerelease=self.pre_release)
+        except github3.exceptions.UnprocessableEntity:
+            existing_release = self.gh.release_from_tag(str(self.tag))
+            if existing_release:
+                raise Exception(
+                    'There is an existing release called %s.' % self.tag
+                )
+            else:
+                raise
+
+    def update_milestones(self):
+        """Create GitHub release page for tag"""
+        try:
+            self.gh.create_milestone(
+                title=str(self.tag.next_revision),
+                due_on=self.next_release_date.strftime('%Y-%m-%dT%H:%M:%SZ')
+            )
+        except github3.exceptions.UnprocessableEntity:
+            next_milestone = None
+            for milestone in self.gh.milestones():
+                if milestone.title == self.tag.next_revision:
+                    next_milestone = milestone
+                    break
+            if next_milestone:
+                raise Exception(
+                    'There is an existing milestone called %s.' % self.tag
+                )
+            else:
+                raise
+        for milestone in self.gh.milestones():
+            if milestone.title == self.tag:
+                milestone.update(state='closed')
+                break
+
+
+def request_doc_update(github_token, repo, release):
+    gh = github3.GitHub(token=github_token)
+    gh_repo = gh.repository(repo.owner, repo.name)
+    issue_title = 'RPCO Release %s' % release.tag
+    issue_body = (
+        'Update release notes and documentation history.\n\n'
+        'This new RPCO release is now available to be deployed on customer'
+        ' environments. [Release notes can be viewed on GitHub] [1]\n'
+        '[1]: https://github.com/rcbops/rpc-openstack/releases/tag/%s'
+    ) % release.tag
+    issue = gh_repo.create_issue(title=issue_title, body=issue_body)
+    major = release.tag.major
+    try:
+        repo.git('rev-parse', '--verify', '%s/v%s' % (repo.remote, major + 1))
+    except sh.ErrorReturnCode_128:
+        from_branch = 'issues/%s/master' % issue.number
+        to_branch = 'master'
+        cherrypick = {'from_branch': 'issues/%s/v%s' % (issue.number, major),
+                      'to_branch': 'v%s' % major}
+    else:
+        from_branch = 'issues/%s/v%s' % (issue.number, major)
+        to_branch = 'v%s' % major
+        cherrypick = None
+    repo.git.checkout('%s/%s' % (repo.remote, to_branch), b=from_branch)
+    overview_file = os.path.join(repo.path, 'common/overview-dochistory.rst')
+
+    with open(overview_file) as fo_r:
+        overview_data = fo_r.readlines()
+
+    overview_addition = (
+        '   * - %s\n     - Rackspace Private Cloud %s release\n' %
+        (release.release_date.strftime('%Y-%m-%d'), release.tag)
+    )
+    with open(overview_file, 'w') as fo_w:
+        for num, line in enumerate(overview_data):
+            fo_w.write(line)
+            if line.strip() == '- Release information':
+                fo_w.write(overview_addition)
+                break
+        else:
+            raise Exception('"%s" does not match expected format.' %
+                            overview_file)
+        fo_w.writelines(overview_data[num + 1:])
+
+    repo.git.add(overview_file)
+
+    if major == 11:
+        whats_new_file = os.path.join(
+            repo.path, 'doc/rpc-releasenotes/whats-new-v%s-1.rst' % major
+        )
+    else:
+        whats_new_file = os.path.join(
+            repo.path, 'doc/rpc-releasenotes/whats-new-v%s.rst' % major
+        )
+
+    with open(whats_new_file) as fn_r:
+        whats_new_data = fn_r.readlines()
+
+    whats_new_addition = (
+        '\n- For detailed changes in RPCO %(tag)s, see'
+        '\n  `github.com/rcbops/rpc-openstack/releases/tag/%(tag)s'
+        '\n  <https://github.com/rcbops/rpc-openstack/releases/tag/%(tag)s>`_.'
+        '\n\n  - This is a maintenance release.\n'
+    ) % {'tag': release.tag}
+
+    whats_new_addition_12 = (
+        '\n  * For detailed changes in rpc-openstack release %(tag)s, see'
+        '\n    `github.com/rcbops/rpc-openstack/releases/tag/%(tag)s\n'
+        '      <https://github.com/rcbops/rpc-openstack/releases/tag/%(tag)s>`'
+        '_.\n\n    - %(tag)s includes fixes for several bugs\n'
+    ) % {'tag': release.tag}
+
+    whats_new_addition_11 = (
+        '\n- To see detailed changes in the RPCO'
+        '\n  `%(tag)s <https://github.com/rcbops/rpc-openstack/releases/tag/'
+        '%(tag)s>`_'
+        '\n  release, click the `%(prev)s...%(tag)s change'
+        '\n  log <https://github.com/rcbops/rpc-openstack/compare/'
+        '%(prev)s...%(tag)s>`_.\n'
+    ) % {'tag': release.tag, 'prev': release.tag.previous}
+
+    with open(whats_new_file, 'w') as fn_w:
+        for num, line in enumerate(whats_new_data):
+            fn_w.write(line)
+            if major == 12 and set(line.strip()) == {'~'}:
+                fn_w.write(whats_new_addition_12)
+                break
+            elif major == 11 and line.strip() == '**Changes per release**':
+                fn_w.write(whats_new_addition_11)
+                break
+            elif major not in (11, 12) and set(line.strip()) == {'~'}:
+                fn_w.write(whats_new_addition)
+                break
+        else:
+            raise Exception('"%s" does not match expected format.' %
+                            whats_new_file)
+        fn_w.writelines(whats_new_data[num + 1:])
+
+    repo.git.add(whats_new_file)
+
+    msg_title = 'Add release %s to documentation' % release.tag
+    msg_body = 'Issue: %s' % issue.html_url
+    repo.git.commit(m='%s\n\n%s' % (msg_title, msg_body))
+    repo.git.push(repo.remote, from_branch)
+    gh_repo.create_pull(title=msg_title, body=msg_body, base=to_branch,
+                        head=from_branch)
+
+    if cherrypick:
+        repo.git.checkout('%s/%s' % (repo.remote, cherrypick['to_branch']),
+                          b=cherrypick['from_branch'])
+        repo.git('cherry-pick', from_branch, x=True)
+        repo.git.push(repo.remote, cherrypick['from_branch'])
+        gh_repo.create_pull(title=msg_title,
+                            body=msg_body,
+                            base=cherrypick['to_branch'],
+                            head=cherrypick['from_branch'])
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description='Publish RPCO tag.')
+    parser.add_argument(
+        '--cache-dir', help='Directory where cached data will be stored.',
+        type=os.path.expanduser, default='~/.rpco-release-tool',
+    )
+    parser.add_argument(
+        '--repo-url', help='URL of repo to update.',
+        default='ssh://git@github.com/rcbops/rpc-openstack.git',
+    )
+    parser.add_argument(
+        '--docs-repo-url', help='URL of docs repo to update.',
+        default='ssh://git@github.com/rackerlabs/docs-rpc.git',
+    )
+    parser.add_argument(
+        '--tag', type=Tag, required=True, help='Name of new tag.'
+    )
+    existing = parser.add_mutually_exclusive_group(required=True)
+    existing.add_argument(
+        '--commit', help='Reference to the commit to tag.'
+    )
+    existing.add_argument(
+        '--existing-release', default=False, action='store_true'
+    )
+    parser.add_argument('--github-token')
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.tag.rc == 1 or (not args.tag.rc and not args.tag.patch):
+        return (
+            'The script currently only supports patch releases and release '
+            'candidates after the initial one.'
+        )
+
+    proceed_text = (
+        'WARNING - Running this script will:\n'
+        '  - add a tag to %s\n'
+        '  - submit an issue/pull-request to %s\n'
+        'If you still wish to proceed type "YES": '
+    ) % (args.repo_url, args.docs_repo_url)
+
+    proceed = raw_input(proceed_text)
+
+    if proceed != 'YES':
+        return
+
+    rpco_repo = Repo(url=args.repo_url, cache_dir=args.cache_dir, bare=True)
+
+    if args.existing_release:
+        rpco_tag = rpco_repo.tags[rpco_repo.tags.index(args.tag)]
+    else:
+        tag_message = 'Release %s' % args.tag
+        rpco_tag = rpco_repo.create_tag(
+            tag_str=str(args.tag), commit=args.commit, message=tag_message
+        )
+
+    release = Release(rpco_tag, github_token=args.github_token)
+
+    if not args.existing_release:
+        release.publish_release()
+        release.update_milestones()
+    if not release.pre_release:
+        docs_repo = Repo(url=args.docs_repo_url, cache_dir=args.cache_dir,
+                         bare=False)
+        request_doc_update(args.github_token, docs_repo, release)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -1,0 +1,216 @@
+# Copyright 2016, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import os.path
+import unittest
+
+from release import Repo, Tag
+
+import release
+
+
+class TestTagMethods(unittest.TestCase):
+    def test_tag_str(self):
+        tag_strings = ('r1.2.3', 'r1.2.3rc1', 'r1.2.3rc1')
+        for tag_string in tag_strings:
+            tag = Tag(tag_string)
+            self.assertEqual(tag_string, str(tag))
+
+    def test_tag_initialisation_equivalence(self):
+        tags = (
+            ('r1.2.3', '1', '2', '3', None),
+            ('r1.2.3rc1', '1', '2', '3', '1'),
+        )
+        for tag_string, major, minor, patch, rc in tags:
+            tag_from_string = Tag(tag_string)
+            tag_from_parts = Tag(major=major, minor=minor, patch=patch, rc=rc)
+            self.assertEqual(tag_from_string, tag_from_parts)
+
+    def test_tag_initialisation_failures(self):
+        bad_tags = ('1.2.3', 'v1.2.3', 'r1.2.3rc0', 'r1.2')
+
+        for tag in bad_tags:
+            self.assertRaises(ValueError, Tag, tag)
+
+    def test_tag_comparison(self):
+        tags_different = (
+            ('r1.0.0rc1', 'r1.0.0rc2'),
+            ('r1.0.0rc2', 'r1.0.0'),
+            ('r1.0.0', 'r1.0.1'),
+            ('r1.0.0', 'r1.1.0'),
+            ('r1.0.0', 'r2.0.0rc1'),
+            ('r1.0.0', 'r2.0.0'),
+            ('r2.0.0', 'r10.0.0'),
+            ('r1.2.0', 'r1.10.0'),
+            ('r1.0.2', 'r1.0.10'),
+            ('r1.0.0rc2', 'r1.0.0rc10'),
+        )
+
+        for smaller, bigger in tags_different:
+            self.assertLess(Tag(smaller), Tag(bigger))
+            self.assertLessEqual(Tag(smaller), Tag(bigger))
+            self.assertGreater(Tag(bigger), Tag(smaller))
+            self.assertGreaterEqual(Tag(bigger), Tag(smaller))
+            self.assertNotEqual(Tag(bigger), Tag(smaller))
+
+        tag_strings = ('r1.2.3', 'r1.2.3rc1')
+        for tag in tag_strings:
+            self.assertEqual(Tag(tag), Tag(tag))
+            self.assertLessEqual(Tag(tag), Tag(tag))
+            self.assertGreaterEqual(Tag(tag), Tag(tag))
+
+    def test_previous(self):
+        tag_string_pairs = (
+            ('r1.0.0rc1', None),
+            ('r1.0.0rc2', 'r1.0.0rc1'),
+            ('r1.0.0', None),
+            ('r2.0.0rc1', 'r1.0.0'),
+            ('r2.0.0', 'r1.0.0'),
+            ('r2.0.1', 'r2.0.0')
+        )
+        tags = []
+        repo = mock.Mock(tags=tags)
+        tag_pairs = []
+        for current, previous in tag_string_pairs:
+            current_tag = Tag(current, repo=repo)
+            previous_tag = previous and Tag(previous, repo=repo)
+
+            tags.append(current_tag)
+            previous_tag and tags.append(previous_tag)
+
+            tag_pairs.append((current_tag, previous_tag))
+
+        tags.sort()
+
+        for tag, previous in tag_pairs:
+            self.assertEqual(tag.previous, previous)
+
+    def test_next_revision(self):
+        tag_string_pairs = (
+            ('r1.0.0rc1', 'r1.0.0rc2'),
+            ('r1.0.0', 'r1.0.1'),
+            ('r2.3.4', 'r2.3.5'),
+        )
+
+        for tag, next_tag in tag_string_pairs:
+            self.assertEqual(Tag(tag).next_revision, Tag(next_tag))
+
+
+class TestRepoMethods(unittest.TestCase):
+    def setUp(self):
+        release.sh.git = mock.Mock()
+        self.git = release.sh.git.bake()
+        release.os.makedirs = mock.Mock()
+        release.os.path.exists = mock.Mock(return_value=True)
+        release.os.path.expandsuser = mock.Mock(side_effect=lambda x: x)
+
+    def test_repo_url_validation(self):
+        remote = 'origin'
+        Repo._get_remote = mock.Mock(return_value=remote)
+        Repo._configure_repo = mock.Mock()
+        Repo._get_tags = mock.Mock()
+        valid_urls = (
+            'ssh://git@github.com/testowner/testrepo.git',
+        )
+        invalid_urls = (
+            '',
+            'https://github.com/testowner/testrepo.git',
+        )
+        for valid_url in valid_urls:
+            repo = Repo(valid_url)
+            self.assertEqual(repo.url, valid_url)
+
+        for invalid_url in invalid_urls:
+            self.assertRaises(ValueError, Repo, invalid_url)
+
+    def test_repo_defaults(self):
+        remote = 'origin'
+        Repo._get_remote = mock.Mock(return_value=remote)
+        Repo._configure_repo = mock.Mock()
+        tags = mock.Mock()
+        Repo._get_tags = mock.Mock(return_value=tags)
+        owner = 'testowner'
+        name = 'testrepo'
+        cache_dir = ''
+        url = 'ssh://git@github.com/%s/%s.git' % (owner, name)
+
+        attributes = {
+            'url': url,
+            'owner': owner,
+            'name': name,
+            'cache_dir': cache_dir,
+            'bare': False,
+            'dir': name,
+            'path': name,
+            'git': self.git,
+            'tags': tags,
+        }
+        repo = Repo(url)
+
+        for attribute, value in attributes.items():
+            self.assertEqual(getattr(repo, attribute), value)
+
+    def test_repo_overrides(self):
+        remote = 'origin'
+        Repo._get_remote = mock.Mock(return_value=remote)
+        Repo._configure_repo = mock.Mock()
+        tags = mock.Mock()
+        Repo._get_tags = mock.Mock(return_value=tags)
+        owner = 'testowner'
+        name = 'testrepo'
+        cache_dir = 'testcachedir'
+        directory = '%s.git' % name
+        url = 'ssh://git@github.com/%s/%s.git' % (owner, name)
+        bare = True
+
+        attributes = {
+            'url': url,
+            'owner': owner,
+            'name': name,
+            'cache_dir': cache_dir,
+            'bare': bare,
+            'dir': directory,
+            'path': os.path.join(cache_dir, directory),
+            'git': self.git,
+            'tags': tags,
+        }
+        repo = Repo(url, cache_dir=cache_dir, bare=bare)
+
+        for attribute, value in attributes.items():
+            self.assertEqual(getattr(repo, attribute), value)
+
+    def test_create_tag(self):
+        remote = 'origin'
+        Repo._get_remote = mock.Mock(return_value=remote)
+        Repo._configure_repo = mock.Mock()
+        tags = [Tag('r1.0.0'), Tag('r1.5.0')]
+        Repo._get_tags = mock.Mock(return_value=tags)
+
+        owner = 'testowner'
+        name = 'testrepo'
+        url = 'ssh://git@github.com/%s/%s.git' % (owner, name)
+
+        repo = Repo(url)
+
+        tag_str = 'r1.2.3'
+        commit = 'commit'
+        message = 'Test tag.'
+        tag = repo.create_tag(tag_str, commit=commit, message=message)
+
+        self.git.tag.assert_called_once_with(tag, commit, a=True, m=message)
+        self.git.push.assert_called_once_with(remote, tag)
+        self.assertIn(tag, repo.tags)
+        self.assertEqual(repo.tags.index(tag), 1)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,3 +12,8 @@ sphinx>=1.3.4
 oslosphinx>=2.5.0 # Apache-2.0
 reno>=0.1.1 #Apache-2.0
 sphinx_rtd_theme>=0.1.9
+
+# release.py testing
+github3.py
+mock
+sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = flake8,ansible-lint,bashate,docs,releasenotes
+envlist = flake8,ansible-lint,bashate,docs,releasenotes,release-script
 
 [testenv]
 passenv = ANSIBLE_VERSION
@@ -48,6 +48,9 @@ commands =
         ansible-galaxy install -r {toxinidir}/ansible-role-requirements.yml; \
         ansible-galaxy install -r {homedir}/openstack-ansible-role-requirements.yml; \
         {toxinidir}/scripts/linting-ansible.sh"
+
+[testenv:release-script]
+commands = python -m unittest discover -s scripts -p test_release.py -v
 
 [flake8]
 # Ignores the following rules due to how ansible modules work in general


### PR DESCRIPTION
RELEASING.md documents the current release process for releasing major,
minor, patch/revision and release candidate (rc) releases.

release.py automates the process of releasing patch and release
candidate (excluding rc1) releases. It depends on pandoc, rpc-differ and
the python module sh.

In general, the following should be run to complete a release:

```
./release.py --github-token YOUR_TOKEN --tag TAG --commit COMMIT
```

For a complete help message:

```
./release.py --help
```

When testing, be sure to override the repo URLs, e.g.:

```
./release.py --github-token YOUR_TOKEN --tag TAG --commit COMMIT \
    --repo-url 'ssh://git@github.com/git-harry/rpc-openstack.git' \
    --docs-repo-url 'ssh://git@github.com/git-harry/docs-rpc.git'
```

Some basic unit testing has been added and can be run with tox.

Connected https://github.com/rcbops/u-suk-dev/issues/535
