### PR TITLE
MaaS: Set default alarm/check params

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -82,7 +82,20 @@ maas_alarm_remote_consecutive_count: 1
 # horizon_local_check is disabled until https://github.com/rcbops/u-suk-dev/issues/781
 # is resolved
 maas_excluded_checks:
-  - horizon_local_check
+  - 'horizon_local_check.*'
+
+# Disable the following MaaS alarms
+# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
+maas_excluded_alarms:
+  - '^idle_percent_average.*'
+  - '^memory_used.*'
+  - '^alarm-network-receive.*'
+  - '^alarm-network-transmit.*'
+
+# Set overrides for check periods
+# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
+maas_check_period_override:
+  disk_utilisation: 900
 
 # Set the threshold for filesystem monitoring when you are not specifying specific filesystems.
 maas_filesystem_warning_threshold: 80.0


### PR DESCRIPTION
This patch sets the default alarm exclusions and check periods as
specified in rcbops/u-suk-dev#948.

Connects rcbops/u-suk-dev#1081