### PR TITLE
[Backport Newton] fix generated f5 config to actually work

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -67,6 +67,7 @@ MONITORS = [
     r' rpc\r\n\r\n" }',
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_SPICE_CONSOLE {'
     r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /spice_auto.html'
+    r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_NOVNC_CONSOLE {'
     r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /novnc_auto.html'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',

--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -69,7 +69,7 @@ MONITORS = [
     r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /spice_auto.html'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_NOVNC_CONSOLE {'
-    r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /novnc_auto.html'
+    r' defaults-from http destination *:6080 recv "200 OK" send "HEAD /novnc_auto.html'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
     r'create ltm monitor https /' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_HORIZON_SSL { defaults-from'
     r' https destination *:443 recv "302 FOUND" send "HEAD / HTTP/1.1\r\nHost:'


### PR DESCRIPTION
Without the missing line the two rules are joined and there is a
dangling ".

(cherry picked from commit 311d6426824d4af87b4dfceb3305a11df069f4cb)