### PR TITLE
Skip holland backup check for short lived machines

### DIFF
--- a/maas/plugins/holland_local_check.py
+++ b/maas/plugins/holland_local_check.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 import argparse
 import datetime
+import os
 import shlex
 import subprocess
 
@@ -91,6 +92,15 @@ def main():
 
     yesterday = datetime.date.today() - datetime.timedelta(days=1)
     yesterday = yesterday.strftime('%Y%m%d')
+
+    # Guess machine age based on ctime of hostname, if machine is less than a
+    # day old it can't have a backup from yesterday so skip check.
+    hostname_ctime = datetime.datetime.fromtimestamp(
+        os.path.getctime('/etc/hostname'))
+    if (datetime.datetime.now() - hostname_ctime).days < 1:
+        status_ok()
+        metric_bool('holland_backup_status', True)
+        return
 
     # Get completed Holland backup set
     backupsets = \

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -543,13 +543,6 @@ verify_maas_delay: 20
 verify_maas_retries: 5
 
 #
-# verify_local_maas_excluded_checks: Exclude checks by name from verify-local task.
-#                                    Multiple entries are allowed as list.
-#
-verify_local_maas_excluded_checks:
- - "holland_local_check"
-
-#
 # maas_use_api: Allow operations that make use of the MaaS api, set to false
 #               for offline testing
 #

--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_preinstall.yml
@@ -31,7 +31,6 @@
     state: latest
     virtualenv: "{{ holland_venv_enabled | bool | ternary(holland_venv, omit) }}"
     extra_args: "{{ pip_install_options|default('') }}"
-    state: latest
   with_items: "{{ holland_pip_dependencies }}"
   when: holland_pip_dependencies is defined
   register: pip_install
@@ -54,7 +53,6 @@
     state: latest
     virtualenv: "{{ holland_venv_enabled | bool | ternary(holland_venv, omit) }}"
     extra_args: "{{ pip_install_options|default('') }}"
-    state: latest
   register: pip_install
   until: pip_install|success
   retries: 5

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -45,9 +45,7 @@
         {% if maas_venv_enabled | bool %}
         . {{ maas_venv_bin }}/activate
         {% endif %}
-        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-local \
-        {% for ec in verify_local_maas_excluded_checks %} --excludeverifycheck {{ec}}
-        {% endfor %}
+        {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-local
       register: verify_maas
       failed_when: verify_maas.rc != 0
       changed_when: False

--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -291,12 +291,6 @@ class RpcMassCli(object):
                             help='A check that should not be present'
                                  'can be specified multiple times',
                             default=[])
-        parser.add_argument('--excludeverifycheck',
-                            action="append",
-                            help='A check that should be excluded from'
-                                 'verification, can be specified'
-                                 'multiple times',
-                            default=[])
         self.args = parser.parse_args()
 
     def main(self):
@@ -378,14 +372,6 @@ class RpcMassCli(object):
                     metrics.extend(child_metrics)
         return metrics
 
-    def _verify_excludedcheck(self, check_label):
-        """Verify if a check should be exluded from local verification"""
-        for exclude in self.args.excludeverifycheck:
-            if exclude in check_label:
-                return 1
-
-        return 0
-
     def verify_local(self):
         """Checks MaaS configuration without using MaaS API
 
@@ -430,11 +416,6 @@ class RpcMassCli(object):
         execution_results = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
             for check in self.rpcmac.checks.values():
-                # Skip excluded checks from verification
-                if self._verify_excludedcheck(check['label']):
-                    continue
-
-                # Skip non plugin checks (built-in or remote checks)
                 if check['type'] != 'agent.plugin':
                     continue
                 args = ["{plugin_path}{plugin}".format(
@@ -457,10 +438,6 @@ class RpcMassCli(object):
 
         for result in execution_results:
             check = result['check']
-            # Skip excluded checks from verification
-            if self._verify_excludedcheck(check['label']):
-                continue
-            # Skip failed checks
             if result['success'] is not True:
                 failed_checks.append(result)
                 continue
@@ -480,10 +457,6 @@ class RpcMassCli(object):
         # Parse alarm criteria
         for check in self.rpcmac.checks.values():
             try:
-                # Skip excluded checks from verification
-                if self._verify_excludedcheck(check['label']):
-                    continue
-
                 metrics = _alarm_metrics_from_check(check)
                 # Non agent metrics are not added to required_metrics because
                 # we can't determine locally the metrics that will be


### PR DESCRIPTION
Recently a MaaS check for holland was introduced which checks that
yesterday's backup exists. This makes sense for production but not for
gate runs. In the same PR a mechanism for excluding checks from local
MaaS verification was added, however not all gate runs use local verification
and no mechanism was included for excluding the check from full MaaS API
verification.

This commit attempts to guess the age of a machine by stat-ing
/etc/hostname.  If that file is less than a day old, then the check is
skipped with a successful status returned. This means that gate runs
will pass with no backups, and production deploys will be indicating
backup failures before they are handed over to customers.

Also:
 * Removes local verification check exclusion mechnaism as its no longer used.
 * Removes duplicate state keys in holland_preinstall

Connects rcbops/u-suk-dev#950