### PR TITLE
Re-add ceph variables in cinder_backends

### DIFF
--- a/rpcd/etc/openstack_deploy/conf.d/ceph.yml.aio
+++ b/rpcd/etc/openstack_deploy/conf.d/ceph.yml.aio
@@ -8,20 +8,3 @@ osds_hosts:
     ip: 172.29.236.100
     affinity:
       ceph_osd_container: 3
-
-storage_hosts:
-  aio1:
-    ip: 172.29.236.100
-    container_vars:
-      cinder_backends:
-        limit_container_types: cinder_volume
-        ceph:
-          volume_driver: cinder.volume.drivers.rbd.RBDDriver
-          rbd_pool: volumes
-          rbd_ceph_conf: /etc/ceph/ceph.conf
-          rbd_flatten_volume_from_snapshot: 'false'
-          rbd_max_clone_depth: 5
-          rbd_store_chunk_size: 4
-          rados_connect_timeout: -1
-          glance_api_version: 2
-          volume_backend_name: ceph

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -72,6 +72,33 @@
   hosts: localhost
   user: root
   tasks:
+    # We need to write out the cinder_backend block here, so we avoid
+    # running this block through the config_template module when the
+    # upstream bootstrap role puts the conf.d files into place.
+    - name: Write out storage hosts and cinder backends to conf.d/ceph.yml
+      lineinfile:
+        name: "/etc/openstack_deploy/conf.d/ceph.yml"
+        line: |
+          storage_hosts:
+            aio1:
+              ip: 172.29.236.100
+              container_vars:
+                cinder_backends:
+                  limit_container_types: cinder_volume
+                  ceph:
+                    volume_driver: cinder.volume.drivers.rbd.RBDDriver
+                    rbd_pool: volumes
+                    rbd_ceph_conf: /etc/ceph/ceph.conf
+                    rbd_flatten_volume_from_snapshot: 'false'
+                    rbd_max_clone_depth: 5
+                    rbd_store_chunk_size: 4
+                    rados_connect_timeout: -1
+                    glance_api_version: 2
+                    volume_backend_name: ceph
+                    rbd_user: "{%raw%}{{ cinder_ceph_client }}{%endraw%}"
+                    rbd_secret_uuid: "{%raw%}{{ cinder_ceph_client_uuid }}{%endraw%}"
+      when: "{{ rpco_deploy_ceph | bool }}"
+
     - name: Ensure that the env.d directory is present
       file:
         path: "/etc/openstack_deploy/env.d"


### PR DESCRIPTION
These variables were incorrectly removed as part of
https://github.com/rcbops/rpc-openstack/commit/e80a7a5b9014b07299622fe5b102f748f6efea0b
This commit re-adds the rdb_* variables using the lineinfile ansible module.
This is because the bootstrap role runs this
file through config_template, which attempts to resolve the ceph
variables. However, since the variables are not avaialbe when the
bootstrap role is invoked, it will fail. Adding these variables
via lineinfile makes it possible to write out raw jinja, whereas
using config_template makes this impossible.

Connects https://github.com/rcbops/u-suk-dev/issues/1188

(cherry picked from commit 7f045b29e5b674e7299399a305649ab9f7e96680)