### PR TITLE
[Backport - Kilo] Fix item.group bug in process.yml

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/process.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 - name: Install process checks
   template:
     src: "{{ item.name }}.yaml.j2"
@@ -24,6 +23,7 @@
   with_items:
     - "{{ process_checks_list }}"
   when:
-    - inventory_hostname in groups[ '{{ item.group }}' ]
+    - item.group in groups
+    - inventory_hostname in groups['{{ item.group }}']
     - item.name not in maas_excluded_checks
   delegate_to: "{{ physical_host }}"


### PR DESCRIPTION
This patch fixes a bug where the `setup-maas.yml` playbook would
fail when checking for `item.group` in the host groups.

Connects rcbops/u-suk-dev#1025
Connects rcbops/u-suk-dev#1175
(cherry picked from commit db8062419945809f7fafecfccdc1df7b359f2c29)