### PR TITLE
Cleanup artifact upload

### DIFF
--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -179,7 +179,7 @@
         dest: "/tmp/list"
         regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }}"
         line: "{{ lookup('file', built_container_artifact_metadata_file ) }}"
-    - name: Remove the metada file
+    - name: Remove the metadata file
       file:
         path: "{{ built_container_artifact_metadata_file }}"
         state: absent

--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -156,3 +156,32 @@
         state: absent
   tags:
     - always
+
+- name: container artifacts metadata prep
+  hosts: localhost
+  connection: local
+  vars_files:
+    - container-vars.yml
+  vars:
+    artifact_list: "{{ rpco_mirror_base_url }}/meta/1.0/index-system"
+  tasks:
+    - name: Check if the list exist to avoid re-hitting the server
+      stat:
+        path: /tmp/list
+      register: metadata_file_locally_exists
+    - name: get the container artifacts list
+      get_url:
+        url: "{{ artifact_list }}"
+        dest: "/tmp/list"
+      when: not metadata_file_locally_exists.stat.exists
+    - name: patch the current list with the new artifact
+      lineinfile:
+        dest: "/tmp/list"
+        regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }}"
+        line: "{{ lookup('file', built_container_artifact_metadata_file ) }}"
+    - name: Remove the metada file
+      file:
+        path: "{{ built_container_artifact_metadata_file }}"
+        state: absent
+  tags:
+    - always

--- a/scripts/artifacts-building/containers/artifact-upload.yml
+++ b/scripts/artifacts-building/containers/artifact-upload.yml
@@ -13,34 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: container artifacts metadata prep
-  hosts: localhost
-  connection: local
-  vars_files:
-    - container-vars.yml
-  vars:
-    artifact_list: "{{ repo_server_url }}/meta/1.0/index-system"
-    repo_server_url: "http://rpc-repo.rackspace.com"
-  tasks:
-    - name: Check if the list exist to avoid re-hitting the server
-      stat:
-        path: /tmp/list
-      register: metadata_file_locally_exists
-    - name: get the container artifacts list
-      get_url:
-        url: "{{ artifact_list }}"
-        dest: "/tmp/list"
-      when: not metadata_file_locally_exists.stat.exists
-    - name: patch the current list with the new artifact
-      lineinfile:
-        dest: "/tmp/list"
-        regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }}"
-        line: "{{ lookup('file', built_container_artifact_metadata_file ) }}"
-    - name: Remove the metada file
-      file:
-        path: "{{ built_container_artifact_metadata_file }}"
-        state: absent
-
 - name: Push the changes
   hosts: mirrors
   vars_files:

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -112,7 +112,5 @@ else
     export ANSIBLE_HOST_KEY_CHECKING=False
 
     # Ship it!
-    openstack-ansible containers/artifact-upload.yml -e role_name=os_keystone -i /opt/inventory -v
-    openstack-ansible containers/artifact-upload.yml -e role_name=os_cinder -i /opt/inventory -v
-    openstack-ansible containers/artifact-upload.yml -e role_name=rabbitmq_server -i /opt/inventory -v
+    openstack-ansible containers/artifact-upload.yml -i /opt/inventory -v
 fi


### PR DESCRIPTION
From now on, the metadata will be generated during the container
preparation, and the upload will upload all the containers and
metadata at the end of the build process.