### PR TITLE
Prevent race condition with LB

### DIFF
--- a/scripts/artifacts-building/containers/artifact-upload.yml
+++ b/scripts/artifacts-building/containers/artifact-upload.yml
@@ -22,10 +22,15 @@
     artifact_list: "{{ repo_server_url }}/meta/1.0/index-system"
     repo_server_url: "http://rpc-repo.rackspace.com"
   tasks:
+    - name: Check if the list exist to avoid re-hitting the server
+      stat:
+        path: /tmp/list
+      register: metadata_file_locally_exists
     - name: get the container artifacts list
       get_url:
         url: "{{ artifact_list }}"
         dest: "/tmp/list"
+      when: not metadata_file_locally_exists.stat.exists
     - name: patch the current list with the new artifact
       lineinfile:
         dest: "/tmp/list"

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -83,6 +83,9 @@ cd /opt/rpc-openstack/scripts/artifacts-building/
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_keystone -v" "install" "config"
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_cinder -v" "install" "config"
 
+# Ensure no remnants (not necessary if ephemeral host, but useful for dev purposes
+rm -f /tmp/list
+
 if [ -z ${REPO_KEY+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_USER+x} ]; then
     echo "Skipping upload to rpc-repo as the REPO_* env vars are not set."
     exit 1


### PR DESCRIPTION
We download from LB, patch the file, then upload it.
Then for the next image, we do the same.
If the upload didn't got the chance to be rsynced across all nodes
with lsyncd, there is a chance that the file we will get will not
have all the latest changes.