### PR TITLE
Fix rpco_mirror_base_url to prevent var loop

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -177,9 +177,7 @@ neutron_legacy_ha_tool_enabled: true
 #
 # Set variables used for enabling/disabling the use of staged apt/container artifacts
 #
-# TODO(odyssey4me) When the staging implementation is complete, switch this to 'no'
-rpco_online_install: yes
-rpco_mirror_base_url: "{{ (rpco_online_install | bool) | ternary('http://rpc-repo.rackspace.com', openstack_repo_url) }}"
+rpco_mirror_base_url: "http://rpc-repo.rackspace.com"
 
 #
 # Set RPC deployments to make use of the apt artifacts repository

--- a/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+++ b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
@@ -19,10 +19,6 @@
 # the build time a bit.
 apply_security_hardening: False
 
-# We are not going to setup a repo server and stage the apt/python
-# artifacts into it, so we ensure that an online install is set.
-rpco_online_install: yes
-
 # In a normal deployment, openstack_repo_url is the address
 # of the repo server. When we build artifacts we don't build
 # a repo container so we override the default group_var to


### PR DESCRIPTION
Previously I attempted to make rpco_mirror_base_url set based on
an online/offline situation. This caused a loop in the vars when
doing the container artifact building.

For now we do everything online. We can revisit the offline model
at a later stage.