### PR TITLE
Add repo_cache to f5-config pool parts and monitor

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -346,12 +346,12 @@ POOL_PARTS = {
         'hosts': []
     },
     'repo_cache':{
-        'port': 3142
-        'mon_type': '/' + PART + '/' PREFIX_NAME + '_MON_HTTP_REPO_CACHE',
+        'port': 3142,
+        'backend_port': 3142,
+        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO_CACHE',
         'group': 'repo_all',
         'priority': True,
         'hosts': []
-        
     },
     'repo_git': {
         'port': 9418,

--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -89,6 +89,9 @@ MONITORS = [
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO {'
     r' defaults-from http destination *:8181 recv "200 OK" send "HEAD /'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
+    r' create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO_CACHE {'
+    r' defaults-from http destination *:3142 recv "200 OK" send "HEAD /acng-report.html'
+    r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
     r'create ltm monitor tcp /' + PART + '/' + PREFIX_NAME + '_MON_TCP_REPO_GIT {'
     r' defaults-from tcp destination *:9418 }',
     '\n'
@@ -341,6 +344,14 @@ POOL_PARTS = {
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_REPO',
         'group': 'pkg_repo',
         'hosts': []
+    },
+    'repo_cache':{
+        'port': 3142
+        'mon_type': '/' + PART + '/' PREFIX_NAME + '_MON_HTTP_REPO_CACHE',
+        'group': 'repo_all',
+        'priority': True,
+        'hosts': []
+        
     },
     'repo_git': {
         'port': 9418,


### PR DESCRIPTION
Per https://github.com/openstack/openstack-ansible/commit/c9925bee814dd1ee25ac4f6d29d31922c43eb0f3, 
OSA by default implements a package manager cache on the repo servers. This commit makes the changes necessary to the f5-config.py script so that the cache can be utilized.

Connects https://github.com/rcbops/rpc-openstack/issues/1626