### PR TITLE
[Backport - Newton] Maas: Update MaaS plugins readme

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/files/plugins/README.md
+++ b/rpcd/playbooks/roles/rpc_maas/files/plugins/README.md
@@ -381,9 +381,12 @@ Returns metrics indicating the status of parts of HP hardware.
 
 ##### Example Output:
 
+    metric hardware_controller_battery_status uint32 1
+    metric hardware_controller_cache_status uint32 1
+    metric hardware_controller_status uint32 1
+    metric hardware_disk_status uint32 1
     metric hardware_memory_status uint32 1
     metric hardware_processors_status uint32 1
-    metric hardware_disk_status uint32 1
 
 ***
 #### ceph_monitoring.py


### PR DESCRIPTION
[Backport - Newton] Updates plugin README for updated output of hp_monitoring.py MaaS plugin.

Connects rcbops/u-suk-dev#1128