### PR TITLE
Reduce unnecessary metrics of osd status check

### DIFF
--- a/maas/plugins/ceph_monitoring.py
+++ b/maas/plugins/ceph_monitoring.py
@@ -70,17 +70,15 @@ def get_osd_statistics(client=None, keyring=None, osd_ids=None):
         else:
             msg = 'The OSD ID %s does not exist.' % osd_id
             raise maas_common.MaaSException(msg)
-        for key in ('up', 'in'):
-            name = '_'.join((osd_ref, key))
-            maas_common.metric_bool(name, osd[key])
+
+        key = 'up'
+        name = '_'.join((osd_ref, key))
+        maas_common.metric_bool(name, osd[key])
 
         for _osd in pg_osds_dump:
             if _osd['osd'] == osd_id:
                 osd = _osd
                 break
-        for key in ('kb', 'kb_used', 'kb_avail'):
-            name = '_'.join((osd_ref, key))
-            maas_common.metric(name, 'uint64', osd[key])
 
 
 def get_cluster_statistics(client=None, keyring=None):


### PR DESCRIPTION
Current we build 5 metrics ('up', 'in', 'kb', 'kb_used', and
'kb_avail') for each OSD stat check, and most of them are not
pratically used. MaaS limits only 50 metrics at most, and it's so
easy to get check fail when large OSD scale.  So we only leave
'up' metric to tolerate up to 25 OSDs stats check.

Connected https://github.com/rcbops/rpc-openstack/issues/1182