### PR TITLE
Modularise ansible bootstrap portion of deploy.sh

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,12 +1,16 @@
 - name: ceph.ceph-common
+  scm: git
   src: https://github.com/ceph/ansible-ceph-common.git
   version: 1c623611a1d43b4c9116d1a0c21f0bdbdd87a0e7
 - name: ceph.ceph-mon
+  scm: git
   src: https://github.com/ceph/ansible-ceph-mon.git
   version: 01d3d6f0b06125b33b1e25745c06fa1d7137f7e9
 - name: ceph.ceph-osd
+  scm: git
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
 - name: rcbops_openstack-ops
+  scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 1383d0db302c6fc400a50fae4f85e77bf1633581

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -e -u -x
+set -o pipefail
+
+## Vars ----------------------------------------------------------------------
+
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+export OA_DIR="${BASE_DIR}/openstack-ansible"
+export RPCD_DIR="${BASE_DIR}/rpcd"
+# Set the role fetch mode to any option [galaxy, git-clone]
+export ANSIBLE_ROLE_FETCH_MODE=${ANSIBLE_ROLE_FETCH_MODE:-galaxy}
+
+## Main ----------------------------------------------------------------------
+
+# Confirm OA_DIR is properly checked out
+submodulestatus=$(git submodule status ${OA_DIR})
+case "${submodulestatus:0:1}" in
+  "-")
+    echo "ERROR: rpc-openstack submodule is not properly checked out"
+    exit 1
+    ;;
+  "+")
+    echo "WARNING: rpc-openstack submodule does not match the expected SHA"
+    ;;
+  "U")
+    echo "ERROR: rpc-openstack submodule has merge conflicts"
+    exit 1
+    ;;
+esac
+
+# begin the bootstrap process
+pushd ${OA_DIR}
+
+  ./scripts/bootstrap-ansible.sh
+
+  # This removes legacy roles which were downloaded into the
+  # rpc-o folder structure, dirtying the git tree.
+  ansible-galaxy remove --roles-path /opt/rpc-openstack/rpcd/playbooks/roles/ \
+                        ceph-common ceph-mon ceph-osd \
+                        ceph.ceph-common ceph.ceph-mon ceph.ceph-osd \
+                        rcbops_openstack-ops
+
+  if [[ "${ANSIBLE_ROLE_FETCH_MODE}" == 'galaxy' ]];then
+    # Pull all required roles.
+    ansible-galaxy install --role-file="${BASE_DIR}/ansible-role-requirements.yml" \
+                           --force
+  elif [[ "${ANSIBLE_ROLE_FETCH_MODE}" == 'git-clone' ]];then
+    ansible-playbook ${OA_DIR}/tests/get-ansible-role-requirements.yml \
+                     -i ${OA_DIR}/tests/test-inventory.ini \
+                     -e role_file="${BASE_DIR}/ansible-role-requirements.yml"
+  else
+    echo "Please set the ANSIBLE_ROLE_FETCH_MODE to either of the following options ['galaxy', 'git-clone']"
+    exit 99
+  fi
+
+popd


### PR DESCRIPTION
In order to improve the development workflow, and also increase
the resemblence to the OpenStack-Ansible workflow, the Ansible
bootstrap portion of deploy.sh is extracted into its own script.

The bootstrap-ansible.sh script is called from deploy.sh in
order to maintain like behaviour.

This patch implements the following improvements:

- The Ansible bootstrap can be executed independently of a
  deployment.
- The role download can be done via 'galaxy' (default), or
  'git-clone'. The 'git-clone' method is useful when doing
  development and is also useful as a fallback when the galaxy
  API is down.
- The ceph roles download to the same location as all the other
  roles, rather than being downloaded into a folder which
  dirties the rpc-o git tree.
- As 'ANSIBLE_FORCE_COLOR' being set to 'true' is the Ansible
  default, this variable is no longer being set in deploy.sh

Connected: https://github.com/rcbops/u-suk-dev/issues/834