### PR TITLE
MaaS: Add Service Checks for Swift Processes

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -366,10 +366,31 @@ elasticsearch_process_names:
 filebeat_process_names:
   - filebeat
 
+swift_object_process_names:
+  - swift-object-server
+  - swift-object-replicator
+  - swift-object-updater
+  - swift-object-auditor
+
+swift_account_process_names:
+  - swift-account-server
+  - swift-account-replicator
+  - swift-account-reaper
+  - swift-account-auditor
+
+swift_container_process_names:
+  - swift-container-server
+  - swift-container-replicator
+  - swift-container-updater
+  - swift-container-auditor
+
 process_checks_list:
   - { name: "rsyslogd_process_check", group: "rsyslog_all" }
   - { name: "elasticsearch_process_check", group: "elasticsearch_all" }
   - { name: "filebeat_process_check", group: "all" }
+  - { name: "swift_object_process_check", group: "swift_obj" }
+  - { name: "swift_account_process_check", group: "swift_acc" }
+  - { name: "swift_container_process_check", group: "swift_cont" }
 
 ceph_checks_list:
   - { name: "ceph_osd_stats", group: "osds" }

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_account_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_account_process_check.yaml.j2
@@ -1,0 +1,22 @@
+{% set label = "swift_account_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}process_check.py", {% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ swift_account_process_names|join("\", \"") }}"]
+alarms      :
+{% for process in swift_account_process_names %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ ansible_hostname }}");
+            }
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_container_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_container_process_check.yaml.j2
@@ -1,0 +1,22 @@
+{% set label = "swift_container_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}process_check.py", {% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ swift_container_process_names|join("\", \"") }}"]
+alarms      :
+{% for process in swift_container_process_names %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ ansible_hostname }}");
+            }
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_object_process_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_object_process_check.yaml.j2
@@ -1,0 +1,22 @@
+{% set label = "swift_object_process_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}process_check.py", {% if inventory_hostname in groups['all_containers'] %} "-c", "{{ inventory_hostname }}", {% else %}{% endif %}"{{ swift_object_process_names|join("\", \"") }}"]
+alarms      :
+{% for process in swift_object_process_names %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ ansible_hostname }}");
+            }
+{% endfor %}


### PR DESCRIPTION
Adds service checks for Swift processes.  Will add swift-object-expirer (mitaka+) as a separate commit as it will not need to be backported to kilo and liberty.

Connects rcbops/u-suk-dev#1215

Depends on https://github.com/rcbops/rpc-openstack/pull/1869 being merged.