### PR TITLE
Add -f (--fail) flag to curl to return non-zero

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -108,7 +108,7 @@
     - reindex-wrapper
 
 - name: Drop log_test1 template
-  shell: 'curl -sk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
+  shell: 'curl -fsk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
   retries: 5
   tags:
     - logging-upgrade

--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -109,7 +109,12 @@
 
 - name: Drop log_test1 template
   shell: 'curl -fsk -XDELETE {{ internal_lb_vip_address }}:{{ elasticsearch_http_port }}/_template/log_test1'
-  retries: 5
+  args:
+     warn: no
+  register: curl_result
+  retries: 12
+  delay: 5
+  until: curl_result.rc == 0
   tags:
     - logging-upgrade
     - elasticsearch-upgrade


### PR DESCRIPTION
Adding -f to the curl command will make curl return a non-zero
exit code when the DELETE request fails.  This will allow Ansible
to retry the task.

Connects https://github.com/rcbops/u-suk-dev/issues/1065