### PR TITLE
Revert "Reduce failures due to MaaS issues"

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_remote.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_remote.yml
@@ -13,19 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Verify raxmon-entities-list and MaaS API authentication does not fail
+  shell: |
+    {% if maas_venv_enabled | bool %}
+    . {{ maas_venv_bin }}/activate
+    {% endif %}
+    raxmon-entities-list
+  register: raxmon_output
+  failed_when: raxmon_output.rc != 0
+
 - name: Entity {{ entity_name }} count
   shell: |
-    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l
-  args:
-    executable: "/bin/bash"
   register: entity_count
-  until: entity_count|success
-  retries: 5
-  delay: 2
 
 - name: Zero entities with label {{ entity_name }} exist
   fail:
@@ -39,17 +42,11 @@
 
 - name: Get entity {{ entity_name }}
   shell: |
-    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | awk '{print $2}' | cut -d= -f2
-  args:
-    executable: "/bin/bash"
   register: entity
-  until: entity|success
-  retries: 5
-  delay: 2
 
 - name: Assign agent ID to entity
   shell: |
@@ -60,17 +57,11 @@
 
 - name: Agent token {{ entity_name }} count
   shell: |
-    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-agent-tokens-list | grep ' label={{ entity_name }}, ' | wc -l
-  args:
-    executable: "/bin/bash"
   register: agent_token_count
-  until: agent_token_count|success
-  retries: 5
-  delay: 2
   when: maas_agent_token is not defined
 
 - name: At most one {{ entity_name }} agent token should exist
@@ -89,17 +80,11 @@
 
 - name: Get agent token
   shell: |
-    set -o pipefail
     {% if maas_venv_enabled | bool %}
     . {{ maas_venv_bin }}/activate
     {% endif %}
     raxmon-agent-tokens-list | grep '<AgentToken: id=.* label={{ entity_name }}, .*>' | awk '{print $2}' | sed -e 's/id=\(.*\),/\1/g'
-  args:
-    executable: "/bin/bash"
   register: maas_agent_token_id
-  until: maas_agent_token_id|success
-  retries: 5
-  delay: 2
   when: maas_agent_token is not defined
 
 - name: Set agent token fact
@@ -113,6 +98,7 @@
     mode: 0600
     owner: root
     group: root
+
 
 - name: Start raxmon agent
   service:

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -24,7 +24,6 @@
 - name: Install MaaS
   hosts: hosts:all_containers
   user: root
-  any_errors_fatal: true
   pre_tasks:
     # This is needed to set the rpc_openstack_repo and rpc_release variables
     # correctly


### PR DESCRIPTION
While this change was passing the gate fine, it wasn't thought through correctly as the greps in the pipelines will cause the pipelines to fail if no results are found.  We could create a subshell for the greps and || true but this is probably taking us down the wrong path and we should re-implement properly without going to this length.

This reverts commit 7568bceaf85876983c4669f3b383f23f3a6d584f.