### PR TITLE
MaaS: Set rabbitmq_qgrowth_excl_notifications to WARNING

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -84,5 +84,5 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{rabbitmq_queue_growth_rate_threshold / maas_check_period}}) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ Queue growth rate is above configured threshold. Currently above {{ rabbitmq_queue_growth_rate_threshold }}");
+                return new AlarmStatus(WARNING, "RabbitMQ Queue growth rate is above configured threshold. Currently above {{ rabbitmq_queue_growth_rate_threshold }}");
             }


### PR DESCRIPTION
rabbitmq_qgrowth_excl_notifications identifies the rate of messages in
the queue but in most cases will also trigger
rabbitmq_msgs_excl_notifications resulting in two tickets for the same
issue.  Flipping rabbitmq_qgrowth_excl_notifications to WARNING will
prevent a ticket from being opened but still capture metrics.

Connects rcbops/u-suk-dev#1075