### PR TITLE
Create default flavor list

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/create_default_flavors.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/create_default_flavors.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install shade and its dependencies
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version }}"
+    extra_args: "--isolated"
+  with_items:
+    - { name: "shade", version: "1.16.0"}
+
+- name: Add default flavors
+  os_nova_flavor:
+    name: "{{ item.name }}"
+    vcpus: "{{ item.vcpus }}"
+    state: present
+    disk: "{{ item.disk }}"
+    ram: "{{ item.ram }}"
+    auth:
+      auth_url: "{{ keystone_service_internalurl }}"
+      username: "admin"
+      password: "{{ keystone_auth_admin_password }}"
+      project_name: "admin"
+      domain_name: "Default"
+    validate_certs: false
+  with_items:
+    - { name: 'm1.tiny', vcpus: '1', disk: '1', ram: '512' }
+    - { name: 'm1.small', vcpus: '1', disk: 20, ram: '2048' }
+    - { name: 'm1.medium', vcpus: '2', disk: '40', ram: '4096' }
+    - { name: 'm1.large', vcpus: '4', disk: '80', ram: '8192' }
+    - { name: 'm1.xlarge', vcpus: '8', disk: '160', ram: '16384' }
+

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -98,3 +98,6 @@
 - include: autocompletion.yml
 
 - include: configure_unattended_upgrades.yml
+
+- include: create_default_flavors.yml
+  when:  inventory_hostname == groups['utility'][0]


### PR DESCRIPTION
Newton no longer creates the default flavors. This change adds a
playbook to rpc_support to create the following:
m1.tiny
m1.small
m1.medium
m1.large
m1.xlarge

Connects rcbops/u-suk-dev#1183