### PR TITLE
Use OSA's stable/newton version of tempest

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -222,7 +222,16 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
 
   if [[ "${DEPLOY_TEMPEST}" == "yes" ]]; then
     # Deploy tempest
-    run_ansible os-tempest-install.yml
+    # NOTE(mattt): This is an attempt to reduce the number of tempest-related
+    #              gate failures that we are seeing.  We cannot have the repo
+    #              server build this version of tempest because it has
+    #              requirements that do not jive with stable/mitaka.
+    run_ansible os-tempest-install.yml -e tempest_developer_mode=true \
+                                       -e tempest_git_repo=https://git.openstack.org/openstack/tempest \
+                                       -e tempest_git_install_branch=304802830b56354a83bad86925851107411d45ec \
+                                       -e tempest_requirements_git_repo=https://git.openstack.org/openstack/requirements \
+                                       -e tempest_requirements_git_install_branch=6c86e861875529f87b09244de355d5df865b7adc \
+                                       -e pip_install_options=--isolated
   fi
 
 fi


### PR DESCRIPTION
This commit updates scripts/deploy.sh to use OSA's stable/newton
version of tempest.  We cannot have the repo server build the later
version as requirements of this version do not fall in line with
stable/mitaka's global requirements.

Bumping tempest specifically should fix the frequent
test_reboot_server_hard failures that we are seeing, but hopefully
fixes other issues also.

The upstream tempest review which addresses the issue:

[1] https://review.openstack.org/#/c/340723/

Connects https://github.com/rcbops/u-suk-dev/issues/278