### PR TITLE
Bring consistency in container version

### DIFF
--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -106,7 +106,7 @@
   tasks:
     - name: Set artifact facts
       set_fact:
-        image_path: "{{ lxc_image_folder }}/{{ lxc_index_path }}/{{ image_name }}-{{ pip_artifacts_version }}/{{ build_id }}/"
+        image_path: "{{ lxc_image_folder }}/{{ lxc_index_path }}/{{ image_name }}-{{ rpc_release }}/{{ build_id }}/"
     - name: Ensure image doesn't exist yet.
       file:
         path: "{{ image_path }}"
@@ -140,7 +140,7 @@
     - name: Create release index entries
       lineinfile:
         dest: "{{ built_container_artifact_metadata_file }}"
-        line: "{{ lxc_index_entry }};{{ image_name }}-{{ pip_artifacts_version }};{{ build_id }};/{{ webserver_container_artifacts_uri }}/{{ lxc_index_path }}/{{ image_name }}-{{ pip_artifacts_version }}/{{ build_id }}"
+        line: "{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};{{ build_id }};/{{ webserver_container_artifacts_uri }}/{{ lxc_index_path }}/{{ image_name }}-{{ rpc_release }}/{{ build_id }}"
         create: yes
         state: present
     - name: create sha256sums

--- a/scripts/artifacts-building/containers/artifact-upload.yml
+++ b/scripts/artifacts-building/containers/artifact-upload.yml
@@ -29,7 +29,7 @@
     - name: patch the current list with the new artifact
       lineinfile:
         dest: "/tmp/list"
-        regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ pip_artifacts_version }}"
+        regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }}"
         line: "{{ lookup('file', built_container_artifact_metadata_file ) }}"
     - name: Remove the metada file
       file:

--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -3,7 +3,7 @@ build_id: "{{ ansible_date_time.date | replace('-','') }}"
 lxc_index_path: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}/{{ architecture_mapping.get( ansible_architecture ) }}"
 lxc_index_entry: "{{ ansible_distribution | lower }};{{ ansible_distribution_release | lower }};{{ architecture_mapping.get( ansible_architecture ) }}"
 lxc_image_folder: "/var/cache/artifacts"
-built_container_artifact_metadata_file: "{{ lxc_image_folder }}/{{ image_name }}-{{ pip_artifacts_version }}-entry"
+built_container_artifact_metadata_file: "{{ lxc_image_folder }}/{{ image_name }}-{{ rpc_release }}-entry"
 webserver_container_artifacts_uri: "lxc-images"
 lxc_container_cache_path: "/var/cache/lxc/download"
 image_name: "{{ role_name | replace('os_', '') }}"
@@ -15,8 +15,8 @@ architecture_mapping:
   x86_64: amd64
   ppc64le: ppc64el
 role_vars:
-  "venv_download_url": "{{ mirror_base_url }}/venvs/{{ pip_artifacts_version }}/ubuntu/{{ image_name }}-{{ pip_artifacts_version }}-{{ ansible_architecture }}.tgz"
-  "venv_tag": "{{ pip_artifacts_version }}"
+  "venv_download_url": "{{ mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
+  "venv_tag": "{{ rpc_release }}"
   "developer_mode": False
 webserver_owner: "nginx"
 webserver_group: "www-data"


### PR DESCRIPTION
We are currently using pip_artifacts_version to build the
containers. But since the creation of these playbooks and vars,
we moved to being consistent and use rpc_release for everything.

This moves the code to our latest practices.