### PR TITLE
Check openstack-ansible submodule status

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,6 +29,22 @@ function run_ansible {
   openstack-ansible ${ANSIBLE_PARAMETERS} --forks ${FORKS} $@
 }
 
+# Confirm OA_DIR is properly checked out
+submodulestatus=$(git submodule status ${OA_DIR})
+case "${submodulestatus:0:1}" in
+  "-")
+    echo "ERROR: rpc-openstack submodule is not properly checked out"
+    exit 1
+    ;;
+  "+")
+    echo "WARNING: rpc-openstack submodule does not match the expected SHA"
+    ;;
+  "U")
+    echo "ERROR: rpc-openstack submodule has merge conflicts"
+    exit 1
+    ;;
+esac
+
 # begin the bootstrap process
 cd ${OA_DIR}
 


### PR DESCRIPTION
When executing the deploy script, check for the presence of a properly
checked out openstack-ansible submodule. This check will not attempt to
update the submodule.

If the submodule is not checked out or has merge conflicts, an error
message will be printed and the deploy script will halt execution. This
is to prevent missing or broken files from causing partial or incorrect
deployments.

If the submodule is checked out, but does not match the expected SHA,
a warning message will be printed but the deploy script will continue
execution. This is to allow local changes or specific versions of OSA
to be tested during deployment.

Connects #1328

(cherry picked from commit 1cd5977f2a20ec6bc4dd53039b62fdff65f9379c)