### PR TITLE
Introduce a temp workaround

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -61,6 +61,13 @@ cp user_*.yml /etc/openstack_deploy/
 # Patch the roles
 git config --global user.email "rcbops@rackspace.com"
 git config --global user.name "RCBOPS gating"
+
+# TEMP WORKAROUND: CHECKOUT the version you need!
+pushd /etc/ansible/roles/os_keystone
+git fetch --all
+git checkout stable/newton
+popd
+
 cd containers/patches/
 patch_all_roles
 


### PR DESCRIPTION
Currently, the osa keystone role has received a cleanup of tags,
but the version checked out by rpc is lagging behind.
This is a workaround to use the latest version, and this way
I can cleanly apply patches to change behavior of the role on top
of it.