### PR TITLE
Disable SNMP hardening check

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -214,12 +214,15 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
     run_ansible haproxy-install.yml
   fi
 
-  # We have to skip V-38462 when using an unauthenticated mirror
-  # V-38660 is skipped for compatibility with Ubuntu Xenial
+  # NOTE(mhayden): V-38642 must be skipped when using an apt repository with
+  # unsigned/untrusted packages.
+  # NOTE(mhayden): V-38660 halts the playbook run when it finds SNMP v1/2
+  # configurations on a server. RPC has these configurations applied, so this
+  # task must be skipped.
   if [[ ${UNAUTHENTICATED_APT} == "yes" && ${DEPLOY_HARDENING} == "yes" ]]; then
     run_ansible setup-hosts.yml --skip-tags=V-38462,V-38660
   else
-    run_ansible setup-hosts.yml
+    run_ansible setup-hosts.yml --skip-tags=V-38660
   fi
 
   if [[ "$DEPLOY_CEPH" == "yes" ]]; then


### PR DESCRIPTION
This patch disables the V-38660 hardening check for SNMP and updates
the comments in the `deploy.sh` script to reflect the changes.

V-38660 checks to see if any SNMPv1/v2 configurations exist. If they
exist, the playbook halts. This is highly disruptive for production
deployments.

Connects rcbops/rpc-openstack#1616