### PR TITLE
Remove container_release from env.d files

### DIFF
--- a/rpcd/etc/openstack_deploy/env.d/ceph.yml
+++ b/rpcd/etc/openstack_deploy/env.d/ceph.yml
@@ -29,7 +29,6 @@ container_skel:
     contains:
       - mons
     properties:
-      container_release: trusty
       service_name: ceph
   ceph_osd_container:
     belongs_to:
@@ -38,7 +37,6 @@ container_skel:
       - osds
     properties:
       is_metal: true
-      container_release: trusty
       service_name: ceph
 
 

--- a/rpcd/etc/openstack_deploy/env.d/elasticsearch.yml
+++ b/rpcd/etc/openstack_deploy/env.d/elasticsearch.yml
@@ -12,4 +12,3 @@ container_skel:
       - elasticsearch
     properties:
       service_name: elasticsearch
-      container_release: trusty

--- a/rpcd/etc/openstack_deploy/env.d/kibana.yml
+++ b/rpcd/etc/openstack_deploy/env.d/kibana.yml
@@ -12,4 +12,3 @@ container_skel:
       - kibana
     properties:
       service_name: kibana
-      container_release: trusty

--- a/rpcd/etc/openstack_deploy/env.d/logstash.yml
+++ b/rpcd/etc/openstack_deploy/env.d/logstash.yml
@@ -12,4 +12,3 @@ container_skel:
       - logstash
     properties:
       service_name: logstash
-      container_release: trusty


### PR DESCRIPTION
container_release now adapts to the host RPCO is being deployed on.
Therefore, this variable is no longer needed.

Connects https://github.com/rcbops/rpc-openstack/issues/1712

(cherry picked from commit 0a65c4c19e96171d20bc6a147c274c32204d6aa3)