### PR TITLE
[Backport - Kilo] Fix cinder_backends template bug

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -239,7 +239,7 @@ mysql_connection_critical_threshold: 90
 # cinder-volumes volume group thresholds
 cinder_volumes_vg_warning_threshold: 80.0
 cinder_volumes_vg_critical_threshold: 90.0
-cinder_vg_name: "{{ cinder_backends['lvm']['volume_group'] }}"
+cinder_vg_name: "{{ cinder_backends['lvm']['volume_group'] | default('cinder-volumes') }}"
 
 # MaaS CPU idle threshold
 cpu_idle_percent_avg_threshold: 10.0
@@ -326,7 +326,7 @@ elasticsearch_process_names:
   # process name that includes "elasticsearch". The process running
   # elasticsearch is actually named "java" so we search for that here. This is
   # less than ideal, but the best we can do right now.
-  - java 
+  - java
 
 beaver_process_names:
   - beaver


### PR DESCRIPTION
This patch combines the three patches that changed the same line.

Connects rcbops/u-suk-dev#1175
(cherry picked from commit ad4181d)