### PR TITLE
Fix deprecation warnings & errors in MaaS

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_local.yml
@@ -44,7 +44,7 @@
   file:
     path: "{{ item }}"
     mode: "0755"
-  with_items: plugin_files.stdout_lines
+  with_items: "{{ plugin_files.stdout_lines }}"
 
 - name: Create openrc file
   template:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
@@ -17,7 +17,6 @@
   vars:
     checks: "{{ cpu_memory_checks_list }}"
 
-
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ disk_utilisation_checks_list }}"
@@ -26,23 +25,26 @@
 - name: Gathering facts for mounted drives
   set_fact:
     mounted_drives: "{% for item in ansible_mounts %}{% if 'xfs' in item.fstype or 'ext' in item.fstype %}{{ item.mount }}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}"
-  when: >
-    maas_filesystem_overrides is not defined and maas_filesystem_monitors is not defined
+  when:
+    - maas_filesystem_overrides is not defined
+    - maas_filesystem_monitors is not defined
 
 - include: ensure_filesystem_auto_checks.yml
   vars:
     drives: "{{ mounted_drives.split(',') }}"
-  when: >
-    maas_filesystem_overrides is not defined and maas_filesystem_monitors is not defined
+  when:
+    - maas_filesystem_overrides is not defined
+    - maas_filesystem_monitors is not defined
 
 - include: ensure_filesystem_checks.yml
   vars:
     drives: "{{ maas_filesystem_monitors }}"
-  when: >
-    maas_filesystem_overrides is not defined and maas_filesystem_monitors is defined
+  when:
+    - maas_filesystem_overrides is not defined
+    - maas_filesystem_monitors is defined
 
 - include: ensure_filesystem_checks.yml
   vars:
     drives: "{{ maas_filesystem_overrides }}"
-  when: >
-    maas_filesystem_overrides is defined
+  when:
+    - maas_filesystem_overrides is defined

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -48,6 +48,7 @@
 - include: swift_access_check.yml
   when:
     - swift_accesscheck_enabled | bool
+    - groups['swift_proxy'] | length > 0
     - inventory_hostname == groups['swift_proxy'][0]
 
 - include: remote.yml

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -30,7 +30,7 @@
   until: install_packages|success
   retries: 5
   delay: 2
-  with_items: maas_requires_pip_packages
+  with_items: "{{ maas_requires_pip_packages }}"
 
 - name: Update pip
   pip:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/rabbitmq_user.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/rabbitmq_user.yml
@@ -51,6 +51,6 @@
     write_priv: ".*"
     tags: "administrator"
     state: "present"
-  with_items: vhost_json
+  with_items: "{{ vhost_json }}"
   tags:
     - rabbitmq-user

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -33,7 +33,8 @@
       delegate_to: localhost
       run_once: true
     - name: Display rpc_release variable
-      debug: var=rpc_release
+      debug:
+        var: rpc_release
       run_once: true
   roles:
     - { role: "rpc_maas", tags: [ "maas-setup" ] }


### PR DESCRIPTION
This patch fixes some deprecation warnings for bare variables and fixes
an error that stops the playbook when no servers are in the swift_proxy
group.

A few other cleanups of `when:` conditionals are also included.

Connects rcbops/rpc-openstack#1647