### PR TITLE
[Backport - Liberty] MaaS: Use maas_external_ip_address properly

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -63,7 +63,7 @@ maas_notification_plan: npManaged
 #
 # maas_external_ip_address:
 #
-maas_external_ip_address: "{{ external_vip_address }}"
+maas_external_ip_address: "{{ external_lb_vip_address }}"
 
 #
 # maas_agent_token: The Cloud Monitoring agent token to configure the agent with.

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - include: remote.yml
   vars:
-    ip_address: "{{ external_lb_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
   when: >
     remote_check == true
 
@@ -59,7 +59,7 @@
 
 - include: swift.yml
   vars:
-    external_vip_address: "{{ external_lb_vip_address }}"
+    external_vip_address: "{{ maas_external_ip_address }}"
   when: >
     inventory_hostname in groups['swift_all']
 


### PR DESCRIPTION
The `maas_external_ip_address` variable was ignored in the `rpc_maas`
role. This patch sets the variable to `external_lb_vip_address` as a
default and allows a deployer to override the default if needed.

Manual backport of 0ffd8af from master. The master branch has some
Ansible 2 updates that aren't needed for Liberty.

Connects rcbops/u-suk-dev#1036