### PR TITLE
Fix cinder_backends template bug (backport)

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -269,7 +269,7 @@ innodb_row_lock_time_avg_critical_threshold: 10000
 # cinder-volumes volume group thresholds
 cinder_volumes_vg_warning_threshold: 80.0
 cinder_volumes_vg_critical_threshold: 90.0
-cinder_vg_name: "{% if cinder_backends is defined %}cinder_backends['lvm']['volume_group']{% endif %}"
+cinder_vg_name: "{{ cinder_backends['lvm']['volume_group'] | default('cinder-volumes') }}"
 
 # MaaS CPU idle threshold
 cpu_idle_percent_avg_warning_threshold: 10.0


### PR DESCRIPTION
Previously the expression within the if statement was not expanded as it
was not enclosed in {{}}. That lead to an invalid volume group name.

(cherry picked from commit ad4181d9cb52a57bac4d8d3aae7bdcf228ba1412)

Connects https://github.com/rcbops/u-suk-dev/issues/1013