### PR TITLE
[backport] Change hoirzon SSL monitor to HTTP_443

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -68,8 +68,8 @@ MONITORS = [
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_SPICE_CONSOLE {'
     r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
-    r'create ltm monitor https /' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_HORIZON_SSL { defaults-from'
-    r' https destination *:443 recv "302 FOUND" send "HEAD / HTTP/1.1\r\nHost:'
+    r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_HORIZON_443 { defaults-from'
+    r' http destination *:443 recv "200 OK" send "HEAD / HTTP/1.1\r\nHost:'
     r' rpc\r\n\r\n" }',
     r'create ltm monitor https /' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_NOVA_SPICE_CONSOLE {'
     r' defaults-from https destination *:6082 recv "200 OK" send "HEAD /'
@@ -296,8 +296,8 @@ POOL_PARTS = {
     },
     'horizon_ssl': {
         'port': 443,
-        'backend_port': 443,
-        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_HORIZON_SSL',
+        'backend_port': 80,
+        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_HORIZON_443',
         'group': 'horizon',
         'hosts': [],
         'make_public': True,


### PR DESCRIPTION
Also changes backend port to use port 80.
This is kind of a strange one. Due to the new behavior
introduced in https://review.openstack.org/#/c/277199/
and https://review.openstack.org/#/c/288786, horizon listens
on port 443 and 80 on http. The LB monitor needs to be changed
accordingly. Curling http://<container-ip>:443 results in a
200 OK now. Curling https//<container-ip>:443 will no longer
work since certs no longer exist on the container

Connects https://github.com/rcbops/rpc-openstack/issues/1632

(cherry picked from commit eb59440ad5cce2a33f87ae06d2281fbcf14b2d67)