### PR TITLE
[Backport - Mitaka] MaaS: Enable agent auto upgrade

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -545,3 +545,9 @@ verify_maas_retries: 5
 #               for offline testing
 #
 maas_use_api: true
+
+#
+# maas_agent_upgrade: Allow for automatic MaaS agent upgrades
+#
+#
+maas_agent_upgrade: true

--- a/rpcd/playbooks/roles/rpc_maas/templates/rackspace-monitoring-agent.cfg
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rackspace-monitoring-agent.cfg
@@ -1,2 +1,3 @@
 monitoring_id {{ entity_name }}
 monitoring_token {{ maas_agent_token }}
+monitoring_upgrade {{ maas_agent_upgrade }}


### PR DESCRIPTION
Enables auto upgrade in the rackspace-monitoring-agent. Auto upgrades are hard coded enabled in the agent currently, so this ensures we maintain auto upgrades being enabled. 

Cherry picks 95b62c8 but had to correct a conflict with newer versions in the defaults file.

Connects rcbops/u-suk-dev#1064