### PR TITLE
Ensure the apt artifact build derives the version

### DIFF
--- a/scripts/artifacts-building/apt/artifacting-vars.yml
+++ b/scripts/artifacts-building/apt/artifacting-vars.yml
@@ -20,10 +20,9 @@ artifact_extradownloads_dest_folder: "{{ artifacts_root_folder }}/downloads"
 ansible_roles_folder: "/etc/ansible/roles"
 
 # Generic details
-rpc_branch: "master"
-osa_branch: 'stable/newton' #can be automated later by lookup
-roles_details: "{{ lookup('url','https://raw.githubusercontent.com/openstack/openstack-ansible/'+osa_branch+'/ansible-role-requirements.yml',wantlist=True) | join('\n') | from_yaml  }}"
-artifacts_version: "rpc-14.0.0rc1" #Move to reading variable from here: "https://github.com/rcbops/rpc-openstack/blob/master/rpcd/playbooks/group_vars/all.yml"
+role_requirements_file: "{{ lookup('env', 'BASE_DIR') ~ 'openstack-ansible/ansible-role-requirements.yml') }}"
+roles_details: "{{ lookup('file', role_requirements_file, wantlist=True) | join('\n') | from_yaml }}"
+artifacts_version: "{{ lookup('pipe', '/opt/rpc-openstack/derive-artifact-version.py') }}"
 
 # rpc-repo mirror details
 webservice_owner: "nginx"

--- a/scripts/artifacts-building/apt/bindep.txt
+++ b/scripts/artifacts-building/apt/bindep.txt
@@ -1,9 +1,0 @@
-build-essential
-git-core
-libssl-dev
-libffi-dev
-python2.7
-python-dev
-python-pyasn1
-python-openssl
-gzip


### PR DESCRIPTION
Currently the apt artifact build process uses a static
version. This patch ensures that it uses the appropriate
script to derive the artifact version in the same way
as the python artifact building job.

Connects https://github.com/rcbops/u-suk-dev/issues/1133