### PR TITLE
[DO NOT MERGE] Remove remote and filebeat checks

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -49,8 +49,12 @@ maas_target_alias: public0_v4
 # Set whether checks should be enabled or disabled
 ssl_check: false
 dell_check: false
-remote_check: true
+remote_check: false
 hp_check: false
+
+# Disable filebeat checks to debug maas issues
+maas_excluded_checks:
+  - filebeat_process_check
 
 # Set the LB device name in CORE
 #lb_name: 'unspecified'


### PR DESCRIPTION
The maas team has asked us to run our maas plugins with
half the checks to debug some issues we are having
with our maas account. This commit disables remote and
filebeat checks, which constitute about half our checks.

Connects https://github.com/rcbops/u-suk-dev/issues/809