### PR TITLE
MaaS: Disable alarms/checks with regex

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -506,10 +506,22 @@ maas_source_plugin_dir: /opt/rpc-openstack/maas/plugins/
 maas_plugin_dir: /usr/lib/rackspace-monitoring-agent/plugins/
 
 maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
+
+# The following two variables control which checks and alarms are excluded from
+# MaaS. Here is explanation of what each variable does:
 #
-# maas_excluded_checks: List of checks and alarms to exclude from this deploy
+# 1) When you add a check to `maas_excluded_checks`, the check (and any
+#    associated alarms) are not provisioned. This disables graphing,
+#    monitoring, alarms and alerts for that particular check.
 #
+# 2) When you add an alarm to `maas_excluded_alarms`, the alarm is not
+#    provisioned. However, the check itself (and any associated graphing) is
+#    maintained.
+#
+# Both lists can contain simple strings that match exactly, or they can contain
+# regular expressions.
 maas_excluded_checks: []
+maas_excluded_alarms: []
 
 # openrc definitions from OSA
 # This is necessary until LP #1537117 is implemented

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_cinder_volumes_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_cinder_volumes_checks.yml
@@ -23,5 +23,5 @@
   with_dict: "{{ cinder_backends | default({}) }}"
   when:
     - inventory_hostname in groups["cinder_volume"]
-    - "'cinder_volume_{{ item.key }}_check' not in maas_excluded_checks"
+    - not 'cinder_volume_{{ item.key }}_check' | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
@@ -25,5 +25,5 @@
   when:
     - item.group in group_names
     - inventory_hostname in groups["{{ item.group }}"]
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
@@ -27,5 +27,5 @@
     - groups["{{ item.group }}"]|length > 0
     - inventory_hostname in groups["{{ item.group }}"]
     - inventory_hostname != groups["{{ item.group }}"][0]
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
@@ -26,5 +26,5 @@
     - item.group in group_names
     - groups["{{ item.group }}"]|length > 0
     - inventory_hostname == groups["{{ item.group }}"][0]
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Merge regular expressions for excluded checks/alarms into a single
+# regular expression string. If the lists are empty, use '^$' as the regular
+# expression since it does not match anything.
+- name: Gather regular expressions for excluded checks and alarms
+  set_fact:
+    maas_excluded_checks_regex: "{{ (maas_excluded_checks | length > 0) | ternary('('+maas_excluded_checks | join(')|(')+')', '^$') }}"
+    maas_excluded_alarms_regex: "{{ (maas_excluded_alarms | length > 0) | ternary('('+maas_excluded_alarms | join(')|(')+')', '^$') }}"
+
 - include: host_setup.yml
   when: >
     inventory_hostname in groups['hosts']

--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -39,7 +39,7 @@
     - "{{ discover_nic_speed.results }}"
   when:
     - inventory_hostname in groups["{{ item.0.group }}"]
-    - "'network_throughput-{{ item.0.name }}' not in maas_excluded_checks"
+    - not 'network_throughput-{{ item.0.name }}' | match(maas_excluded_checks_regex)
 
 - name: Remove checks that are excluded
   file:
@@ -47,4 +47,4 @@
     state: absent
   with_items: "{{ network_checks_list }}"
   when:
-    - "'network_throughput-{{ item.name }}' in maas_excluded_checks"
+    - not 'network_throughput-{{ item.name }}' | match(maas_excluded_checks_regex)

--- a/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
@@ -25,5 +25,5 @@
   when:
     - item.group in groups
     - inventory_hostname in groups['{{ item.group }}']
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     ceph_health_err :
         label                   : ceph_health_err--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('ceph_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 0) {
@@ -19,6 +20,7 @@ alarms      :
     ceph_health_warn :
         label                   : ceph_health_warn--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('ceph_health_warn--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     mon_health_err :
         label                   : mon_health_err--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('mon_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 0) {
@@ -19,6 +20,7 @@ alarms      :
     mon_health_warn :
         label                   : mon_health_warn--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('mon_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     ceph_warn_osd.{{ osd_id }} :
         label                   : ceph_warn_osd.{{ osd_id }}--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('ceph_warn_osd.'+osd_id+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["osd.{{ osd_id }}_up"] == 0) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_api_local_status :
         label                   : cinder_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_backup_status :
         label                   : cinder_backup_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_backup_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-backup_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_scheduler_status :
         label                   : cinder_scheduler_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_scheduler_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-scheduler_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_vg_space_status :
         label                   : cinder_vg_space_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_vg_space_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["{{ item.cinder_vg_name }}_vg_used_space"], metric["{{ item.cinder_vg_name }}_vg_total_space"]) > {{ cinder_volumes_vg_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_volume_{{ item.key }}_status :
         label                   : cinder_volume_{{ item.key }}_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_volume_'+item.key+'_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-volume-{{ item.key}}_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     conntrack_count_status :
         label                   : conntrack_count_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('conntrack_count_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ nf_conntrack_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
@@ -7,6 +7,7 @@ alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["idle_percent_average"] <= {{ cpu_idle_percent_avg_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ disk_utilisation_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filebeat_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filebeat_process_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
@@ -9,6 +9,7 @@ alarms      :
     filesystem_{{ item.filesystem }}_check :
         label                   : "Disk space used on {{ item.filesystem }}--{{ ansible_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('Disk space used on '+item.filesystem+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric['used'], metric['total']) >= {{ item.critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
@@ -9,6 +9,7 @@ alarms      :
     filesystem_{{ item }}_check :
         label                   : "Disk space used on {{ item }}--{{ ansible_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('Disk space used on '+item+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric['used'], metric['total']) >= {{ maas_filesystem_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     wsrep_cluster_size :
         label                   : wsrep_cluster_size--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('wsrep_cluster_size--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_cluster_size"] < {{ groups["galera"] | length }}) {
@@ -18,6 +19,7 @@ alarms      :
     wsrep_local_state :
         label                   : wsrep_local_state--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('wsrep_local_state--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_local_state_comment"] != "Synced" ) {
@@ -26,6 +28,7 @@ alarms      :
     percentage_used_mysql_connections :
         label                   : percentage_used_mysql_connections--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('percentage_used_mysql_connections--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["mysql_current_connections"], metric["mysql_max_configured_connections"]) > {{ mysql_connection_critical_threshold }} ) {
@@ -37,6 +40,7 @@ alarms      :
     open_file_size_limit_reached :
         label                   : open_file_size_limit_reached--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('open_file_size_limit_reached--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["num_of_open_files"], metric["open_files_limit"]) > {{ mysql_open_files_percentage_critical_threshold }}) {
@@ -48,6 +52,7 @@ alarms      :
     innodb_row_lock_time_avg :
         label                   : innodb_row_lock_time_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('innodb_row_lock_time_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["innodb_row_lock_time_avg"] > {{ innodb_row_lock_time_avg_critical_threshold }}) {
@@ -59,6 +64,7 @@ alarms      :
     innodb_deadlocks :
         label                   : innodb_deadlocks--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('innodb_deadlocks--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["innodb_deadlocks"] != 0) {
@@ -67,6 +73,7 @@ alarms      :
     access_denied_errors :
         label                   : access_denied_errors--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('access_denied_errors--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_warning_threshold }}) {
@@ -78,6 +85,7 @@ alarms      :
     aborted_clients :
         label                   : aborted_clients--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('aborted_clients--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_clients"]) > {{ mysql_aborted_clients_rate_warning_threshold }}) {
@@ -89,6 +97,7 @@ alarms      :
     aborted_connects :
         label                   : aborted_connects--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('aborted_connects--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_connects"]) > {{ mysql_aborted_connects_rate_warning_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     glance_api_local_status :
         label                   : glance_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('glance_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["glance_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     glance_registry_local_status :
         label                   : glance_registry_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('glance_registry_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["glance_registry_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     heat_api_local_status :
         label                   : heat_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('heat_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     heat_cfn_api_local_status :
         label                   : heat_cfn_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('heat_cfn_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_cfn_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     heat_cw_api_local_status :
         label                   : heat_cw_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('heat_cw_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_cw_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/holland_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/holland_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
      holland_backup_status:
         label                   : holland_backup_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('holland_backup_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["holland_backup_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     horizon_local_status :
         label                   : "horizon_local_status--{{ ansible_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('horizon_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["horizon_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     hp-memory_status :
         label                   : hp-memory--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('hp-memory--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_memory_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     hp-processors_status :
         label                   : hp-processors--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('hp-processors--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_processors_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     hp-disk_status :
         label                   : hp-disk--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('hp-disk--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_disk_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     keystone_api_local_status :
         label                   : keystone_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('keystone_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["keystone_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_cinder     :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_cinder
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_cinder' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200' && metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_glance     :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_glance
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_glance' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_heat_api   :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_heat_api
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_heat_api' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_heat_cfn   :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_heat_cfn
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_heat_cfn' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_heat_cloudwatch :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_heat_cloudwatch
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_heat_cloudwatch' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_horizon     :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_horizon
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_horizon' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_keystone   :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_keystone
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_keystone' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_neutron    :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_neutron
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_neutron' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_nova       :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_nova
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_nova' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_access.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_access.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_swift_access:
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_swift_access
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_swift_access' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_healthcheck.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_healthcheck.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_swift_healthcheck:
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_swift_healthcheck
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_swift_healthcheck' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
@@ -9,8 +9,9 @@ details           :
     url           : "https://{{ ip_address }}:443/auth/login/"
 alarms            :
     lb_ssl_alarm_cert_expiry:
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_ssl_alarm_cert_expiry
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_ssl_alarm_cert_expiry' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             if (metric['cert_end_in'] < 604800) {
                 return new AlarmStatus(CRITICAL, 'Cert expiring in less than 7 days.');

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     memcache_api_local_status :
         label                   : memcache_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('memcache_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_api_local_status"] != 1) {
@@ -18,6 +19,7 @@ alarms      :
     memcache_curr_connections :
         label                   : memcache_curr_connections--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('memcache_curr_connections--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_curr_connections"] > {{ ((memcached_connections*0.9)|round|int) }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
@@ -7,6 +7,7 @@ alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('memory_check--'+inventory_hostname | quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["actual_used"], metric["total"]) >= {{ memory_used_percentage_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
@@ -15,6 +15,7 @@ alarms:
     alarm-network-receive:
         label: Network receive rate on {{ item.0.name }}
         notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ (('Network receive rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric['rx_bytes']) > {{ rx_crit }}) {
@@ -27,6 +28,7 @@ alarms:
     alarm-network-transmit:
         label: Network transmit rate on {{ item.0.name }}
         notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ (('Network transmit rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric['tx_bytes']) > {{ tx_crit }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_api_local_status :
         label                   : neutron_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_api_local_status--'+ansible_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_dhcp_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-dhcp-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_l3_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-l3-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_linuxbridge_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-linuxbridge-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_metadata_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-metadata-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_metering_agent_status :
         label                   : neutron_metering_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_metering_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-metering-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_api_local_status :
         label                   : nova_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
@@ -10,6 +10,8 @@ alarms      :
     nova_api_metadata_local_status :
         label                   : nova_api_metadata_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_api_metadata_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_api_metadata_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_cert_status :
         label                   : nova_cert_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cert_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-cert_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     nova_cloud_memory_status :
         label                   : nova_cloud_memory_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cloud_memory_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_memory"], metric["cloud_resource_total_memory"]) > {{ cloud_resource_critical_memory }}) {
@@ -22,6 +23,7 @@ alarms      :
     nova_cloud_disk_status :
         label                   : nova_cloud_disk_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cloud_disk_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_disk_space"], metric["cloud_resource_total_disk_space"]) > {{ cloud_resource_critical_disk_space }}) {
@@ -33,6 +35,7 @@ alarms      :
     nova_cloud_vcpu_status :
         label                   : nova_cloud_vcpu_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cloud_vcpu_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_vcpus"], metric["cloud_resource_total_vcpus"]) > {{ cloud_resource_critical_vcpus }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_compute_status :
         label                   : nova_compute_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_compute_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-compute_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_conductor_status :
         label                   : nova_conductor_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_conductor_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-conductor_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_consoleauth_status :
         label                   : nova_consoleauth_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_consoleauth_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-consoleauth_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_scheduler_status :
         label                   : nova_scheduler_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_scheduler_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-scheduler_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_spice_api_local_status :
         label                   : nova_spice_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_spice_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_spice_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     openmanage-memory_status :
         label                   : openmanage-memory--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('openmanage-memory--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_memory_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     openmanage-processors :
         label                   : openmanage-processors--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('openmanage-processors--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_processors_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     openmanage-vdisk :
         label                   : openmanage-vdisk--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('openmanage-vdisk--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_vdisk_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_disk_free_alarm_status"] != 1) {
@@ -19,6 +20,7 @@ alarms      :
     rabbitmq_mem_alarm_status :
         label                   : rabbitmq_mem_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_mem_alarm_status"] != 1) {
@@ -28,6 +30,7 @@ alarms      :
     rabbitmq_max_channels_per_conn :
         label                   : rabbitmq_max_channels_per_conn--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_max_channels_per_conn--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_max_channels_per_conn"] > {{ rabbitmq_max_channels_per_con_threshold }}) {
@@ -37,6 +40,7 @@ alarms      :
     rabbitmq_fd_used_alarm_status :
         label                   : rabbitmq_fd_used_alarm_status-{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_fd_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_fd_used"],metric["rabbitmq_fd_total"]) >= {{ rabbitmq_fd_used_threshold }}) {
@@ -46,6 +50,7 @@ alarms      :
     rabbitmq_proc_used_alarm_status :
         label                   : rabbitmq_proc_used_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_proc_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_proc_used"],metric["rabbitmq_proc_total"]) >= {{ rabbitmq_proc_used_threshold }}) {
@@ -55,6 +60,7 @@ alarms      :
     rabbitmq_socket_used_alarm_status :
         label                   : rabbitmq_socket_used_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_socket_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_sockets_used"],metric["rabbitmq_sockets_total"]) >= {{ rabbitmq_socket_used_threshold }}) {
@@ -63,6 +69,7 @@ alarms      :
     rabbitmq_msgs_excl_notifications :
         label                   : rabbitmq_msgs_excl_notifications--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_msgs_excl_notifications--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_msgs_excl_notifications"] > {{ rabbitmq_queued_messages_excluding_notifications_threshold }} ) {
@@ -71,6 +78,7 @@ alarms      :
     rabbitmq_qgrowth_excl_notifications :
         label                   : rabbitmq_qgrowth_excl_notifications--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_qgrowth_excl_notifications--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{rabbitmq_queue_growth_rate_threshold / maas_check_period}}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_account_replication_failure_check :
         label                   : swift_account_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_account_replication_failure_percentage_threshold }}) {
@@ -18,6 +19,7 @@ alarms      :
     swift_account_replication_rate_check :
         label                   : swift_account_replication_rate_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ swift_account_replication_growth_rate_threshold / maas_check_period}}) {
@@ -26,6 +28,7 @@ alarms      :
     swift_account_replication_avg_time_check :
         label                   : swift_account_replication_avg_time_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ swift_account_replication_avg_time_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_account_server_api_local_status :
         label                   : swift_account_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_account_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_async_failure_check :
         label                   : swift_async_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_async_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["async_failed"] > {{ swift_async_pending_failure_percentage_threshold }}) {
@@ -19,6 +20,7 @@ alarms      :
     swift_async_avg_check :
         label                   : swift_async_avg_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_async_avg_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["async_avg"] > {{ swift_async_pending_average_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_container_replication_failure_check :
         label                   : swift_container_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_container_replication_failure_percentage_threshold }}) {
@@ -18,6 +19,7 @@ alarms      :
     swift_container_replication_rate_check :
         label                   : swift_container_replication_rate_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ swift_container_replication_growth_rate_threshold / maas_check_period}}) {
@@ -26,6 +28,7 @@ alarms      :
     swift_container_replication_avg_time_check :
         label                   : swift_container_replication_avg_time_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ swift_container_replication_avg_time_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_container_server_api_local_status :
         label                   : swift_container_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_container_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_ring_md5_check :
         label                   : swift_ring_md5_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_ring_md5_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["ring_errors"] > 0) {
@@ -19,6 +20,7 @@ alarms      :
     swift_conf_md5_check :
         label                   : swift_conf_md5_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_conf_md5_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_conf_errors"] > 0) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_object_replication_failure_check :
         label                   : swift_object_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_object_replication_failure_percentage_threshold }}) {
@@ -18,6 +19,7 @@ alarms      :
     swift_object_replication_rate_check :
         label                   : swift_object_replication_rate_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ swift_object_replication_growth_rate_threshold / maas_check_period}}) {
@@ -26,6 +28,7 @@ alarms      :
     swift_object_replication_avg_time_check :
         label                   : swift_object_replication_avg_time_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ swift_object_replication_avg_time_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_object_server_api_local_status :
         label                   : swift_object_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_object_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_proxy_server_api_local_status :
         label                   : swift_proxy_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_proxy_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_proxy_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_quarantine_object_failed :
         label                   : swift_quarantine_object_failed--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_object_failed--'+ansible_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["objects_failed"] > {{ swift_object_quarantine_failed_percentage_threshold }}) {
@@ -19,6 +20,7 @@ alarms      :
     swift_quarantine_object_avg :
         label                   : swift_quarantine_object_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_object_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["objects_avg"] > {{ swift_object_quarantine_average_threshold }}) {
@@ -28,6 +30,7 @@ alarms      :
     swift_quarantine_account_failed :
         label                   : swift_quarantine_account_failed--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_account_failed--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["accounts_failed"] > {{ swift_account_quarantine_failed_percentage_threshold }}) {
@@ -37,6 +40,7 @@ alarms      :
     swift_quarantine_account_avg :
         label                   : swift_quarantine_account_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_account_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["accounts_avg"] > {{ swift_account_quarantine_average_threshold }}) {
@@ -46,6 +50,7 @@ alarms      :
     swift_quarantine_container_failed :
         label                   : swift_quarantine_container_failed--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_container_failed--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["containers_failed"] > {{ swift_container_quarantine_failed_percentage_threshold }}) {
@@ -55,6 +60,7 @@ alarms      :
     swift_quarantine_container_avg :
         label                   : swift_quarantine_container_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_container_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["containers_avg"] > {{ swift_container_quarantine_average_threshold }}) {


### PR DESCRIPTION
This patch allows for regular expressions to be used in the
`maas_excluded_checks` variable.

It also adds `maas_excluded_alarms` and allows deployers to use a
regular expression to exclude **only** alarms for a particular check.
The check itself (and any related graphing) is maintained.

This comes from a discussion in rcbops/u-suk-dev#948 where some of the
checks are good to have, but the alarms aren't needed.

Connects rcbops/u-suk-dev#1019