### PR TITLE
[backport] HORIZON_SSL to use monitor that checks port 80

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -296,13 +296,12 @@ POOL_PARTS = {
     },
     'horizon_ssl': {
         'port': 443,
-        'backend_port': 443,
-        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_HORIZON_SSL',
+        'backend_port': 80,
+        'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_HORIZON',
         'group': 'horizon',
         'hosts': [],
         'make_public': True,
         'persist': True,
-        'backend_ssl': True
     },
     'elasticsearch': {
         'port': 9200,


### PR DESCRIPTION
This commit configures the HORIZON_SSL pool to use the
HTTP monitor which checks the backend nodes using port 80.
This commit fulfills the feedback given in:
https://github.com/rcbops/rpc-openstack/pull/1668#issuecomment-272914892.

The reason this is done is due to the new behavior introduced
in OSA Newton. SSL is expected to be terminated at the LB, and
is no longer implemented on the horizon containers. For more
information on that change, please see:
https://review.openstack.org/#/c/277199/

Connects https://github.com/rcbops/rpc-openstack/issues/1632

(cherry picked from commit b40cd5009779e7e2991058af8bd01c14fb16fcf7)