### PR TITLE
MaaS: Do not deploy filebeat alarms w/o ELK

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -577,3 +577,9 @@ swift_accesscheck_file: "index.html"
 swift_accesscheck_user_name: "accesscheck"
 swift_operator_role: "swiftoperator"
 swift_service_project_name: "service"
+
+# The tasks that deploy checks/alarms for processes will skip the deployment
+# of filebeat checks if ELK is not deployed in the RPC environment. Deployers
+# can override this check and *force* the deployment of filebeat checks/alarms
+# even if ELK is not deployed by setting `maas_force_check_filebeat` to `true`.
+maas_force_check_filebeat: False

--- a/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE(mhayden): The filebeat check in this task ensures that filebeat checks
+#                and alarms are not deployed if the ELK stack is not being
+#                deployed. Deployers can override this check and deploy
+#                filebeat checks/alarms anyway by setting
+#                `maas_force_check_filebeat` to `true`.
 - name: Install process checks
   template:
     src: "{{ item.name }}.yaml.j2"
@@ -26,4 +31,5 @@
     - item.group in groups
     - inventory_hostname in groups['{{ item.group }}']
     - not item.name | match(maas_excluded_checks_regex)
+    - item.name != 'filebeat_process_check' or (item.name == 'filebeat_process_check' and ((maas_force_check_filebeat | bool) or 'elasticsearch_all' in groups))
   delegate_to: "{{ physical_host }}"


### PR DESCRIPTION
The `rpc_maas` role currently deploys filebeat checks and alarms to
all hosts and containers, but this causes alarms if ELK isn't
deployed in the environment.

This patch checks to see if the ELK group exists and only deploys
filebeat checks and alarms if it exists.

Connects rcbops/u-suk-dev#1032