### PR TITLE
[Backport - Mitaka] MaaS improvements

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -360,7 +360,7 @@ elasticsearch_process_names:
   # process name that includes "elasticsearch". The process running
   # elasticsearch is actually named "java" so we search for that here. This is
   # less than ideal, but the best we can do right now.
-  - java 
+  - java
 
 filebeat_process_names:
   - filebeat
@@ -557,3 +557,9 @@ verify_maas_retries: 5
 #               for offline testing
 #
 maas_use_api: true
+
+#
+# maas_agent_upgrade: Allow for automatic MaaS agent upgrades
+#
+#
+maas_agent_upgrade: true

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -521,6 +521,20 @@ maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
 maas_excluded_checks: []
 maas_excluded_alarms: []
 
+# Customizing MaaS check period and timeout.
+# The following two variables allow deployers to provide custom check periods
+# and timeouts for certain checks. Each variable is a list of dictionaries
+# containing the check label and the appropriate value:
+#
+#   maas_check_period_override:
+#     - disk_utilization: 60
+#     - conntrack_count: 45
+#   maas_check_timeout_override:
+#     - cinder_backup_check: 120
+#
+maas_check_period_override: {}
+maas_check_timeout_override: {}
+
 # openrc definitions from OSA
 # This is necessary until LP #1537117 is implemented
 openrc_os_endpoint_type: internalURL

--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -504,10 +504,22 @@ maas_source_plugin_dir: /opt/rpc-openstack/maas/plugins/
 maas_plugin_dir: /usr/lib/rackspace-monitoring-agent/plugins/
 
 maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
+
+# The following two variables control which checks and alarms are excluded from
+# MaaS. Here is explanation of what each variable does:
 #
-# maas_excluded_checks: List of checks and alarms to exclude from this deploy
+# 1) When you add a check to `maas_excluded_checks`, the check (and any
+#    associated alarms) are not provisioned. This disables graphing,
+#    monitoring, alarms and alerts for that particular check.
 #
+# 2) When you add an alarm to `maas_excluded_alarms`, the alarm is not
+#    provisioned. However, the check itself (and any associated graphing) is
+#    maintained.
+#
+# Both lists can contain simple strings that match exactly, or they can contain
+# regular expressions.
 maas_excluded_checks: []
+maas_excluded_alarms: []
 
 # openrc definitions from OSA
 # This is necessary until LP #1537117 is implemented

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_cinder_volumes_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_cinder_volumes_checks.yml
@@ -23,5 +23,5 @@
   with_dict: "{{ cinder_backends | default({}) }}"
   when:
     - inventory_hostname in groups["cinder_volume"]
-    - "'cinder_volume_{{ item.key }}_check' not in maas_excluded_checks"
+    - not 'cinder_volume_{{ item.key }}_check' | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_local_checks.yml
@@ -24,5 +24,5 @@
     - "{{ checks }}"
   when:
     - inventory_hostname in groups["{{ item.group }}"]
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_backup_checks.yml
@@ -26,5 +26,5 @@
     - groups["{{ item.group }}"]|length > 0
     - inventory_hostname in groups["{{ item.group }}"]
     - inventory_hostname != groups["{{ item.group }}"][0]
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/ensure_remote_checks.yml
@@ -25,5 +25,5 @@
   when:
     - groups["{{ item.group }}"]|length > 0
     - inventory_hostname == groups["{{ item.group }}"][0]
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Merge regular expressions for excluded checks/alarms into a single
+# regular expression string. If the lists are empty, use '^$' as the regular
+# expression since it does not match anything.
+- name: Gather regular expressions for excluded checks and alarms
+  set_fact:
+    maas_excluded_checks_regex: "{{ (maas_excluded_checks | length > 0) | ternary('('+maas_excluded_checks | join(')|(')+')', '^$') }}"
+    maas_excluded_alarms_regex: "{{ (maas_excluded_alarms | length > 0) | ternary('('+maas_excluded_alarms | join(')|(')+')', '^$') }}"
+
 - include: host_setup.yml
   when: >
     inventory_hostname in groups['hosts']

--- a/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/network.yml
@@ -39,7 +39,7 @@
     - discover_nic_speed.results
   when:
     - inventory_hostname in groups["{{ item.0.group }}"]
-    - "'network_throughput-{{ item.0.name }}' not in maas_excluded_checks"
+    - not 'network_throughput-{{ item.0.name }}' | match(maas_excluded_checks_regex)
 
 - name: Remove checks that are excluded
   file:
@@ -47,4 +47,4 @@
     state: absent
   with_items: "{{ network_checks_list }}"
   when:
-    - "'network_throughput-{{ item.name }}' in maas_excluded_checks"
+    - not 'network_throughput-{{ item.name }}' | match(maas_excluded_checks_regex)

--- a/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
@@ -25,5 +25,5 @@
   when:
     - item.group in groups
     - inventory_hostname in groups['{{ item.group }}']
-    - item.name not in maas_excluded_checks
+    - not item.name | match(maas_excluded_checks_regex)
   delegate_to: "{{ physical_host }}"

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     ceph_health_err :
         label                   : ceph_health_err--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('ceph_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 0) {
@@ -19,6 +20,7 @@ alarms      :
     ceph_health_warn :
         label                   : ceph_health_warn--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('ceph_health_warn--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "ceph_cluster_stats--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "ceph_cluster_stats" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "cluster"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "ceph_mon_stats--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "ceph_mon_stats" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "mon", "--host", "{{ ansible_hostname }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     mon_health_err :
         label                   : mon_health_err--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('mon_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 0) {
@@ -19,6 +20,7 @@ alarms      :
     mon_health_warn :
         label                   : mon_health_warn--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('mon_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     ceph_warn_osd.{{ osd_id }} :
         label                   : ceph_warn_osd.{{ osd_id }}--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('ceph_warn_osd.'+osd_id+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["osd.{{ osd_id }}_up"] == 0) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -11,7 +11,7 @@ alarms      :
     ceph_warn_osd.{{ osd_id }} :
         label                   : ceph_warn_osd.{{ osd_id }}--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('ceph_warn_osd.'+osd_id+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('ceph_warn_osd.'+osd_id|string+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["osd.{{ osd_id }}_up"] == 0) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "ceph_osd_stats--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "ceph_osd_stats" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_api_local_status :
         label                   : cinder_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "cinder_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}cinder_api_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_backup_status :
         label                   : cinder_backup_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_backup_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-backup_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_backup_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_backup_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_scheduler_status :
         label                   : cinder_scheduler_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_scheduler_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-scheduler_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_scheduler_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_scheduler_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_vg_space_status :
         label                   : cinder_vg_space_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_vg_space_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["{{ item.cinder_vg_name }}_vg_used_space"], metric["{{ item.cinder_vg_name }}_vg_total_space"]) > {{ cinder_volumes_vg_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_vg_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_vg_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}vg_check.py", "{{ item.cinder_vg_name }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_volume_{{ item.key }}_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_volume_"+item.key+"_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     cinder_volume_{{ item.key }}_status :
         label                   : cinder_volume_{{ item.key }}_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('cinder_volume_'+item.key+'_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-volume-{{ item.key}}_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     conntrack_count_status :
         label                   : conntrack_count_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('conntrack_count_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ nf_conntrack_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "conntrack_count--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "conntrack_count" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}conntrack_count.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
@@ -7,6 +7,7 @@ alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["idle_percent_average"] <= {{ cpu_idle_percent_avg_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "cpu_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
 type              : agent.cpu
-label             : cpu_check--{{ inventory_hostname|quote }}
-disabled          : false
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ disk_utilisation_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "disk_utilisation--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "disk_utilisation" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}disk_utilisation.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "elasticsearch_process_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "elasticsearch_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}process_check.py", {% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ elasticsearch_process_names|join(",") }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filebeat_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filebeat_process_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "filebeat_process_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "filebeat_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}process_check.py", {% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ filebeat_process_names|join(",") }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/filebeat_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filebeat_process_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.filesystem
-label: "filesystem_{{ item.filesystem }}--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "filesystem_"+item.filesystem %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.filesystem
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     target  : "{{ item.filesystem }}"
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
@@ -9,6 +9,7 @@ alarms      :
     filesystem_{{ item.filesystem }}_check :
         label                   : "Disk space used on {{ item.filesystem }}--{{ ansible_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('Disk space used on '+item.filesystem+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric['used'], metric['total']) >= {{ item.critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
@@ -9,6 +9,7 @@ alarms      :
     filesystem_{{ item }}_check :
         label                   : "Disk space used on {{ item }}--{{ ansible_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('Disk space used on '+item+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric['used'], metric['total']) >= {{ maas_filesystem_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.filesystem
-label: "filesystem_{{ item }}--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "filesystem_"+item %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.filesystem
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     target  : "{{ item }}"
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "galera_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "galera_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}galera_check.py", "-H", "{{ ansible_ssh_host }}"]
@@ -77,10 +79,10 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_warning_threshold }}) {
-                return new AlarmStatus(WARNING, "Access denied errors rate is greater than {{ mysql_access_denied_errors_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+                return new AlarmStatus(WARNING, "Access denied errors rate is greater than {{ mysql_access_denied_errors_rate_warning_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
             if (rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_critical_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Access denied errors rate is greater than {{ mysql_access_denied_errors_rate_critical_threshold }} per {{ maas_check_period }} seconds");
+                return new AlarmStatus(CRITICAL, "Access denied errors rate is greater than {{ mysql_access_denied_errors_rate_critical_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
     aborted_clients :
         label                   : aborted_clients--{{ ansible_hostname }}
@@ -89,10 +91,10 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_clients"]) > {{ mysql_aborted_clients_rate_warning_threshold }}) {
-                return new AlarmStatus(WARNING, "Aborted clients rate is greater than {{ mysql_aborted_clients_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+                return new AlarmStatus(WARNING, "Aborted clients rate is greater than {{ mysql_aborted_clients_rate_warning_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
             if (rate(metric["aborted_clients"]) > {{ mysql_aborted_clients_rate_critical_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Aborted clients rate is greater than {{ mysql_aborted_clients_rate_critical_threshold }} per {{ maas_check_period }} seconds");
+                return new AlarmStatus(CRITICAL, "Aborted clients rate is greater than {{ mysql_aborted_clients_rate_critical_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
     aborted_connects :
         label                   : aborted_connects--{{ ansible_hostname }}
@@ -101,8 +103,8 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_connects"]) > {{ mysql_aborted_connects_rate_warning_threshold }}) {
-                return new AlarmStatus(WARNING, "Aborted connects rate is greater than {{ mysql_aborted_connects_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+                return new AlarmStatus(WARNING, "Aborted connects rate is greater than {{ mysql_aborted_connects_rate_warning_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
             if (rate(metric["aborted_connects"]) > {{ mysql_aborted_connects_rate_critical_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Aborted connects rate is greater than {{ mysql_aborted_connects_rate_critical_threshold }} per {{ maas_check_period }} seconds");
+                return new AlarmStatus(CRITICAL, "Aborted connects rate is greater than {{ mysql_aborted_connects_rate_critical_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     wsrep_cluster_size :
         label                   : wsrep_cluster_size--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('wsrep_cluster_size--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_cluster_size"] < {{ groups["galera"] | length }}) {
@@ -18,6 +19,7 @@ alarms      :
     wsrep_local_state :
         label                   : wsrep_local_state--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('wsrep_local_state--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_local_state_comment"] != "Synced" ) {
@@ -26,6 +28,7 @@ alarms      :
     percentage_used_mysql_connections :
         label                   : percentage_used_mysql_connections--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('percentage_used_mysql_connections--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["mysql_current_connections"], metric["mysql_max_configured_connections"]) > {{ mysql_connection_critical_threshold }} ) {
@@ -37,6 +40,7 @@ alarms      :
     open_file_size_limit_reached :
         label                   : open_file_size_limit_reached--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('open_file_size_limit_reached--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["num_of_open_files"], metric["open_files_limit"]) > {{ mysql_open_files_percentage_critical_threshold }}) {
@@ -48,6 +52,7 @@ alarms      :
     innodb_row_lock_time_avg :
         label                   : innodb_row_lock_time_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('innodb_row_lock_time_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["innodb_row_lock_time_avg"] > {{ innodb_row_lock_time_avg_critical_threshold }}) {
@@ -59,6 +64,7 @@ alarms      :
     innodb_deadlocks :
         label                   : innodb_deadlocks--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('innodb_deadlocks--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["innodb_deadlocks"] != 0) {
@@ -67,6 +73,7 @@ alarms      :
     access_denied_errors :
         label                   : access_denied_errors--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('access_denied_errors--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["access_denied_errors"]) > {{ mysql_access_denied_errors_rate_warning_threshold }}) {
@@ -78,6 +85,7 @@ alarms      :
     aborted_clients :
         label                   : aborted_clients--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('aborted_clients--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_clients"]) > {{ mysql_aborted_clients_rate_warning_threshold }}) {
@@ -89,6 +97,7 @@ alarms      :
     aborted_connects :
         label                   : aborted_connects--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('aborted_connects--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_connects"]) > {{ mysql_aborted_connects_rate_warning_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     glance_api_local_status :
         label                   : glance_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('glance_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["glance_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "glance_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "glance_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}glance_api_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     glance_registry_local_status :
         label                   : glance_registry_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('glance_registry_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["glance_registry_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "glance_registry_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "glance_registry_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}glance_registry_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     heat_api_local_status :
         label                   : heat_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('heat_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "heat_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "heat_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}heat_api_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "heat_cfn_api_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "heat_cfn_api_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "heat_cfn", "{{ ansible_ssh_host }}", "8000"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     heat_cfn_api_local_status :
         label                   : heat_cfn_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('heat_cfn_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_cfn_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     heat_cw_api_local_status :
         label                   : heat_cw_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('heat_cw_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_cw_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "heat_cw_api_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "heat_cw_api_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "heat_cw", "{{ ansible_ssh_host }}", "8003"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "horizon_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "horizon_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}horizon_check.py", "{{ ansible_ssh_host }}", "{{ horizon_site_name }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     horizon_local_status :
         label                   : "horizon_local_status--{{ ansible_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('horizon_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["horizon_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     hp-memory_status :
         label                   : hp-memory--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('hp-memory--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_memory_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: hp-memory
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "hp-memory" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     hp-processors_status :
         label                   : hp-processors--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('hp-processors--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_processors_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: hp-processors
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "hp-processors" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     hp-disk_status :
         label                   : hp-disk--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('hp-disk--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_disk_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: hp-disk
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "hp-disk" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "keystone_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "keystone_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}keystone_api_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     keystone_api_local_status :
         label                   : keystone_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('keystone_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["keystone_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_cinder     :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_cinder
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_cinder' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200' && metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_cinder" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_cinder--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_glance" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_glance--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_glance     :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_glance
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_glance' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_heat_api   :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_heat_api
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_heat_api' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_heat_api" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_heat_api--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_heat_cfn" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_heat_cfn--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_heat_cfn   :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_heat_cfn
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_heat_cfn' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_heat_cloudwatch :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_heat_cloudwatch
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_heat_cloudwatch' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_heat_cloudwatch" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_heat_cloudwatch--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_horizon" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_horizon--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_horizon     :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_horizon
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_horizon' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_keystone   :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_keystone
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_keystone' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '300') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_keystone" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_keystone--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_neutron    :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_neutron
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_neutron' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_neutron" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_neutron--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_nova       :
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_nova
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_nova' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_nova" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_nova--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_proxy.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_proxy.yaml.j2
@@ -13,8 +13,9 @@ monitoring_zones_poll:
 {% endfor %}
 alarms            :
     lb_api_alarm_swift_proxy:
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_api_alarm_swift_proxy
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_api_alarm_swift_proxy' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_proxy.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_proxy.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_alarm_swift_proxy" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_swift_proxy--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_ssl_cert_expiry_check" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_ssl_cert_expiry_check--{{ lb_name }}
-disabled          : false
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
@@ -9,8 +9,9 @@ details           :
     url           : "https://{{ ip_address }}:443/auth/login/"
 alarms            :
     lb_ssl_alarm_cert_expiry:
-        notification_plan_id: "{{ maas_notification_plan }}"
         label               : lb_ssl_alarm_cert_expiry
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ ('lb_ssl_alarm_cert_expiry' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             if (metric['cert_end_in'] < 604800) {
                 return new AlarmStatus(CRITICAL, 'Cert expiring in less than 7 days.');

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "memcached_status--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "memcached_status" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}memcached_status.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     memcache_api_local_status :
         label                   : memcache_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('memcache_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_api_local_status"] != 1) {
@@ -18,6 +19,7 @@ alarms      :
     memcache_curr_connections :
         label                   : memcache_curr_connections--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('memcache_curr_connections--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_curr_connections"] > {{ ((memcached_connections*0.9)|round|int) }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
@@ -7,6 +7,7 @@ alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('memory_check--'+inventory_hostname | quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["actual_used"], metric["total"]) >= {{ memory_used_percentage_critical_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "memory_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
 type              : agent.memory
-label             : memory_check--{{ inventory_hostname|quote }}
-disabled          : false
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
@@ -1,14 +1,16 @@
+{% set label = "network_throughput_"+item.0.name %}
+{% set check_name = label+'--'+ansible_hostname %}
 {% set max_speed = (item.0.max_speed | default(0, boolean=true) or item.1.stdout) | int * 10 ** 6 / 8 %}
 {% set rx_warn = (max_speed | int * item.0.rx_pct_warn | float / 100) | int %}
 {% set rx_crit = (max_speed | int * item.0.rx_pct_crit | float / 100) | int %}
 {% set tx_warn = (max_speed | int * item.0.tx_pct_warn | float / 100) | int %}
 {% set tx_crit = (max_speed | int * item.0.tx_pct_crit | float / 100) | int -%}
 
-type: agent.network
-label: network_throughput_{{ item.0.name }}--{{ inventory_hostname|quote }}
-disabled: false
-period: {{ maas_check_period| default(60) }}
-timeout: {{ maas_check_timeout| default(30) }}
+type        : agent.network
+label       : "{{ check_name }}"
+period      : {{ maas_check_period| default(60) }}
+timeout     : {{ maas_check_timeout| default(30) }}
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details:
   target: {{ item.0.name }}
 alarms:

--- a/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
@@ -15,6 +15,7 @@ alarms:
     alarm-network-receive:
         label: Network receive rate on {{ item.0.name }}
         notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ (('Network receive rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric['rx_bytes']) > {{ rx_crit }}) {
@@ -27,6 +28,7 @@ alarms:
     alarm-network-transmit:
         label: Network transmit rate on {{ item.0.name }}
         notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ (('Network transmit rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric['tx_bytes']) > {{ tx_crit }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "neutron_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}neutron_api_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_api_local_status :
         label                   : neutron_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_api_local_status--'+ansible_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_dhcp_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-dhcp-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_dhcp_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_dhcp_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_l3_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-l3-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_l3_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_l3_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_linuxbridge_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_linuxbridge_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_linuxbridge_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-linuxbridge-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_metadata_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_metadata_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_metadata_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-metadata-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     neutron_metering_agent_status :
         label                   : neutron_metering_agent_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('neutron_metering_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-metering-agent_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_metering_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_metering_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "nova_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_api_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_api_local_status :
         label                   : nova_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "nova_api_metadata_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_api_metadata_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_api_metadata_local_check.py", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
@@ -10,6 +10,8 @@ alarms      :
     nova_api_metadata_local_status :
         label                   : nova_api_metadata_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_api_metadata_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_api_metadata_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_cert_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_cert_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_cert_status :
         label                   : nova_cert_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cert_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-cert_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "nova_cloud_stats_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_cloud_stats_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_cloud_stats.py", "--cpu", "{{ cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ cloud_resource_mem_allocation_ratio }}", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     nova_cloud_memory_status :
         label                   : nova_cloud_memory_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cloud_memory_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_memory"], metric["cloud_resource_total_memory"]) > {{ cloud_resource_critical_memory }}) {
@@ -22,6 +23,7 @@ alarms      :
     nova_cloud_disk_status :
         label                   : nova_cloud_disk_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cloud_disk_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_disk_space"], metric["cloud_resource_total_disk_space"]) > {{ cloud_resource_critical_disk_space }}) {
@@ -33,6 +35,7 @@ alarms      :
     nova_cloud_vcpu_status :
         label                   : nova_cloud_vcpu_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_cloud_vcpu_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_vcpus"], metric["cloud_resource_total_vcpus"]) > {{ cloud_resource_critical_vcpus }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_compute_status :
         label                   : nova_compute_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_compute_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-compute_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_compute_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_compute_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_conductor_status :
         label                   : nova_conductor_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_conductor_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-conductor_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_conductor_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_conductor_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_consoleauth_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_consoleauth_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_consoleauth_status :
         label                   : nova_consoleauth_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_consoleauth_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-consoleauth_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_scheduler_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_scheduler_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_scheduler_status :
         label                   : nova_scheduler_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_scheduler_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-scheduler_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     nova_spice_api_local_status :
         label                   : nova_spice_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('nova_spice_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_spice_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_spice_console_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_spice_console_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "nova_spice", "{{ ansible_ssh_host }}", "6082", "--path", "spice_auto.html"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     openmanage-memory_status :
         label                   : openmanage-memory--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('openmanage-memory--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_memory_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: openmanage-memory
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "openmanage-memory" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}openmanage.py", "chassis", "memory"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: openmanage-processors
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "openmanage-processors" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}openmanage.py", "chassis", "processors"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     openmanage-processors :
         label                   : openmanage-processors--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('openmanage-processors--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_processors_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     openmanage-vdisk :
         label                   : openmanage-vdisk--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
+        disabled                : {{ (('openmanage-vdisk--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_vdisk_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: openmanage-vdisk
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "openmanage-vdisk" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}openmanage.py", "storage", "vdisk"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -20,7 +20,7 @@ alarms      :
     rabbitmq_mem_alarm_status :
         label                   : rabbitmq_mem_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_mem_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_mem_alarm_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: rabbitmq_status--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "rabbitmq_status" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}rabbitmq_status.py", "-H", "{{ ansible_ssh_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_disk_free_alarm_status"] != 1) {
@@ -19,6 +20,7 @@ alarms      :
     rabbitmq_mem_alarm_status :
         label                   : rabbitmq_mem_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_mem_alarm_status"] != 1) {
@@ -28,6 +30,7 @@ alarms      :
     rabbitmq_max_channels_per_conn :
         label                   : rabbitmq_max_channels_per_conn--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_max_channels_per_conn--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_max_channels_per_conn"] > {{ rabbitmq_max_channels_per_con_threshold }}) {
@@ -37,6 +40,7 @@ alarms      :
     rabbitmq_fd_used_alarm_status :
         label                   : rabbitmq_fd_used_alarm_status-{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_fd_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_fd_used"],metric["rabbitmq_fd_total"]) >= {{ rabbitmq_fd_used_threshold }}) {
@@ -46,6 +50,7 @@ alarms      :
     rabbitmq_proc_used_alarm_status :
         label                   : rabbitmq_proc_used_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_proc_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_proc_used"],metric["rabbitmq_proc_total"]) >= {{ rabbitmq_proc_used_threshold }}) {
@@ -55,6 +60,7 @@ alarms      :
     rabbitmq_socket_used_alarm_status :
         label                   : rabbitmq_socket_used_alarm_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_socket_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_sockets_used"],metric["rabbitmq_sockets_total"]) >= {{ rabbitmq_socket_used_threshold }}) {
@@ -63,6 +69,7 @@ alarms      :
     rabbitmq_msgs_excl_notifications :
         label                   : rabbitmq_msgs_excl_notifications--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_msgs_excl_notifications--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_msgs_excl_notifications"] > {{ rabbitmq_queued_messages_excluding_notifications_threshold }} ) {
@@ -71,6 +78,7 @@ alarms      :
     rabbitmq_qgrowth_excl_notifications :
         label                   : rabbitmq_qgrowth_excl_notifications--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('rabbitmq_qgrowth_excl_notifications--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{rabbitmq_queue_growth_rate_threshold / maas_check_period}}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/rackspace-monitoring-agent.cfg
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rackspace-monitoring-agent.cfg
@@ -1,2 +1,3 @@
 monitoring_id {{ entity_name }}
 monitoring_token {{ maas_agent_token }}
+monitoring_upgrade {{ maas_agent_upgrade }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
@@ -11,6 +11,7 @@ alarms      :
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "rsyslogd_process_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "rsyslogd_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}process_check.py", {% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ rsyslogd_process_names|join(",") }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_account_replication_failure_check :
         label                   : swift_account_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_account_replication_failure_percentage_threshold }}) {
@@ -18,6 +19,7 @@ alarms      :
     swift_account_replication_rate_check :
         label                   : swift_account_replication_rate_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ swift_account_replication_growth_rate_threshold / maas_check_period}}) {
@@ -26,6 +28,7 @@ alarms      :
     swift_account_replication_avg_time_check :
         label                   : swift_account_replication_avg_time_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ swift_account_replication_avg_time_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_account_replication_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_account_replication_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}swift-recon.py", "--ring-type", "account", "replication"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_account_server_api_local_status :
         label                   : swift_account_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_account_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_account_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_account_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_account_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_account_server", "--path", "/healthcheck", "{{ storage_address }}", "6002"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_async_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_async_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}swift-recon.py", "async-pendings"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_async_failure_check :
         label                   : swift_async_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_async_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["async_failed"] > {{ swift_async_pending_failure_percentage_threshold }}) {
@@ -19,6 +20,7 @@ alarms      :
     swift_async_avg_check :
         label                   : swift_async_avg_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_async_avg_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["async_avg"] > {{ swift_async_pending_average_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_container_replication_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_container_replication_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}swift-recon.py", "--ring-type", "container", "replication"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_container_replication_failure_check :
         label                   : swift_container_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_container_replication_failure_percentage_threshold }}) {
@@ -18,6 +19,7 @@ alarms      :
     swift_container_replication_rate_check :
         label                   : swift_container_replication_rate_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ swift_container_replication_growth_rate_threshold / maas_check_period}}) {
@@ -26,6 +28,7 @@ alarms      :
     swift_container_replication_avg_time_check :
         label                   : swift_container_replication_avg_time_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ swift_container_replication_avg_time_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_container_server_api_local_status :
         label                   : swift_container_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_container_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_container_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_container_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_container_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_container_server", "--path", "/healthcheck", "{{ storage_address }}", "6001"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_ring_md5_check :
         label                   : swift_ring_md5_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_ring_md5_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["ring_errors"] > 0) {
@@ -19,6 +20,7 @@ alarms      :
     swift_conf_md5_check :
         label                   : swift_conf_md5_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_conf_md5_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_conf_errors"] > 0) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_md5_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_md5_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}swift-recon.py", "md5"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_object_replication_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_object_replication_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}swift-recon.py", "--ring-type", "object", "replication"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_object_replication_failure_check :
         label                   : swift_object_replication_failure_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ swift_object_replication_failure_percentage_threshold }}) {
@@ -18,6 +19,7 @@ alarms      :
     swift_object_replication_rate_check :
         label                   : swift_object_replication_rate_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ swift_object_replication_growth_rate_threshold / maas_check_period}}) {
@@ -26,6 +28,7 @@ alarms      :
     swift_object_replication_avg_time_check :
         label                   : swift_object_replication_avg_time_check--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ swift_object_replication_avg_time_threshold }}) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_object_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_object_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_object_server", "--path", "/healthcheck", "{{ storage_address }}", "6000"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_object_server_api_local_status :
         label                   : swift_object_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_object_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_object_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_proxy_server_api_local_status :
         label                   : swift_proxy_server_api_local_status--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_proxy_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_proxy_server_api_local_status"] != 1) {

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_proxy_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_proxy_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}service_api_local_check.py", "swift_proxy_server", "--path", "/healthcheck", "{{ ansible_ssh_host }}", "8080"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_quarantine_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_quarantine_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}swift-recon.py", "quarantine"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
@@ -10,6 +10,7 @@ alarms      :
     swift_quarantine_object_failed :
         label                   : swift_quarantine_object_failed--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_object_failed--'+ansible_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["objects_failed"] > {{ swift_object_quarantine_failed_percentage_threshold }}) {
@@ -19,6 +20,7 @@ alarms      :
     swift_quarantine_object_avg :
         label                   : swift_quarantine_object_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_object_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["objects_avg"] > {{ swift_object_quarantine_average_threshold }}) {
@@ -28,6 +30,7 @@ alarms      :
     swift_quarantine_account_failed :
         label                   : swift_quarantine_account_failed--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_account_failed--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["accounts_failed"] > {{ swift_account_quarantine_failed_percentage_threshold }}) {
@@ -37,6 +40,7 @@ alarms      :
     swift_quarantine_account_avg :
         label                   : swift_quarantine_account_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_account_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["accounts_avg"] > {{ swift_account_quarantine_average_threshold }}) {
@@ -46,6 +50,7 @@ alarms      :
     swift_quarantine_container_failed :
         label                   : swift_quarantine_container_failed--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_container_failed--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["containers_failed"] > {{ swift_container_quarantine_failed_percentage_threshold }}) {
@@ -55,6 +60,7 @@ alarms      :
     swift_quarantine_container_avg :
         label                   : swift_quarantine_container_avg--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_quarantine_container_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["containers_avg"] > {{ swift_container_quarantine_average_threshold }}) {


### PR DESCRIPTION
This backport includes the following four patches to master:

- 63369c2 MaaS: Improve period/timeout/disabling checks
- f501904 MaaS: Enable agent auto upgrade
- ef1bbae MaaS template fixes
- 20d4ba9 Disable MaaS alarms/checks with regex

Connects rcbops/u-suk-dev#1033
Connects rcbops/u-suk-dev#1050
Connects rcbops/u-suk-dev#1052