### PR TITLE
Remove reindex-wapper tag from 2 tasks

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -262,7 +262,6 @@
   tags:
     - logging-upgrade
     - elasticsearch-upgrade
-    - reindex-wrapper
 
 - name: Remove legacy apt repositories
   apt_repository:
@@ -276,7 +275,6 @@
   tags:
     - logging-upgrade
     - elasticsearch-upgrade
-    - reindex-wrapper
 
 - name: Flush apt cache
   apt:


### PR DESCRIPTION
The reindex-wrapper tag was incorrectly applied to 2 removal tasks.
The first task removes legacy plugins of which the reindex-liberty.py uses
to do the actual reindexing. The other removes the legacy apt packages
which is less of an issue but may be needed again during a pre-upgrade
reindexing.

Connects https://github.com/rcbops/u-suk-dev#1550
Connects #1550