### PR TITLE
MaaS: Improve period/timeout/disabling checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -476,6 +476,20 @@ maas_rpc_scripts_dir: /opt/rpc-openstack/scripts
 maas_excluded_checks: []
 maas_excluded_alarms: []
 
+# Customizing MaaS check period and timeout.
+# The following two variables allow deployers to provide custom check periods
+# and timeouts for certain checks. Each variable is a list of dictionaries
+# containing the check label and the appropriate value:
+#
+#   maas_check_period_override:
+#     - disk_utilization: 60
+#     - conntrack_count: 45
+#   maas_check_timeout_override:
+#     - cinder_backup_check: 120
+#
+maas_check_period_override: {}
+maas_check_timeout_override: {}
+
 # openrc definitions from OSA
 # This is necessary until LP #1537117 is implemented
 openrc_os_endpoint_type: internalURL

--- a/rpcd/playbooks/roles/rpc_maas/templates/beaver_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/beaver_process_check.yaml.j2
@@ -1,8 +1,11 @@
-type: agent.plugin
-label: "beaver_process_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+
+{% set label = "beaver_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : process_check.py
     args    : [{% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ beaver_process_names|join(",") }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "ceph_cluster_stats--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "ceph_cluster_stats" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : ceph_monitoring.py
     args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "cluster"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "ceph_mon_stats--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "ceph_mon_stats" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : ceph_monitoring.py
     args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "mon", "--host", "{{ ansible_hostname }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_osd_stats.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "ceph_osd_stats--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "ceph_osd_stats" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : ceph_monitoring.py
     args    : ["--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "cinder_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : cinder_api_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_backup_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_backup_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_backup_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : cinder_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_scheduler_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_scheduler_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_scheduler_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : cinder_service_check.py
     args    : ["--host", "{{ ansible_hostname }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_vg_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_vg_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_vg_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : vg_check.py
     args    : ["{{ item.cinder_vg_name }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cinder_volume_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: cinder_volume_{{ item.key }}_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "cinder_volume_"+item.key+"_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : cinder_service_check.py
     args    : ["--host", "{{ ansible_hostname }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/conntrack_count.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "conntrack_count--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "conntrack_count" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : conntrack_count.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/cpu_check.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "cpu_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
 type              : agent.cpu
-label             : cpu_check--{{ inventory_hostname|quote }}
-disabled          : false
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/disk_utilisation.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "disk_utilisation--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "disk_utilisation" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : disk_utilisation.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/elasticsearch_process_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "elasticsearch_process_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "elasticsearch_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : process_check.py
     args    : [{% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ elasticsearch_process_names|join(",") }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.filesystem
-label: "filesystem_{{ item.filesystem }}--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "filesystem_"+item.filesystem %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.filesystem
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     target  : "{{ item.filesystem }}"
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/filesystem_auto.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.filesystem
-label: "filesystem_{{ item }}--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "filesystem_"+item %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.filesystem
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     target  : "{{ item }}"
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "galera_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "galera_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : galera_check.py
     args    : ["-H", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "glance_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "glance_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : glance_api_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/glance_registry_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "glance_registry_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "glance_registry_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : glance_registry_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "heat_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "heat_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : heat_api_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cfn_api_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "heat_cfn_api_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "heat_cfn_api_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["heat_cfn", "{{ ansible_ssh_host }}", "8000"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/heat_cw_api_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "heat_cw_api_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "heat_cw_api_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["heat_cw", "{{ ansible_ssh_host }}", "8003"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/horizon_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "horizon_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "horizon_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : horizon_check.py
     args    : ["{{ ansible_ssh_host }}", "{{ horizon_site_name }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-memory.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: hp-memory
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "hp-memory" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : hp_monitoring.py
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-processors.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: hp-processors
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "hp-processors" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : hp_monitoring.py
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-vdisk.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: hp-disk
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "hp-disk" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : hp_monitoring.py
 alarms      :

--- a/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/keystone_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "keystone_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "keystone_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : keystone_api_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_cinder.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_cinder" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_cinder--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_glance.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_glance" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_glance--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_api.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_heat_api" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_heat_api--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cfn.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_heat_cfn" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_heat_cfn--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_heat_cloudwatch.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_heat_cloudwatch" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_heat_cloudwatch--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_horizon.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_horizon" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_horizon--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_keystone.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_keystone" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_keystone--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_neutron.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_neutron" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_neutron--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_nova.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_nova" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_nova--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_proxy.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_api_check_swift_proxy.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_api_check_swift_proxy" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_api_check_swift_proxy--{{ lb_name }}
-disabled          : "{{ check_disabled }}"
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/lb_ssl_cert_expiry_check.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "lb_ssl_cert_expiry_check" %}
+{% set check_name = label+'--'+lb_name %}
 type              : remote.http
-label             : lb_ssl_cert_expiry_check--{{ lb_name }}
-disabled          : false
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ ip_address }}"
 details           :

--- a/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memcached_status.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "memcached_status--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "memcached_status" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : memcached_status.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/memory_check.yaml.j2
@@ -1,8 +1,10 @@
+{% set label = "memory_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
 type              : agent.memory
-label             : memory_check--{{ inventory_hostname|quote }}
-disabled          : false
-period            : "{{ maas_check_period }}"
-timeout           : "{{ maas_check_timeout }}"
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/network_throughput.yaml.j2
@@ -1,14 +1,16 @@
+{% set label = "network_throughput_"+item.0.name %}
+{% set check_name = label+'--'+ansible_hostname %}
 {% set max_speed = (item.0.max_speed | default(0, boolean=true) or item.1.stdout) | int * 10 ** 6 / 8 %}
 {% set rx_warn = (max_speed | int * item.0.rx_pct_warn | float / 100) | int %}
 {% set rx_crit = (max_speed | int * item.0.rx_pct_crit | float / 100) | int %}
 {% set tx_warn = (max_speed | int * item.0.tx_pct_warn | float / 100) | int %}
 {% set tx_crit = (max_speed | int * item.0.tx_pct_crit | float / 100) | int -%}
 
-type: agent.network
-label: network_throughput_{{ item.0.name }}--{{ inventory_hostname|quote }}
-disabled: false
-period: {{ maas_check_period| default(60) }}
-timeout: {{ maas_check_timeout| default(30) }}
+type        : agent.network
+label       : "{{ check_name }}"
+period      : {{ maas_check_period| default(60) }}
+timeout     : {{ maas_check_timeout| default(30) }}
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details:
   target: {{ item.0.name }}
 alarms:

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "neutron_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : neutron_api_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_dhcp_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_dhcp_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_dhcp_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : neutron_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_l3_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_l3_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_l3_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : neutron_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_linuxbridge_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_linuxbridge_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : neutron_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metadata_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_metadata_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_metadata_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : neutron_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/neutron_metering_agent_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: neutron_metering_agent_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "neutron_metering_agent_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : neutron_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "nova_api_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_api_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_api_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_api_metadata_local_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "nova_api_metadata_local_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_api_metadata_local_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_api_metadata_local_check.py
     args    : ["{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cert_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_cert_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_cert_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_cloud_stats_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "nova_cloud_stats_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_cloud_stats_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_cloud_stats.py
     args    : ["--cpu", "{{ cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ cloud_resource_mem_allocation_ratio }}", "{{ ansible_ssh_host }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_compute_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_compute_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_compute_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_conductor_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_conductor_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_conductor_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_consoleauth_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_consoleauth_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_consoleauth_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_scheduler_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_scheduler_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_scheduler_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : nova_service_check.py
     args    : ["--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/nova_spice_console_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: nova_spice_console_check--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "nova_spice_console_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["nova_spice", "{{ ansible_ssh_host }}", "6082", "--path", "spice_auto.html"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-memory.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: openmanage-memory
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "openmanage-memory" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : openmanage.py
     args    : ["chassis", "memory"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-processors.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: openmanage-processors
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "openmanage-processors" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : openmanage.py
     args    : ["chassis", "processors"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/openmanage-vdisk.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: openmanage-vdisk
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "openmanage-vdisk" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : openmanage.py
     args    : ["storage", "vdisk"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rabbitmq_status.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: rabbitmq_status--{{ ansible_hostname }}
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "rabbitmq_status" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : rabbitmq_status.py
     args    : ["-H", "{{ ansible_ssh_host }}", "-n", "{{ inventory_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/rsyslogd_process_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "rsyslogd_process_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "rsyslogd_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : process_check.py
     args    : [{% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ rsyslogd_process_names|join(",") }}"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_replication_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_account_replication_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_account_replication_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : swift-recon.py
     args    : ["--ring-type", "account", "replication"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_account_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_account_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["swift_account_server", "--path", "/healthcheck", "{{ storage_address }}", "6002"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_async_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_async_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_async_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : swift-recon.py
     args    : ["async-pendings"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_replication_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_container_replication_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_container_replication_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : swift-recon.py
     args    : ["--ring-type", "container", "replication"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_container_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_container_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["swift_container_server", "--path", "/healthcheck", "{{ storage_address }}", "6001"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_md5_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_md5_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_md5_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : swift-recon.py
     args    : ["md5"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_replication_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_object_replication_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_object_replication_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : swift-recon.py
     args    : ["--ring-type", "object", "replication"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_object_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_object_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["swift_object_server", "--path", "/healthcheck", "{{ storage_address }}", "6000"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_proxy_server_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_proxy_server_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_proxy_server_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : service_api_local_check.py
     args    : ["swift_proxy_server", "--path", "/healthcheck", "{{ ansible_ssh_host }}", "8080"]

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_quarantine_check.yaml.j2
@@ -1,8 +1,10 @@
-type: agent.plugin
-label: "swift_quarantine_check--{{ ansible_hostname }}"
-disabled    : false
-period      : "{{ maas_check_period }}"
-timeout     : "{{ maas_check_timeout }}"
+{% set label = "swift_quarantine_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : swift-recon.py
     args    : ["quarantine"]


### PR DESCRIPTION
This patch adds two new variables that allow deployers to customize
the check period and the check timeout for each MaaS check:

    maas_check_period_override:
      - disk_utilization: 60
      - conntrack_count: 45
    maas_check_timeout_override:
      - cinder_backup_check: 120

The patch makes some adjustments to templates to improve ease of use:

- the check label is set as a variable so that it can be re-used
  in multiple places within the template
- the check period is checked against the list of overrides
- the check timeout is checked against the list of overrides
- the full check name is checked against the list of excluded checks

If a check is disabled, the YAML is left in place on the server, but
the `disabled` option is set to `true`.

Connects rcbops/u-suk-dev#1175
(cherry picked from commit a987481baeaf5f7a247a1a18e338470ddce8755f)