### PR TITLE
[Backport - Newton] Switch keystone UUID to Fernet

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -69,7 +69,6 @@ rabbitmq_ulimit: 65535
 memcached_connections: 16384
 
 # Keystone overrides
-keystone_token_provider: "uuid"
 keystone_token_driver: "sql"
 
 # Galera overrides


### PR DESCRIPTION
Old UUID tonken would consume space of DB and cause authentication
 slow when heavy traffic access DB. Fernet tokens use shared
private keys to avoid having to store or replicate tokens in your
DB. This change will make authentication super fast and big plus
for keystone. And it's already in upstream.

(cherry picked from commit ea4f14b4e46a5e9aa651f5e79900c1cecf31ded3)

Connects https://github.com/rcbops/u-suk-dev/issues/134