### PR TITLE
Allow to supply filename for apt repo

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_pre_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_pre_install.yml
@@ -31,6 +31,7 @@
   apt_repository:
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
+    filename: "{{ item.filename | default(omit) }}"
   with_items: elasticsearch_apt_repos
   register: add_repos
   until: add_repos|success

--- a/rpcd/playbooks/roles/filebeat/tasks/filebeat_pre_install.yml
+++ b/rpcd/playbooks/roles/filebeat/tasks/filebeat_pre_install.yml
@@ -31,6 +31,7 @@
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
     update_cache: yes
+    filename: "{{ item.filename | default(omit) }}"
   with_items: "{{ filebeat_apt_repos }}"
   register: add_beats_repositories
   until: add_beats_repositories|success

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_pre_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_pre_install.yml
@@ -32,6 +32,7 @@
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
     update_cache: yes
+    filename: "{{ item.filename | default(omit) }}"
   with_items: "{{ kibana_apt_repos }}"
   register: add_kibana_repos
   until: add_kibana_repos|success

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_pre_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_pre_install.yml
@@ -31,6 +31,7 @@
   apt_repository:
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
+    filename: "{{ item.filename | default(omit) }}"
   with_items: logstash_apt_repos
   register: add_repos
   until: add_repos|success

--- a/rpcd/playbooks/roles/rpc_maas/tasks/repo_setup.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/repo_setup.yml
@@ -26,6 +26,7 @@
   apt_repository:
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
+    filename: "{{ item.filename | default(omit) }}"
   with_items: "{{ maas_apt_repos }}"
   when:
     - ansible_distribution == 'Ubuntu'

--- a/rpcd/playbooks/roles/rpc_support/tasks/raid_preinstall.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/raid_preinstall.yml
@@ -31,6 +31,7 @@
   apt_repository:
     repo: "{{ item.repo }}"
     state: "{{ item.state }}"
+    filename: "{{ item.filename | default(omit) }}"
   with_items: "{{ hwraid_apt_repos }}"
   register: add_repos
   until: add_repos|success


### PR DESCRIPTION
Apt doesn't allow the same apt entry more than once. If we define
the file, we can count on ansible apt_repository module idempotency
to avoid clashes.

This commit doesn't change the current behavior.

Connected https://github.com/rcbops/u-suk-dev/issues/1031