### PR TITLE
Add playbook for updating git repositories on rpc-repo

### DIFF
--- a/openstackgit-update.yml
+++ b/openstackgit-update.yml
@@ -1,0 +1,92 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This playbook's function is to update the git clones for all
+# git repositories use by the OpenStack-Ansible integrated build.
+#
+# The playbook intentionally clones the full repository to ensure
+# that it's usable by all RPC releases, regardless of branch.
+#
+# The playbook also intentionally uses the OSA master branch as it
+# is expected to contain more repositories than RPC will need, but
+# will always have a complete set.
+
+- name: Pull the current openstackgit folder from rpc-repo
+  hosts: mirrors
+  vars:
+    working_dir: "{{ lookup('ENV', 'PWD') }}"
+  tasks:
+
+    - name: Pull the data from rpc-repo
+      synchronize:
+        src: "/var/www/repo/openstackgit"
+        dest: "{{ working_dir }}/"
+        mode: pull
+        delete: yes
+        recursive: yes
+      register: synchronize
+      until: synchronize | success
+      retries: 5
+      delay: 5
+
+
+
+- name: Update the openstackgit data
+  hosts: localhost
+  connection: local
+  vars:
+    working_dir: "{{ lookup('ENV', 'PWD') }}"
+  tasks:
+
+    - name: Lookup all the git repositories we need to update
+      debug:
+        msg: "Looking up repositories"
+      with_py_pkgs: "{{ working_dir }}/"
+      register: local_packages
+
+    - name: Update the openstackgit clones
+      git:
+        repo: "{{ item['url'] }}"
+        dest: "{{ working_dir }}/openstackgit/{{ item['name'] }}"
+        version: "master"
+        update: true
+        force: true
+      with_items: "{{ local_packages.results.0.item.remote_package_parts }}"
+      register: git_clone
+      until: git_clone | success
+      retries: 5
+      delay: 5
+
+
+
+- name: Push the updated clones to rpc-repo
+  hosts: mirrors
+  vars:
+    working_dir: "{{ lookup('ENV', 'PWD') }}"
+  tasks:
+
+    - name: Push updated git clones to rpc-repo
+      synchronize:
+        src: "{{ working_dir }}/openstackgit"
+        dest: "/var/www/repo/"
+        mode: push
+        delete: yes
+        recursive: yes
+        rsync_opts:
+          - "--chown=nginx:www-data"
+      register: synchronize
+      until: synchronize | success
+      retries: 5
+      delay: 5


### PR DESCRIPTION
This playbook updates the git repositories to the latest master
branch to ensures that rpc-repo has a copy that includes any
release SHA.

Connects https://github.com/rcbops/u-suk-dev/issues/1131