### PR TITLE
MaaS: Fix excluded checks removal

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/maas_exclude.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/maas_exclude.yml
@@ -13,18 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Ensure local checks are removed
-  file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}--{{ inventory_hostname }}.yaml"
-    state: absent
-  with_items:
-    - "{{ maas_excluded_checks }}"
+- name: Get a list of all checks that exist on the system
+  find:
+    paths: /etc/rackspace-monitoring-agent.conf.d/
+    patterns: "*.yaml"
+  register: maas_check_files
   delegate_to: "{{ physical_host }}"
 
-- name: Ensure remote checks are removed
+- name: Ensure excluded checks are removed
   file:
-    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}.yaml"
+    path: "{{ item.path }}"
     state: absent
   with_items:
-    - "{{ maas_excluded_checks }}"
+    - "{{ maas_check_files.files }}"
+  when:
+    - item.path | basename | splitext | first | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -87,6 +87,8 @@
     - groups['ceph_all']|length > 0
     - inventory_hostname in groups['ceph_all']
 
+# Remove any checks that match the regular expressions provided in the
+# `maas_excluded_checks` list.
 - include: maas_exclude.yml
 
 - include: restart_raxmon.yml


### PR DESCRIPTION
This patch updates the tasks in `maas_exclude.yml` to handle regular
expressions rather than strings.

Connects rcbops/u-suk-dev#1052