### PR TITLE
Make RPC Deployment optional

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,6 +15,7 @@ export DEPLOY_CEPH=${DEPLOY_CEPH:-"no"}
 export DEPLOY_SWIFT=${DEPLOY_SWIFT:-"yes"}
 export DEPLOY_MAGNUM=${DEPLOY_MAGNUM:-"no"}
 export DEPLOY_HARDENING=${DEPLOY_HARDENING:-"yes"}
+export DEPLOY_RPC=${DEPLOY_RPC:-"yes"}
 export ANSIBLE_FORCE_COLOR=${ANSIBLE_FORCE_COLOR:-"true"}
 export BOOTSTRAP_OPTS=${BOOTSTRAP_OPTS:-""}
 export UNAUTHENTICATED_APT=${UNAUTHENTICATED_APT:-no}
@@ -250,5 +251,7 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
 
 fi
 
-# Begin the RPC installation
-bash ${BASE_DIR}/scripts/deploy-rpc-playbooks.sh
+if [[ "${DEPLOY_RPC}" == "yes" ]]; then
+  # Begin the RPC installation
+  bash ${BASE_DIR}/scripts/deploy-rpc-playbooks.sh
+fi


### PR DESCRIPTION
This allows deploy.sh to be used to prepare a deployment without
starting the deploy. This is necessary as Jenkins jobs are now being
divided into stages such as prepare and deploy, so that common stages
can be shared between jobs.

Connects rcbops/u-suk-dev#1069