### PR TITLE
Don't install xtrabackup in rpc_support role

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -66,10 +66,6 @@ holland_git_repo_plugins:
 
 holland_pip_wheel_name: holland
 
-holland_packages:
-  - mariadb-client
-  - xtrabackup
-
 holland_venv_enabled: True
 holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
 holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -25,15 +25,6 @@
   with_items: holland_requires_dependencies
   when: holland_requires_dependencies is defined
 
-- name: Install packages required by holland
-  apt:
-    pkg: "{{ item }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 600
-  with_items: "{{ holland_packages }}"
-  when: holland_packages is defined
-
 - name: Install pip dependencies
   pip:
     name: "{{ item }}"


### PR DESCRIPTION
This step is redundant and may interfere with the version deployed by
OSA.

Connects rcbops/u-suk-dev#934