### PR TITLE
Add RPC defaults for cinder

### DIFF
--- a/rpcd/etc/openstack_deploy/user_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_variables.yml
@@ -18,6 +18,9 @@ rpc_conn_pool_size: 180
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
 
+cinder_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
+cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
+
 keystone_database_max_pool_size: 120
 keystone_database_pool_timeout: 60
 


### PR DESCRIPTION
This change overrides OSA defaults for cinder's thread_pool_size and
response_time. The defaults are now set to rpc_thread_pool_size and
rpc_response_timeout.

Connects #1360

(cherry picked from commit 016425a2032ff8369be089b310802f46af91072f)