### PR TITLE
Add RPC defaults for cinder

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -26,6 +26,9 @@ db_max_overflow: 60
 db_max_pool_size: 120
 db_pool_timeout: 60
 
+cinder_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
+cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
+
 keystone_database_max_pool_size: "{{ db_max_pool_size }}"
 keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 


### PR DESCRIPTION
This change overrides OSA defaults for cinder's thread_pool_size and response_time. The defaults are now set to `rpc_thread_pool_size` and `rpc_response_timeout`.

Connects #1360