### PR TITLE
Create raxmon ansible module

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/library/raxmon.py
+++ b/rpcd/playbooks/roles/rpc_maas/library/raxmon.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python2
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ConfigParser
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+DOCUMENTATION = """
+---
+module: raxmon
+short_description:
+  - A module for preparing a node for Rackspace Cloud Monitoring
+description:
+  - This module is written for rpc-openstack's rpc_maas role specifically to
+    prepare a node for Rackspace Cloud Monitoring by a) assigning an agent
+    to an entity and b) creating an agent token.
+options:
+  cmd:
+    description: The command to run
+    choices = [ 'assign_agent_to_entity', 'create_agent_token' ]
+    required: true
+  entity:
+    description: The label of the entity to operate against
+    required: true
+  venv_bin:
+    description: The path to the venv where rackspace-monitoring is installed
+    required: false
+  raxmon_cfg:
+    description: The path to the raxmon configuration file
+    required: false
+    default: /root/.raxrc
+"""
+
+EXAMPLES = """
+raxmon:
+  cmd: assign_agent_to_entity
+  entity: controller1
+  venv_bin: /openstack/venvs/maas-r14.1.0rc1/bin/
+
+raxmon:
+  cmd: create_agent_token
+  entity: controller1
+  venv_bin: /openstack/venvs/maas-r14.1.0rc1/bin/
+"""
+
+RETURN = """
+id:
+  description:
+    - The ID of the entity's agent token, returned when cmd=create_agent_token
+  returned: success
+  type: id
+"""
+
+
+def _get_agent_tokens(conn, entity):
+    agent_tokens = []
+    for a in conn.list_agent_tokens():
+        if a.label == entity:
+            agent_tokens.append(a)
+    return agent_tokens
+
+
+def _get_conn(get_driver, provider_cls, raxmon_cfg):
+    cfg = ConfigParser.RawConfigParser()
+    cfg.read(raxmon_cfg)
+    driver = get_driver(provider_cls.RACKSPACE)
+    try:
+        user = cfg.get('credentials', 'username')
+        api_key = cfg.get('credentials', 'api_key')
+        conn = driver(user, api_key)
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        url = cfg.get('api', 'url')
+        token = cfg.get('api', 'token')
+        conn = driver(None, None, ex_force_base_url=url,
+                      ex_force_auth_token=token)
+    return conn
+
+
+def _get_entities(conn, entity):
+    entities = []
+    for e in conn.list_entities():
+        if e.label == entity:
+            entities.append(e)
+    return entities
+
+
+def assign_agent_to_entity(module, conn, entity):
+    entities = _get_entities(conn, entity)
+    entities_count = len(entities)
+    if entities_count == 0:
+        msg = "Zero entities with the label %s exist. Entities should be " \
+              "created as part of the hardware provisioning process, if " \
+              "missing, please consult the internal documentation for " \
+              "associating one with the device." % entity
+        module.fail_json(msg=msg)
+    elif entities_count == 1:
+        if entities[0].label == entities[0].agent_id:
+            module.exit_json(change=False)
+        else:
+            conn.update_entity(entities[0], {'agent_id': entity})
+            module.exit_json(changed=True)
+    elif entities_count > 1:
+        msg = "Entity count of %s != 1 for entity with the label %s. Reduce " \
+              "the entity count to one by deleting or re-labelling the " \
+              "duplicate entities." % (entities_count, entity)
+        module.fail_json(msg=msg)
+
+
+def create_agent_token(module, conn, entity):
+    agent_tokens = _get_agent_tokens(conn, entity)
+    agent_tokens_count = len(agent_tokens)
+    if agent_tokens_count == 0:
+        module.exit_json(
+            changed=True,
+            id=conn.create_agent_token(label=entity).id
+        )
+    elif agent_tokens_count == 1:
+        module.exit_json(
+            changed=False,
+            id=agent_tokens[0].id
+        )
+    elif agent_tokens_count > 2:
+        msg = "Agent token count of %s > 1 for entity with " \
+              "the label %s" % (agent_tokens_count, entity)
+        module.fail_json(msg=msg)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            cmd=dict(
+                choices=['assign_agent_to_entity', 'create_agent_token'],
+                required=True
+            ),
+            entity=dict(required=True),
+            venv_bin=dict(),
+            raxmon_cfg=dict(default='/root/.raxrc')
+        )
+    )
+
+    if module.params['venv_bin']:
+        activate_this = '%s/activate_this.py' % (module.params['venv_bin'])
+        execfile(activate_this, dict(__file__=activate_this))
+
+    # We place these imports after we activate the virtualenv to ensure we're
+    # importing the correct libraries
+    from rackspace_monitoring.providers import get_driver
+    from rackspace_monitoring.types import Provider
+
+    conn = _get_conn(get_driver, Provider, module.params['raxmon_cfg'])
+
+    if module.params['cmd'] == 'assign_agent_to_entity':
+        assign_agent_to_entity(module, conn, module.params['entity'])
+    elif module.params['cmd'] == 'create_agent_token':
+        create_agent_token(module, conn, module.params['entity'])
+
+
+if __name__ == '__main__':
+    main()

--- a/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_remote.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_remote.yml
@@ -13,82 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Verify raxmon-entities-list and MaaS API authentication does not fail
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-entities-list
-  register: raxmon_output
-  failed_when: raxmon_output.rc != 0
-
-- name: Entity {{ entity_name }} count
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l
-  register: entity_count
-
-- name: Zero entities with label {{ entity_name }} exist
-  fail:
-    msg: "Zero entities with the label {{ entity_name }} exist. Entities should be created as part of the hardware provisioning process, if missing, please consult the internal documentation for associating one with the device."
-  when: entity_count.stdout|int == 0
-
-- name: At most one {{ entity_name }} entity exists
-  fail:
-    msg: "Entity count of {{ entity_count.stdout }} != 1 for entity with the label {{ entity_name }}. Reduce the entity count to one by deleting or re-labelling the duplicate entities."
-  when: entity_count.stdout|int != 1
-
-- name: Get entity {{ entity_name }}
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | awk '{print $2}' | cut -d= -f2
-  register: entity
-
 - name: Assign agent ID to entity
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-entities-update --id {{ entity.stdout }} --agent-id {{ entity_name }}
-
-- name: Agent token {{ entity_name }} count
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-agent-tokens-list | grep ' label={{ entity_name }}, ' | wc -l
-  register: agent_token_count
-  when: maas_agent_token is not defined
-
-- name: At most one {{ entity_name }} agent token should exist
-  fail:
-    msg: "Agent token count of {{ agent_token_count.stdout }} > 1 for entity with the label {{ entity_name }}"
-  when: maas_agent_token is not defined and agent_token_count.stdout|int > 1
+  raxmon:
+    cmd: assign_agent_to_entity
+    entity: "{{ entity_name }}"
+    venv_bin: "{{ maas_venv_bin }}"
 
 - name: Create agent token
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-agent-tokens-create --label={{ entity_name }}
+  raxmon:
+    cmd: create_agent_token
+    entity: "{{ entity_name }}"
+    venv_bin: "{{ maas_venv_bin }}"
   register: agent_token
-  when: maas_agent_token is not defined and agent_token_count.stdout|int == 0
-
-- name: Get agent token
-  shell: |
-    {% if maas_venv_enabled | bool %}
-    . {{ maas_venv_bin }}/activate
-    {% endif %}
-    raxmon-agent-tokens-list | grep '<AgentToken: id=.* label={{ entity_name }}, .*>' | awk '{print $2}' | sed -e 's/id=\(.*\),/\1/g'
-  register: maas_agent_token_id
   when: maas_agent_token is not defined
 
 - name: Set agent token fact
-  set_fact: maas_agent_token={{ maas_agent_token_id.stdout }}
+  set_fact: maas_agent_token={{ agent_token.id }}
   when: maas_agent_token is not defined
 
 - name: Generate raxmon agent config
@@ -98,7 +38,6 @@
     mode: 0600
     owner: root
     group: root
-
 
 - name: Start raxmon agent
   service:


### PR DESCRIPTION
This commit creates a raxmon ansible module to replace all tasks in the
rpc_maas/tasks/agent_install_remote.yml playbook that shell out to the
raxmon-* CLI tools to interact with the MaaS API.

The primary reason for doing this is because a number of those commands
have output piped through wc, etc. which means underlying failures in
the execution of raxmon-* aren't necessary detected, which makes
troubleshooting failures difficult.  An alternate solution would have
been to have a single task that executes raxmon-* and then have
subsequent tasks munge output, but that becomes a little bit more
tricky to do with ansible itself.

Connects rcbops/u-suk-dev#703