### PR TITLE
 Set neutron_legacy_ha_tool_enabled to true by default

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -171,3 +171,6 @@ haproxy_extra_services:
       haproxy_balance_type: tcp
       haproxy_backend_options:
         - "ssl-hello-chk"
+
+#Set the default for Neutron-HA-tool to true
+neutron_legacy_ha_tool_enabled: true


### PR DESCRIPTION
This will allow for neutron_legacy_ha_tool_enabled to be enabled
by default. This tool was providing HA capabilities for networks
and routers that were not using the native Neutron L3HA.

Connects rcbops/u-suk-dev#865