### PR TITLE
Pin reno to 1.9.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,5 +10,12 @@ bashate>=0.2 # Apache-2.0
 # this is required for the docs build jobs
 sphinx>=1.3.4
 oslosphinx>=2.5.0 # Apache-2.0
-reno>=0.1.1 #Apache-2.0
+# TODO (alextricity25)
+# We need to investigate reno > 2.0.0
+# and why it isn't working with our
+# repository. This pin should not be
+# removed until then.
+# See:
+# https://github.com/rcbops/u-suk-dev/issues/687
+reno==1.9.0 #Apache-2.0
 sphinx_rtd_theme>=0.1.9


### PR DESCRIPTION
This commit pins reno version to 1.9.0
For more information, please see the related card

Connects https://github.com/rcbops/u-suk-dev/issues/869

(cherry picked from commit cc9c65f32d81a4ccdb944c04a3ce9fbf95d42ee8)