### PR TITLE
Prepare rpc_maas role for Ansible 2

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -269,7 +269,7 @@ innodb_row_lock_time_avg_critical_threshold: 10000
 # cinder-volumes volume group thresholds
 cinder_volumes_vg_warning_threshold: 80.0
 cinder_volumes_vg_critical_threshold: 90.0
-cinder_vg_name: "{{ cinder_backends['lvm']['volume_group'] }}"
+cinder_vg_name: "{% if cinder_backends is defined %}cinder_backends['lvm']['volume_group']{% endif %}"
 
 # MaaS CPU idle threshold
 cpu_idle_percent_avg_warning_threshold: 10.0

--- a/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/agent_install_local.yml
@@ -37,14 +37,17 @@
   when: maas_venv_enabled
 
 - name: List plugin files to chmod
-  shell: "ls -1 {{ maas_plugin_dir }}*.py"
+  find:
+    path: "{{ maas_plugin_dir }}"
+    patterns: "*.py"
   register: plugin_files
 
 - name: Chmod listed plugin files
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     mode: "0755"
-  with_items: plugin_files.stdout_lines
+  with_items: "{{ plugin_files.files|default({}) }}"
+  when: plugin_files.files|length > 0
 
 - name: Create openrc file
   template:

--- a/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/cdm.yml
@@ -17,7 +17,6 @@
   vars:
     checks: "{{ cpu_memory_checks_list }}"
 
-
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ disk_utilisation_checks_list }}"
@@ -25,24 +24,27 @@
 
 - name: Gathering facts for mounted drives
   set_fact:
-    mounted_drives: "{% for item in ansible_mounts %}{% if 'xfs' in item.fstype or 'ext' in item.fstype %}{{ item.mount }}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}"
-  when: >
-    maas_filesystem_overrides is not defined and maas_filesystem_monitors is not defined
+    mounted_drives: "[{% for item in ansible_mounts %}{% if 'xfs' in item.fstype or 'ext' in item.fstype %}'{{ item.mount }}'{% if not loop.last %},{% endif %}{% endif %}{% endfor %}]"
+  when:
+    - maas_filesystem_overrides is undefined
+    - maas_filesystem_monitors is undefined
 
 - include: ensure_filesystem_auto_checks.yml
   vars:
-    drives: "{{ mounted_drives.split(',') }}"
-  when: >
-    maas_filesystem_overrides is not defined and maas_filesystem_monitors is not defined
+    drives: "{{ mounted_drives|default([]) }}"
+  when:
+    - maas_filesystem_overrides is undefined
+    - maas_filesystem_monitors is undefined
 
 - include: ensure_filesystem_checks.yml
   vars:
-    drives: "{{ maas_filesystem_monitors }}"
-  when: >
-    maas_filesystem_overrides is not defined and maas_filesystem_monitors is defined
+    drives: "{{ maas_filesystem_monitors|default([]) }}"
+  when:
+    - maas_filesystem_overrides is undefined
+    - maas_filesystem_monitors is defined
 
 - include: ensure_filesystem_checks.yml
   vars:
-    drives: "{{ maas_filesystem_overrides }}"
-  when: >
-    maas_filesystem_overrides is defined
+    drives: "{{ maas_filesystem_overrides|default([]) }}"
+  when:
+    - maas_filesystem_overrides is defined

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_filesystem_checks.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install fileystem auto checks
+- name: Install fileystem checks
   template:
     src: "filesystem.yaml.j2"
     dest: "/etc/rackspace-monitoring-agent.conf.d/filesystem_{{ item.filesystem|replace('/', '.') }}--{{ inventory_hostname }}.yaml"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -18,24 +18,27 @@
     inventory_hostname in groups['hosts']
 
 - include: keystone_user.yml
-  when: >
-    groups['utility']|length > 0 and inventory_hostname == groups['utility'][0]
+  when:
+    - groups['utility']|length > 0
+    - inventory_hostname == groups['utility'][0]
 
 - include: rabbitmq_user.yml
-  when: >
-    groups['rabbitmq_all']|length > 0 and inventory_hostname == groups['rabbitmq_all'][0]
+  when:
+    - groups['rabbitmq_all']|length > 0
+    - inventory_hostname == groups['rabbitmq_all'][0]
 
 - include: create_my_cnf.yml
-  when: >
-    inventory_hostname in groups['galera']
+  when:
+    - inventory_hostname in groups['galera']
 
 - include: host_monitoring.yml
-  when: >
-    inventory_hostname in groups['hosts']
+  when:
+    - inventory_hostname in groups['hosts']
 
 - include: network.yml
-  when: >
-    network_checks_list|length > 0 and inventory_hostname in groups['hosts']
+  when:
+    - network_checks_list|length > 0
+    - inventory_hostname in groups['hosts']
 
 - include: kernel.yml
 
@@ -48,33 +51,36 @@
 - include: swift_access_check.yml
   when:
     - swift_accesscheck_enabled | bool
+    - groups['swift_proxy']|length > 0
     - inventory_hostname == groups['swift_proxy'][0]
 
 - include: remote.yml
   vars:
     ip_address: "{{ external_lb_vip_address }}"
-  when: >
-    remote_check == true
+  when:
+    - remote_check == true
 
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ cinder_vg_checks_list }}"
-  when: >
-    cinder_backends['lvm'] is defined
+  when:
+    - cinder_backends['lvm'] is defined
 
 - include: swift.yml
   vars:
     external_vip_address: "{{ external_lb_vip_address }}"
-  when: >
-    inventory_hostname in groups['swift_all']
+  when:
+    - groups['swift_all']|length > 0
+    - inventory_hostname in groups['swift_all']
 
 - include: ceph.yml
-  when: >
-    inventory_hostname in groups['ceph_all'] and
-    groups['ceph_all'] is defined
+  when:
+    - groups['ceph_all'] is defined
+    - groups['ceph_all']|length > 0
+    - inventory_hostname in groups['ceph_all']
 
 - include: maas_exclude.yml
 
 - include: restart_raxmon.yml
-  when: >
-    inventory_hostname in groups['hosts']
+  when:
+    - inventory_hostname in groups['hosts']

--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -35,8 +35,8 @@
     group: "root"
     mode: "0644"
   with_together:
-    - network_checks_list
-    - discover_nic_speed.results
+    - "{{ network_checks_list }}"
+    - "{{ discover_nic_speed.results }}"
   when:
     - inventory_hostname in groups["{{ item.0.group }}"]
     - "'network_throughput-{{ item.0.name }}' not in maas_excluded_checks"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -30,7 +30,7 @@
   until: install_packages|success
   retries: 5
   delay: 2
-  with_items: maas_requires_pip_packages
+  with_items: "{{ maas_requires_pip_packages }}"
 
 - name: Update pip
   pip:

--- a/rpcd/playbooks/rpc-support.yml
+++ b/rpcd/playbooks/rpc-support.yml
@@ -23,7 +23,7 @@
   hosts: all
   gather_facts: no
   roles:
-    - { role: rcbops_openstack-ops }
+    - { role: "rcbops_openstack-ops" }
   tags:
     - "rpc_dependencies"
     - "rpc_pccommon"

--- a/scripts/linting-ansible.sh
+++ b/scripts/linting-ansible.sh
@@ -31,7 +31,7 @@ pushd rpcd/playbooks/
   # Lint playbooks and roles while skipping the ceph-* roles. They are not
   # ours and so we do not wish to lint them and receive errors about code we
   # do not maintain.
-  ansible-lint *.yml --exclude ~/.ansible/roles/ceph.ceph-common \
-                     --exclude ~/.ansible/roles/ceph.ceph-mon \
-                     --exclude ~/.ansible/roles/ceph.ceph-osd
+  ansible-lint -v *.yml --exclude ~/.ansible/roles/ceph.ceph-common \
+                        --exclude ~/.ansible/roles/ceph.ceph-mon \
+                        --exclude ~/.ansible/roles/ceph.ceph-osd
 popd

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint>=2.0.3,<=2.3.6
+ansible-lint>=2.7.0,<3.0.0
 flake8==2.2.4
 hacking>=0.10.0,<0.11
 pep8==1.5.7

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,15 @@ whitelist_externals =
     sed
 deps =
     -rtest-requirements.txt
-    ansible{env:ANSIBLE_VERSION:>=1.9.1,<1.9.5}
+    ansible{env:ANSIBLE_VERSION:==2.1.0}
     -e./hacking
 setenv =
     ANSIBLE_ACTION_PLUGINS = {homedir}/.ansible/roles/plugins/action
     ANSIBLE_CALLBACK_PLUGINS = {homedir}/.ansible/roles/plugins/callback
     ANSIBLE_FILTER_PLUGINS = {homedir}/.ansible/roles/plugins/filter
     ANSIBLE_LOOKUP_PLUGINS = {homedir}/.ansible/roles/plugins/lookup
-    ANSIBLE_LIBRARY = {homedir}/.ansible/roles/plugins/library
-    ANSIBLE_ROLES_PATH = {homedir}/.ansible/roles:{toxinidir}/rcpd/playbooks/roles:{toxinidir}/openstack-ansible/playbooks/roles
+    ANSIBLE_LIBRARY = {homedir}/.ansible/roles/plugins/library:{toxinidir}/rpcd/playbooks/library
+    ANSIBLE_ROLES_PATH = {homedir}/.ansible/roles:{toxinidir}/rpcd/playbooks/roles:{toxinidir}/openstack-ansible/playbooks/roles
 
 
 [testenv:releasenotes]


### PR DESCRIPTION
The warnings and errors as a result of using Ansible 2
are fixed for the rpc_maas role.

Connects #1647
(cherry picked from commit 4277d77cf81a568ee6d6e786acdfd088cc3ee9e9)