### PR TITLE
Reduce failures due to MaaS issues

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_remote.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_remote.yml
@@ -13,22 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Verify raxmon-entities-list and MaaS API authentication does not fail
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-entities-list
-  register: raxmon_output
-  failed_when: raxmon_output.rc != 0
-
 - name: Entity {{ entity_name }} count
   shell: |
+    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l
+  args:
+    executable: "/bin/bash"
   register: entity_count
+  until: entity_count|success
+  retries: 5
+  delay: 2
 
 - name: Zero entities with label {{ entity_name }} exist
   fail:
@@ -42,11 +39,17 @@
 
 - name: Get entity {{ entity_name }}
   shell: |
+    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | awk '{print $2}' | cut -d= -f2
+  args:
+    executable: "/bin/bash"
   register: entity
+  until: entity|success
+  retries: 5
+  delay: 2
 
 - name: Assign agent ID to entity
   shell: |
@@ -57,11 +60,17 @@
 
 - name: Agent token {{ entity_name }} count
   shell: |
+    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-agent-tokens-list | grep ' label={{ entity_name }}, ' | wc -l
+  args:
+    executable: "/bin/bash"
   register: agent_token_count
+  until: agent_token_count|success
+  retries: 5
+  delay: 2
   when: maas_agent_token is not defined
 
 - name: At most one {{ entity_name }} agent token should exist
@@ -80,11 +89,17 @@
 
 - name: Get agent token
   shell: |
+    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-agent-tokens-list | grep '<AgentToken: id=.* label={{ entity_name }}, .*>' | awk '{print $2}' | sed -e 's/id=\(.*\),/\1/g'
+  args:
+    executable: "/bin/bash"
   register: maas_agent_token_id
+  until: maas_agent_token_id|success
+  retries: 5
+  delay: 2
   when: maas_agent_token is not defined
 
 - name: Set agent token fact
@@ -98,7 +113,6 @@
     mode: 0600
     owner: root
     group: root
-
 
 - name: Start raxmon agent
   service:

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -24,6 +24,7 @@
 - name: Install MaaS
   hosts: hosts:all_containers
   user: root
+  any_errors_fatal: true
   pre_tasks:
     # This is needed to set the rpc_openstack_repo and rpc_release variables
     # correctly


### PR DESCRIPTION
This commit does the following:

- adds retries to tasks that call raxmon-*-list because on very large
  accounts these calls can result in timeouts, 500s, etc. and a single
  API failure should be retried in the event that the failure is
  transient
- removes the failed_when from the `Verify raxmon-entities-list and
  MaaS API authentication does not fail` task as this is specifying the
  standard failure criteria
- adds any_errors_fatal=True to setup-maas.yml so that a failure of a
  task will fail the playbook immediate rather than allow the playbook
  to continue to the end [1]

[1] This is helpful because setup-maas.yml basically operates on all
hosts and containers. If a host fails on (for example) `Verify
raxmon-entities-list and MaaS API authentication does not fail` the
playbook will continue on through the rest of the role because we have
so many hosts included in the hosts line.

Connects https://github.com/rcbops/u-suk-dev/issues/703