### PR TITLE
Add cinder_backup_check to venv

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
@@ -4,8 +4,8 @@ disabled    : false
 period      : "{{ maas_check_period }}"
 timeout     : "{{ maas_check_timeout }}"
 details     :
-    file    : cinder_service_check.py
-    args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_backup_status :
         label                   : cinder_backup_status--{{ ansible_hostname }}


### PR DESCRIPTION
Once we moved most of MaaS checks to venv, but cinder_backup_check
is left over, though it's working fine with current dependency.
Here's the fix to add it venv in case improper behevior on future
updated dependency.

Connected https://github.com/rcbops/rpc-openstack/issues/1307