### PR TITLE
Added pool part for repo_git

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -88,7 +88,9 @@ MONITORS = [
     r' tcp destination *:9200 }',
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO {'
     r' defaults-from http destination *:8181 recv "200 OK" send "HEAD /'
-    r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }'
+    r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
+    r'create ltm monitor tcp /' + PART + '/' + PREFIX_NAME + '_MON_TCP_REPO_GIT {'
+    r' defaults-from tcp destination *:9418 }',
     '\n'
 ]
 
@@ -337,6 +339,13 @@ POOL_PARTS = {
         'port': 8181,
         'backend_port': 8181,
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO',
+        'group': 'pkg_repo',
+        'hosts': []
+    },
+    'repo_git': {
+        'port': 9418,
+        'backend_port': 9418,
+        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_TCP_REPO_GIT',
         'group': 'pkg_repo',
         'hosts': []
     }


### PR DESCRIPTION
Per https://github.com/openstack/openstack-ansible/commit/99ffcf3e0f0560475f86075d45c729a5c4159434,
the repo server now utilizes a git server. This commit
adds the git server pool part and monitor so the f5-config.py
script will construct the f5 components necessary for this new
git server.

Connects https://github.com/rcbops/rpc-openstack/issues/1625