### PR TITLE
[Liberty] Checking galera innodb_deadlocks metric as rate

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -266,6 +266,10 @@ mysql_open_files_percentage_critical_threshold: 95
 innodb_row_lock_time_avg_warning_threshold: 2000
 innodb_row_lock_time_avg_critical_threshold: 10000
 
+# Maas InnoDB deadlock thresholds per maas check interval
+innodb_deadlocks_rate_warning_threshold: 1
+innodb_deadlocks_rate_critical_threshold: 2
+
 # cinder-volumes volume group thresholds
 cinder_volumes_vg_warning_threshold: 80.0
 cinder_volumes_vg_critical_threshold: 90.0

--- a/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/galera_check.yaml.j2
@@ -61,8 +61,11 @@ alarms      :
         notification_plan_id    : "{{ maas_notification_plan }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["innodb_deadlocks"] != 0) {
-                return new AlarmStatus(CRITICAL, "InnoDB has experienced a deadlock");
+            if (rate(metric["innodb_deadlocks"]) > {{ innodb_deadlocks_rate_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "InnoDB has experienced a deadlock rate greater than {{ innodb_deadlocks_rate_warning_threshold }} per {{ maas_check_period }} seconds");
+            }
+            if (rate(metric["innodb_deadlocks"]) > {{ innodb_deadlocks_rate_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "InnoDB has experienced a deadlock rate greater than {{ innodb_deadlocks_rate_critical_threshold }} per {{ maas_check_period }} seconds");
             }
     access_denied_errors :
         label                   : access_denied_errors--{{ ansible_hostname }}


### PR DESCRIPTION
This fix checks the galera innodb_deadlocks metric as rate per
MaaS service check interval rather than absolute values.
A SQL database can experience occasional dead locking due to concurrent
table crud.
New overrides ``innodb_deadlocks_rate_warning_threshold`` defined as 1
and ``innodb_deadlocks_rate_critical_threshold`` defined as 2, are
exposed as configuration option to allow/reduce the number of deadlocks
a database can occur.

Connects rcbops/u-suk-dev#1175
(cherry picked from commit 0ab03ae489511c204a8b53eec0cce8c69bc08ba0)