### PR TITLE
Remove duplicated ansible.cfg configurations

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -1,25 +1,4 @@
 [defaults]
-gathering = smart
-fact_caching = jsonfile
-fact_caching_connection = /etc/openstack_deploy/ansible_facts
-fact_caching_timeout = 86400
-host_key_checking = False
-
-# Setting forks should be based on your system. The Ansible defaults to 5,
-# the os-lxc-hosts assumes that you have a system that can support
-# OpenStack, thus it has been conservatively been set to 15
-forks = 15
-
-# SSH timeout
+# NOTE: The ssh timeout is increased here to 120 (OSA's default is 5) to
+#       avoid transient ssh errors in some environments.
 timeout = 120
-
-# Set the path to the folder in openstack-ansible which holds the dynamic
-# inventory script - new config setting for ansible v1.9 and above
-inventory = ../../openstack-ansible/playbooks/inventory/
-
-# Set the path to the folder in openstack-ansible which holds the roles
-# that are depended on by the rpc-openstack roles
-roles_path = ../../openstack-ansible/playbooks/roles/:/etc/ansible/roles/
-
-[ssh_connection]
-pipelining = True


### PR DESCRIPTION
This patch removes duplicated Ansible configurations that match OSA's
defaults. The ssh timeout was left in the file since it differs from
the OSA default (120 seconds in RPC vs 5 seconds in OSA).

RPC previously set forks at 15 for all deployments, but OSA uses a
safer mechanism to determine the maximum amount of forks. It sets a
hard limit of 10 but it lowers that limit to the maximum amount of
CPUs in the system if the CPU count is under 10.

Connects rcbops/rpc-openstack#1639