### PR TITLE
Properly generate secrets files

### DIFF
--- a/releasenotes/notes/handle-merging-new-secrets-0e1fd06d86f0abbd.yaml
+++ b/releasenotes/notes/handle-merging-new-secrets-0e1fd06d86f0abbd.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - The ``update-yaml.py`` script now contains an optional
+    argument, ``--output-file``, for specifying an output
+    file.
+upgrade:
+  - Any new secret variables that may be introduced in
+    later releases are now handled by the ``update-secrets.sh``
+    script. ``test-upgrade.sh`` and ``deploy.sh`` have been updated
+    to use ``update-secrets.sh`` to handle any new variables
+    that may be introduced in newer releases. If the deployer
+    is not using these scripts for upgrades, then
+    ``update-secrets.sh`` needs to be invoked manually. Please
+    see official RPCO upgrade docs for usage.
+fixes:
+  - Secret variables defined in rpco specific variable
+    files are now properly merged with any new secret
+    variables that might be introduced in a subsequent
+    release.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -138,6 +138,9 @@ if [[ ! -f /etc/openstack_deploy/user_osa_secrets.yml ]] && [[ -f /etc/openstack
   mv /etc/openstack_deploy/user_secrets.yml /etc/openstack_deploy/user_osa_secrets.yml
 fi
 
+# update the RPC-O secrets
+bash ${BASE_DIR}/scripts/update-secrets.sh
+
 # ensure all needed passwords and tokens are generated
 ./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_osa_secrets.yml
 ./scripts/pw-token-gen.py --file $RPCD_SECRETS

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -45,14 +45,9 @@ if [[ ! -f "/etc/openstack_deploy/user_osa_variables_overrides.yml" ]]; then
     --output-file /etc/openstack_deploy/user_osa_variables_overrides.yml
   rm -f /etc/openstack_deploy/user_variables.yml
 fi
-# TODO: We need to eventually find a proper way to migrate these secret variables.
-#       For now, we just copy existing secret variables defined previously on the
-#       liberty install. This won't cause any problems since there aren't any new
-#       secret variables in mitaka that are not defined in liberty.
-if [[ -f "/etc/openstack_deploy/user_extras_secrets.yml" ]]; then
-  mv /etc/openstack_deploy/user_extras_secrets.yml \
-     /etc/openstack_deploy/user_rpco_secrets.yml
-fi
+
+$BASE_DIR/scripts/update-secrets.sh
+
 if [[ -f "/etc/openstack_deploy/user_secrets.yml" ]]; then
   mv /etc/openstack_deploy/user_secrets.yml \
      /etc/openstack_deploy/user_osa_secrets.yml

--- a/scripts/update-secrets.sh
+++ b/scripts/update-secrets.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x
+
+export OA_DIR=${OA_DIR:-"$BASE_DIR/openstack-ansible"}
+export RPCD_DIR=${RPCD_DIR:-"$BASE_DIR/rpcd"}
+
+# If the user_rpco_secrets.yml file exists in the user config, then merge that with
+# the user_rpco_secrets.yml in tree. Otherwise, see if the user_extras_secrets.yml
+# file exists and if so, use that.
+if [[ -f "/etc/openstack_deploy/user_rpco_secrets.yml" ]]; then
+  OVERRIDES="/etc/openstack_deploy/user_rpco_secrets.yml"
+elif [[ -f "/etc/openstack_deploy/user_extras_secrets.yml" ]]; then
+  OVERRIDES="/etc/openstack_deploy/user_extras_secrets.yml"
+else
+  echo "Cannot find user defined rpco secrets file! Please copy an rpco secrets file to /etc/openstack_deploy/"
+  exit
+fi
+
+python2.7 /opt/rpc-openstack/scripts/update-yaml.py --output-file /etc/openstack_deploy/user_rpco_secrets.yml $RPCD_DIR/etc/openstack_deploy/user_rpco_secrets.yml $OVERRIDES
+python2.7 $OA_DIR/scripts/pw-token-gen.py --file /etc/openstack_deploy/user_rpco_secrets.yml

--- a/scripts/update-yaml.py
+++ b/scripts/update-yaml.py
@@ -25,6 +25,9 @@ def parse_args():
                              'configuration.')
     parser.add_argument('overrides',
                         help='The path to the yaml file with overrides.')
+    parser.add_argument('--output-file',
+                        help='The name of the file that will contain both '
+                             'base and overrides')
     return parser.parse_args()
 
 
@@ -51,6 +54,11 @@ if __name__ == '__main__':
     base = get_config(args.base)
     overrides = get_config(args.overrides)
     config = dict(base.items() + overrides.items())
+
     if config:
-        with open(args.base, 'w') as f:
+        if args.output_file:
+            output_file = args.output_file
+        else:
+            output_file = args.base
+        with open(output_file, 'w') as f:
             f.write(str(yaml.safe_dump(config, default_flow_style=False)))


### PR DESCRIPTION
This allows for the secrets file to be merged with the existing
secrets files without leaving any of the new secrets ungenerated.
This cleans up from our old way of copying the existing secrets
file from the previous installation. 

Connects http://github.com/rcbops/u-suk-dev#475