### PR TITLE
Add retry to restart of apache2

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/handlers/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/handlers/main.yml
@@ -2,3 +2,7 @@
   service:
     name: apache2
     state: restarted
+  register: apache_restart
+  until: apache_restart|success
+  retries: 5
+  delay: 2


### PR DESCRIPTION
This commit adds a retry to the restart of apache2 in the
horizon_extensions role.  This is will hopefully fix the periodic
restart failures that we see in the gate that appear to be
environmental (ie. a result of the instance's load).

We have attempted to debug a misconfiguration of port, another service
binding to ports 80/443, but in both situation everything appeared as
expected.  Also, we attempted to recreate this in a development
environment but were not able to replicate teh failure.

Connects https://github.com/rcbops/u-suk-dev/issues/552

(cherry picked from commit c24feb24e5fa4e4a825e27e74d836a47c12bebe0)