### PR TITLE
[Backport -Newton] Add DISABLED as an allowed alarms state

### DIFF
--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -636,7 +636,7 @@ class RpcMassCli(object):
         for entity in self.rpcm.get_entities():
             for alarm in entity.alarms:
                 alarms.append(alarm)
-                if alarm.state not in ["OK", "UNKNOWN"]:
+                if alarm.state not in ["OK", "UNKNOWN", "DISABLED"]:
                     failed_alarms.append(alarm)
                     alarm.bullet = "!"
         return (alarms, failed_alarms)


### PR DESCRIPTION
This allows maas verification to pass even when alarms has been disabled,
which they have been recently.

Related: rcbops/u-suk-dev#1081
Connects rcbops/u-suk-dev#1139
(cherry picked from commit 19dcb5f9f75f888ff897e1d978a8db381ec9c1df)