### PR TITLE
MaaS: Enable agent auto upgrade

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -560,6 +560,12 @@ verify_maas_retries: 5
 #
 maas_use_api: true
 
+#
+# maas_agent_upgrade: Allow for automatic MaaS agent upgrades
+#
+#
+maas_agent_upgrade: true
+
 # Swift object access check
 swift_accesscheck_enabled: true
 swift_accesscheck_container: "accesscheck"

--- a/rpcd/playbooks/roles/rpc_maas/templates/rackspace-monitoring-agent.cfg
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rackspace-monitoring-agent.cfg
@@ -1,2 +1,3 @@
 monitoring_id {{ entity_name }}
 monitoring_token {{ maas_agent_token }}
+monitoring_upgrade {{ maas_agent_upgrade }}


### PR DESCRIPTION
Enables auto upgrade in the rackspace-monitoring-agent.  It appears that the key is monitoring_upgrade, but oddly, if this is set to true or false or not even set, the logs always show:

Tue Jan 24 05:39:33 PM 2017 INF: Upgrades are enabled

It might be hard coded to be enabled here:

https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/blob/4d20ce09493b75fdbb3140ca15c89ea420836920/agent.lua#L58

Connects rcbops/u-suk-dev#1064
