### PR TITLE
Revert changes to HORIZON_SSL monitor

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -68,8 +68,8 @@ MONITORS = [
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_SPICE_CONSOLE {'
     r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
-    r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_HORIZON_443 { defaults-from'
-    r' http destination *:443 recv "200 OK" send "HEAD / HTTP/1.1\r\nHost:'
+    r'create ltm monitor https /' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_HORIZON_SSL { defaults-from'
+    r' https destination *:443 recv "302 FOUND" send "HEAD / HTTP/1.1\r\nHost:'
     r' rpc\r\n\r\n" }',
     r'create ltm monitor https /' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_NOVA_SPICE_CONSOLE {'
     r' defaults-from https destination *:6082 recv "200 OK" send "HEAD /'
@@ -297,12 +297,11 @@ POOL_PARTS = {
     'horizon_ssl': {
         'port': 443,
         'backend_port': 80,
-        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_HORIZON_443',
+        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_HORIZON',
         'group': 'horizon',
         'hosts': [],
         'make_public': True,
         'persist': True,
-        'backend_ssl': True
     },
     'elasticsearch': {
         'port': 9200,


### PR DESCRIPTION
And change what monitor the HORIZON_SSL pool is using.
This commit configures the HORIZON_SSL pool to use the
HTTP monitor which checks the backend nodes using port 80.
This commit fulfills the feedback given in:
https://github.com/rcbops/rpc-openstack/pull/1668#issuecomment-272914892.

The reason this is done is due to the new behavior introduced
in OSA Newton. SSL is expected to be terminated at the LB, and
is no longer implemented on the horizon containers. For more
information on that change, please see:
https://review.openstack.org/#/c/277199/

Connects https://github.com/rcbops/rpc-openstack/issues/1632