### PR TITLE
Use Rackspace mirror of hwraid repositories

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -77,13 +77,13 @@ holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"
 holland_pip_dependencies:
   - MySQL-python
 
-hwraid_apt_repo_url: "http://hwraid.le-vert.net/ubuntu"
+hwraid_apt_repo_url: "http://mirror.rackspace.com/hwraid.le-vert.net/ubuntu/"
 
 hwraid_apt_repos:
   - { repo: "deb {{ hwraid_apt_repo_url }} {{ ansible_lsb.codename }} main", state: "present" }
 
 hwraid_apt_keys:
-  - { url: "http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key", state: "present" }
+  - { url: "http://mirror.rackspace.com/hwraid.le-vert.net/ubuntu/hwraid.le-vert.net.gpg.key", state: "present" }
 
 hwraid_apt_packages:
   - megacli


### PR DESCRIPTION
The hwraid repositories hosting the megacli and lsiutil command-line
utilities was occasionally unreliable and flakey. As a result, we've
obtained permission from the repository maintainer and Rackspace Legal
to mirror the repository on mirror.rackspace.com for a more reliable
source for customer installations.

Connects rcbops/rpc-openstack#1197

(cherry picked from commit a61c58490dd7904a36539323459c3644f11443b6)