### PR TITLE
Remove rabbitmq role clone

### DIFF
--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -15,9 +15,6 @@
 
 # Prepare for aptly, repos to clone.
 aptly_clone_this_first:
-  - repo: "https://github.com/openstack/openstack-ansible-rabbitmq_server.git"
-    dest: "{{ ansible_roles_folder }}/rabbitmq_server"
-    version: "{{ roles_details | selectattr('name','equalto', 'rabbitmq_server') | list | map(attribute='version') | list | join('') }}"
   - repo: "https://github.com/evrardjp/ansible-role-aptly.git"
     dest: "{{ ansible_roles_folder }}/infOpen.aptly"
     version: "rax"

--- a/scripts/artifacts-building/apt/artifacting-vars.yml
+++ b/scripts/artifacts-building/apt/artifacting-vars.yml
@@ -20,8 +20,6 @@ artifact_extradownloads_dest_folder: "{{ artifacts_root_folder }}/downloads"
 ansible_roles_folder: "/etc/ansible/roles"
 
 # Generic details
-role_requirements_file: "{{ lookup('env', 'BASE_DIR') ~ 'openstack-ansible/ansible-role-requirements.yml') }}"
-roles_details: "{{ lookup('file', role_requirements_file, wantlist=True) | join('\n') | from_yaml }}"
 artifacts_version: "{{ lookup('pipe', '/opt/rpc-openstack/derive-artifact-version.py') }}"
 
 # rpc-repo mirror details


### PR DESCRIPTION
As the rabbitmq role is already being cloned by the
Ansible bootstrap process, the extra machinery for
doing this in the aptly playbooks is not required.

Connects https://github.com/rcbops/u-suk-dev/issues/1133