### PR TITLE
Fix Xenial noninteractive apt installs

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -244,7 +244,7 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
     ansible neutron_agent -m command \
                           -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 8000 -j CHECKSUM --checksum-fill'
     ansible neutron_agent -m shell \
-                          -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
+                          -a 'DEBIAN_FRONTEND=noninteractive apt-get -y install iptables-persistent'
   fi
 
   # setup openstack


### PR DESCRIPTION
In Xenial -y is required with DEBIAN_FRONTEND=noninteractive, otherwise
the script prompts for confirmation and aborts because its not reading
from an interactive terminal.

Connects rcbops/u-suk-dev#825