### PR TITLE
Avoid curl return '0' in 'Drop log_test1 template' task

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -108,7 +108,8 @@
     - reindex-wrapper
 
 - name: Drop log_test1 template
-  shell: 'curl -sk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
+  shell: 'curl -fsk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
+  register: drop_output
   retries: 5
   tags:
     - logging-upgrade
@@ -137,6 +138,11 @@
     - logging-upgrade
     - elasticsearch-upgrade
     - reindex-wrapper
+
+- name: VERBOSITY
+  debug: msg="{{ item }}"
+  with_items:
+      - "{{ drop_out.stdout_lines }}"
 
 - name: Remove legacy liberty template script
   file:


### PR DESCRIPTION
As before, curl always return '0' when met HTTP 503 error, which
lead the task wouldn't retry times until dropping successfully.
By adding '-f' will let curl return '22' when doc doesn't exists,
and would trigger more retries.