### PR TITLE
[backport] Use to_json filter to properly format unicode

### DIFF
--- a/rpcd/playbooks/roles/filebeat/templates/filebeat.yml.j2
+++ b/rpcd/playbooks/roles/filebeat/templates/filebeat.yml.j2
@@ -2,7 +2,7 @@
 filebeat:
   prospectors:
 {% for service in filebeat_logging_paths %}
-    - paths: {{ service.paths }}
+    - paths: {{ service.paths | to_json }}
 {% if service.document_type is defined %}
       document_type: {{ service.document_type }}
 {% endif %}
@@ -18,7 +18,7 @@ filebeat:
  # happy.
  #}
       fields:
-        tags: {{ service.tags }}
+        tags: {{ service.tags | to_json }}
 {% endif %}
 {% if service.multiline is defined %}
       multiline:


### PR DESCRIPTION
For some reason in Newton the filebeat paths and tags are being
populated into the jinja2 template as unicode strings.  The leading
u is causing filebeat to treat the path as not found, hence it is
not sending any logs.  Using the to_json filter causes jinja2 to
properly format the string allowing the path to be read and the
correct tag(s) to be applied.

Connects https://github.com/rcbops/u-suk-dev/issues/863

(cherry picked from commit a9f21bca9e050ef4990c4b2e382dde46d610e542)