### PR TITLE
MaaS: Use regex for default check exclusion

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -82,7 +82,7 @@ maas_alarm_remote_consecutive_count: 1
 # horizon_local_check is disabled until https://github.com/rcbops/u-suk-dev/issues/781
 # is resolved
 maas_excluded_checks:
-  - horizon_local_check
+  - "horizon_local_check.*"
 
 # Set the threshold for filesystem monitoring when you are not specifying specific filesystems.
 maas_filesystem_warning_threshold: 80.0


### PR DESCRIPTION
This patch updates the `maas_excluded_checks` value that is provided
in the RPC-O defaults file to use a regular expression.

Connects rcbops/u-suk-dev#1050