### PR TITLE
Set RPC-O to use the apt artifacts by default

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -173,3 +173,89 @@ haproxy_extra_services:
 
 #Set the default for Neutron-HA-tool to true
 neutron_legacy_ha_tool_enabled: true
+
+#
+# Set variables used for enabling/disabling the use of staged apt/container artifacts
+#
+# TODO(odyssey4me) When the staging implementation is complete, switch this to 'no'
+rpco_online_install: yes
+rpco_mirror_base_url: "{{ (rpco_online_install | bool) | ternary('http://rpc-repo.rackspace.com', openstack_repo_url) }}"
+
+#
+# Set RPC deployments to make use of the apt artifacts repository
+#
+rpco_mirror_apt_deb_line: "deb {{ rpco_mirror_apt_url }} {{ rpc_release }}-{{ ansible_distribution_release }} main"
+rpco_mirror_apt_url: "{{ rpco_mirror_base_url }}/apt-mirror/integrated/"
+rpco_mirror_apt_filename: rpco
+rpco_gpg_key_location: "{{ rpco_mirror_base_url }}/apt-mirror/"
+rpco_gpg_key_name: "rcbops-release-signing-key.asc"
+rpco_gpg_key_id: 22A9BF80 #SET IN STATIC (to force key verification per release).
+
+# For convenience
+rpco_apt_repo:
+  repo: "{{ rpco_mirror_apt_deb_line }}"
+  state: "present"
+  filename: "{{ rpco_mirror_apt_filename }}"
+rpco_apt_gpg_keys:
+  - hash_id:  "{{ rpco_gpg_key_id }}"
+    url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
+    state: "present"
+
+# HAProxy
+haproxy_repo: "{{ rpco_apt_repo }}"
+haproxy_gpg_keys: "{{ rpco_apt_gpg_keys }}"
+
+# RabbitMQ
+rabbitmq_install_method: "external_repo"
+rabbitmq_repo: "{{ rpco_apt_repo }}"
+rabbitmq_gpg_keys: "{{ rpco_apt_gpg_keys }}"
+
+# ceph_client wiring
+ceph_apt_repos:
+  uca: "{{ rpco_apt_repo }}"
+ceph_pkg_source: "uca"
+
+# galera_client role wiring
+galera_client_repo: "{{ rpco_mirror_apt_deb_line }}"
+mariadb_repo_filename: "{{ rpco_mirror_apt_filename }}"
+galera_client_gpg_keys: "{{ rpco_apt_gpg_keys }}"
+
+# galera_server wiring
+use_percona_upstream: True
+galera_repo: "{{ rpco_apt_repo }}"
+galera_percona_xtrabackup_repo: "{{ rpco_apt_repo }}"
+
+# neutron, nova wiring
+uca_repo: "{{ rpco_mirror_apt_deb_line }}"
+uca_apt_source_list_filename: "{{ rpco_mirror_apt_filename }}"
+
+# Elasticsearch
+elasticsearch_apt_repos:
+  - "{{ rpco_apt_repo }}"
+elasticsearch_apt_keys: "{{ rpco_apt_gpg_keys }}"
+
+# Filebeat
+filebeat_apt_repos:
+  - "{{ rpco_apt_repo }}"
+filebeat_apt_gpg_keys: "{{ rpco_apt_gpg_keys }}"
+
+# Kibana
+kibana_apt_repos:
+  - "{{ rpco_apt_repo }}"
+kibana_apt_keys: "{{ rpco_apt_gpg_keys }}"
+
+# Logstash
+logstash_apt_repos:
+  - "{{ rpco_apt_repo }}"
+logstash_apt_keys: "{{ rpco_apt_gpg_keys }}"
+
+# MAAS
+maas_apt_repos:
+  - "{{ rpco_apt_repo }}"
+maas_apt_keys: "{{ rpco_apt_gpg_keys }}"
+
+# RPC Support
+hwraid_apt_repos:
+  - repo: "deb {{ rpco_mirror_base_url }}/apt-mirror/independant/hwraid-{{ ansible_distribution_release }}/ {{ rpc_release }}-{{ ansible_distribution_release }} main"
+    state: "present"
+hwraid_apt_keys: "{{ rpco_apt_gpg_keys }}"

--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -15,7 +15,7 @@ architecture_mapping:
   x86_64: amd64
   ppc64le: ppc64el
 role_vars:
-  "venv_download_url": "{{ mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
+  "venv_download_url": "{{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
   "venv_tag": "{{ rpc_release }}"
   "developer_mode": False
 webserver_owner: "nginx"

--- a/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+++ b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
@@ -1,110 +1,30 @@
-## Generic variables
-mirror_base_url: "http://rpc-repo.rackspace.com"
-apply_security_hardening: False #Makes gates faster!
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-## PIP
-# openstack_repo_url is the address of the repo server, so
-# everything is fine if the repo has the staged artifacts.
-# However, for builds without repos (like building containers),
-# we override it with what we want, i.e. the rax mirror
-openstack_repo_url: "{{ mirror_base_url }}"
+# Security hardening has no effect on the containers
+# we're building (it only touches hosts), so we may
+# as well disable the playbook execution to speed up
+# the build time a bit.
+apply_security_hardening: False
 
-# TODO(evrardjp): remove re-wire this variable with
-# rpc_release per appropriate branch/tag (read other files).
-pip_artifacts_version: "master"
+# We are not going to setup a repo server and stage the apt/python
+# artifacts into it, so we ensure that an online install is set.
+rpco_online_install: yes
 
-# TODO(evrardjp) remove this when openstack_release is wired with rpc_release
-# For the building of containers, we currently don't have
-# the proper pip_links, pip upstream url and upper constraints
-# because they rely on openstack_release which isn't wired (yet)
-# The following do the wiring:
-openstack_repo_full_url: "{{ openstack_repo_url }}/os-releases/{{ pip_artifacts_version }}"
-pip_links:
-  - name: "openstack_release"
-    link: "{{ openstack_repo_full_url }}/"
-pip_upstream_url: "{{ openstack_repo_full_url }}/get-pip.py"
-pip_install_upper_constraints: "{{ openstack_repo_full_url }}/requirements_absolute_requirements.txt"
-
-## CONTAINER
-# TODO(evrardjp) remove this wiring when container and pip_artifacts_version will be consistent
-# (other todos addressed)
-container_artifact_version: "{{ pip_artifacts_version }}"
-
-## APT 
-# TODO(evrardjp): replace apt_artifacts_version with rpc_release when repos are merged together
-apt_artifacts_version: "rpc-14.0.0rc1" #Move to reading variable
-mirror_apt_deb_line: "deb {{ mirror_apt_url }} {{ apt_artifacts_version }}-{{ ansible_distribution_release }} main"
-mirror_apt_url: "{{ mirror_base_url }}/apt-mirror/integrated/"
-mirror_apt_rpc_filename: rax
-gpg_key_location: "{{ mirror_base_url }}/apt-mirror/"
-gpg_key_name: "rcbops-release-signing-key.asc"
-gpg_key_id: 22A9BF80 #SET IN STATIC (to force key verification per release).
-
-# For convenience
-rax_repo:
-  repo: "{{ mirror_apt_deb_line }}"
-  state: "present"
-  filename: "{{ mirror_apt_rpc_filename }}"
-rax_gpg_keys:
-  - hash_id:  "{{ gpg_key_id }}"
-    url: "{{ gpg_key_location }}{{ gpg_key_name }}"
-    state: "present"
-
-# HAProxy
-haproxy_repo: "{{ rax_repo }}"
-haproxy_gpg_keys: "{{ rax_gpg_keys }}"
-
-# RabbitMQ
-rabbitmq_install_method: "external_repo"
-rabbitmq_repo: "{{ rax_repo }}"
-rabbitmq_gpg_keys: "{{ rax_gpg_keys }}"
-
-# ceph_client wiring
-ceph_apt_repos:
-  uca: "{{ rax_repo }}"
-ceph_pkg_source: "uca"
-
-# galera_client role wiring
-galera_client_repo: "{{ mirror_apt_deb_line }}"
-mariadb_repo_filename: "{{ mirror_apt_rpc_filename }}"
-galera_client_gpg_keys: "{{ rax_gpg_keys }}"
-
-# galera_server wiring
-use_percona_upstream: True
-galera_repo: "{{ rax_repo }}"
-galera_percona_xtrabackup_repo: "{{ rax_repo }}"
-
-# neutron, nova wiring
-uca_repo: "{{ mirror_apt_deb_line }}"
-uca_apt_source_list_filename: "{{ mirror_apt_rpc_filename }}"
-
-# Elasticsearch
-elasticsearch_apt_repos:
-  - "{{ rax_repo }}"
-elasticsearch_apt_keys: "{{ rax_gpg_keys }}"
-
-# Filebeat
-filebeat_apt_repos:
-  - "{{ rax_repo }}"
-filebeat_apt_gpg_keys: "{{ rax_gpg_keys }}"
-
-# Kibana
-kibana_apt_repos:
-  - "{{ rax_repo }}"
-kibana_apt_keys: "{{ rax_gpg_keys }}"
-
-# Logstash
-logstash_apt_repos:
-  - "{{ rax_repo }}"
-logstash_apt_keys: "{{ rax_gpg_keys }}"
-
-# MAAS
-maas_apt_repos:
-  - "{{ rax_repo }}"
-maas_apt_keys: "{{ rax_gpg_keys }}"
-
-# RPC Support
-hwraid_apt_repos:
-  - repo: "deb http://rpc-repo.rackspace.com/apt-mirror/independant/hwraid-{{ ansible_distribution_release }}/ {{ apt_artifacts_version }}-{{ ansible_distribution_release }} main"
-    state: "present"
-hwraid_apt_keys: "{{ rax_gpg_keys }}"
+# In a normal deployment, openstack_repo_url is the address
+# of the repo server. When we build artifacts we don't build
+# a repo container so we override the default group_var to
+# ensure that we re-use the python artifacts in rpc-repo.
+openstack_repo_url: "{{ rpco_mirror_base_url }}"


### PR DESCRIPTION
This commit sets RPC-O to use the apt artifacts on rpc-repo
by default. The version is tied to rpc_release to ensure
that as each tag is released, newer artifacts are used.

Included in this commit is a clean-up of the artifacts
building variables to only include what it needs to complete
the container build process.

The original var names used in the artifact building process
have been adjusted in the implementation for RPC-O defaults
in order to reduce the possibility of namespace clashing.