### PR TITLE
[WIP] Port f5-config.py to an Ansible role

### DIFF
--- a/rpcd/playbooks/roles/rpc_f5/LICENSE
+++ b/rpcd/playbooks/roles/rpc_f5/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rpcd/playbooks/roles/rpc_f5/README.rst
+++ b/rpcd/playbooks/roles/rpc_f5/README.rst
@@ -1,0 +1,50 @@
+Ansible rpc_f5 role
+###################
+
+Role for generating bigip F5 commands for an RPC reference architecture
+
+Example playbook:
+.. code-block:: yaml
+
+  - name: Generate F5 configuration
+    hosts: localhost
+    user: root
+    roles:
+      - { role: "rpc_f5" }
+
+Services and options
+~~~~~~~~~~~~~~~~~~~~
+
+The services that will have respective F5 configurations are listed in defaults/main.yml.
+
+This list can be overridden, but keep in mind that it must be overridden as a whole, so services cannot be
+overridden individually.
+
+Take the following snippit from the ``services`` list as an example:
+
+.. code-block:: yaml
+
+    - name: "nova_spice"
+      proto: 'http'
+      port: "{{ nova_spice_html5proxy_base_port }}"
+      backend_port: "{{ nova_spice_html5proxy_base_port }}"
+      make_public: true
+      ssl_impossible: true
+      persist: true
+      group: "nova_console"
+      mon_options:
+        - "defaults-from http"
+        - "destination '*:{{ nova_spice_html5proxy_base_port }}'"
+        - "recv '200 OK'"
+        - "send 'HEAD /spice_auto.html HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+      condition: "{{ nova_console_type == 'spice' and groups['nova_console'] | length > 0 | bool }}"
+
+* name - The name of the service. This value will be used to build out virtual server names and monitors if applicable
+* proto - The protocol to on the monitor for that service (if applicable)
+* port - The frontend port of the service
+* backend_port - The backend port of the service
+* make_public - If make_public is true, then this role will create a virtual server for this service using the external_lb_vip_address
+* ssl_impossible - Only used when make_public is true. If ssl_impossible is true, then the virtual server for this service will not be configured with an SSL profile
+* persist - If persist is true, then the virtual server for this service will be configured with connection persistance
+* mon_options - If it's required to create a custom monitor for this service, then options for that monitor can be specified here. Otherwise the service will use a generic external monitor
+* condition - The F5 networking configurations for this service will only be printed if this condition is true

--- a/rpcd/playbooks/roles/rpc_f5/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_f5/defaults/main.yml
@@ -1,0 +1,307 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Some basic information
+partition_name: "RPC"
+prefix_name: "RPC"
+is_lem: "{{ lookup('env', 'LAB_DATA_DIR') | bool | ternary('true', 'false') }}"
+ssl_domain_name: "{{ is_lem | bool | ternary(lookup('env', 'LAB_NAME') ~ '.rpc.rackspace.com', 'None') }}"
+f5_destination_output_file: "/root/f5-setup.sh"
+
+superman: |
+          '       **************************       '
+          '    .*##*:*####***:::**###*:######*.    '
+          '   *##: .###*            *######:,##*   '
+          ' *##:  :####:             *####*.  :##: '
+          '  *##,:########**********:,       :##:  '
+          '   .#########################*,  *#*    '
+          '     *#########################*##:     '
+          '       *##,        ..,,::**#####:       '
+          '        ,##*,*****,        *##*         '
+          '          *#########*########:          '
+          '            *##*:*******###*            '
+          '             .##*.    ,##*              '
+          '               :##*  *##,               '
+          '                 *####:                 '
+          '                   :,                   '
+
+# Getting snat pool address. The default will be the first .15 address of container_cidr
+_container_cidr: "{{ container_cidr.split('/')[0] }}"
+snat_pool_addresses: 
+  - "{{ _container_cidr.split('.')[0] }}.{{ _container_cidr.split('.')[1] }}.{{ _container_cidr.split('.')[2] }}.15"
+
+# A list of services to be load balanced
+services:
+  - name: "galera"
+    # The protocol to user for this services f5 monitor(if appllicable)
+    proto: 'mysql'
+    # The front end port for this service
+    port: "3306"
+    # The backend port that is listening on the server
+    backend_port: "3306"
+    # If priority is true, then the service's virtual server will prioritize
+    # the nodes in it's respective group such that it will always prefer the
+    # first node.
+    priority: true
+    # The Ansible inventory group this service belongs to
+    group: "galera"
+    # If a custom monitor is needed for the service, then mon_options
+    # can be specified with any number of options. Otherwise the service
+    # will use a generic external monitor
+    mon_options:
+      - "count 1"
+      - "database information_schema"
+      - "debug no"
+      - "defaults-from 'mysql'"
+      - "destination '*'"
+      - "interval 3"
+      - "recv big5_chinese_ci"
+      - "recv-column 2"
+      - "recv-row 0"
+      - "send 'select * from CHARACTER_SETS;'"
+      - "time-util-up 0"
+      - "timeout 10"
+      - "username 'monitoring'"
+    # A condition that must be met for f5 configurations to run for this service
+    condition: "{{ groups['galera'] | length > 0 }}" 
+
+  - name: "glance_api"
+    proto: "http"
+    port: "{{ glance_service_port }}"
+    backend_port: "{{ glance_service_port }}"
+    # If make_public is true, then a virtual server will be created for this
+    # service using the external vip address. This will make the service
+    # publically available via the outside interface of the LB
+    make_public: true
+    group: "glance_api"
+    condition: "{{ groups['glance_api'] | length > 0 }}"
+
+  - name: "glance_registry"
+    proto: "http"
+    port: "{{ glance_registry_service_port }}"
+    backend_port: "{{ glance_registry_service_port }}"
+    group: "glance_registry"
+    condition: "{{ groups['glance_registry'] | length > 0 }}"
+
+  - name: "keystone_admin"
+    proto: 'http'
+    port: "{{ keystone_admin_port }}"
+    backend_port: "{{ keystone_admin_port }}"
+    group: "keystone"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:{{ keystone_admin_port }}'"
+      - "recv '200 OK'"
+      - "send 'HEAD /v3 HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ groups['keystone'] | length > 0 }}"
+
+  - name: "keystone_service"
+    proto: "http"
+    port: "{{ keystone_service_port }}"
+    backend_port: "{{ keystone_service_port }}"
+    make_public: true
+    group: "keystone"
+    condition: "{{ groups['keystone'] | length > 0 }}"
+
+  - name: "neutron_server"
+    proto: "http"
+    port: "{{ neutron_service_port }}"
+    backend_port: "{{ neutron_service_port }}"
+    make_public: true
+    group: "neutron_server"
+    condition: "{{ groups['neutron_server'] | length > 0 }}"
+
+  - name: "nova_api_metadata"
+    proto: 'http'
+    port: "{{ nova_metadata_port }}"
+    backend_port: "{{ nova_metadata_port }}"
+    group: "nova_api_metadata"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:{{ nova_metadata_port }}'"
+      - "recv '200 OK'"
+      - "send 'HEAD / HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ groups['nova_api_metadata'] | length > 0 }}"
+
+  - name: "nova_api_os_compute"
+    proto: "http"
+    port: "{{ nova_service_port }}"
+    backend_port: "{{ nova_service_port }}"
+    make_public: true
+    group: "nova_api_os_compute"
+    condition: "{{ groups['nova_api_os_compute'] | length > 0 }}"
+
+  - name: "nova_spice"
+    proto: 'http'
+    port: "{{ nova_spice_html5proxy_base_port }}"
+    backend_port: "{{ nova_spice_html5proxy_base_port }}"
+    make_public: true
+    # If ssl_impossible is true, then the service's public virtual servers(if any)
+    # will not be associated with an SSL profile
+    ssl_impossible: true
+    # If persist is true, then the service's virtual servers will be configured
+    # with connection persistance
+    persist: true
+    group: "nova_console"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:{{ nova_spice_html5proxy_base_port }}'"
+      - "recv '200 OK'"
+      - "send 'HEAD /spice_auto.html HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ nova_console_type == 'spice' and groups['nova_console'] | length > 0 | bool }}"
+
+  - name: "nova_novnc"
+    proto: "http"
+    port: "{{ nova_novncproxy_port }}"
+    backend_port: "{{ nova_novncproxy_port }}"
+    make_public: true
+    ssl_impossible: true
+    persist: true
+    group: "nova_console"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:{{ nova_novncproxy_port}}'"
+      - "recv '200 OK'"
+      - "send 'HEAD /novnc_auto.html HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ nova_console_type == 'novnc' and groups['nova_console'] | length > 0 | bool }}"
+
+  - name: "cinder_api"
+    proto: "http"
+    port: "{{ cinder_service_port }}"
+    backend_port: "{{ cinder_service_port }}"
+    make_public: true
+    group: "cinder_api"
+    condition: "{{ groups['cinder_api'] | length > 0 }}"
+
+  - name: "horizon"
+    proto: 'http'
+    port: "80"
+    backend_port: "80"
+    group: "horizon"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:80'"
+      - "recv '302 Found'"
+      - "send 'HEAD / HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ groups['horizon'] | length > 0 }}"
+
+  - name: "horizon_ssl"
+    proto: "https"
+    port: "443"
+    backend_port: "80"
+    make_public: true
+    persist: true
+    group: "horizon"
+    mon_options:
+      - "defaults-from https"
+      - "destination '*:443'"
+      - "recv '302 FOUND'"
+      - "send 'HEAD / HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ groups['horizon'] | length > 0 }}"
+
+  - name: "heat_api_cfn"
+    proto: "tcp"
+    port: "{{ heat_cfn_service_port }}"
+    backend_port: "{{ heat_cfn_service_port }}"
+    make_public: true
+    group: "heat_api_cfn"
+    mon_options:
+      - "defaults-from tcp"
+      - "destination '*:{{ heat_cfn_service_port }}'"
+    condition: "{{ groups['heat_api_cfn'] | length > 0 }}"
+
+  - name: "heat_api_cloudwatch"
+    proto: "tcp"
+    port: "{{ heat_watch_port }}"
+    backend_port: "{{ heat_watch_port }}"
+    make_public: true
+    group: "heat_api_cloudwatch"
+    mon_options:
+      - "defaults-from tcp"
+      - "destination '*:{{ heat_watch_port }}'"
+    condition: "{{ groups['heat_api_cloudwatch'] | length > 0 }}"
+
+  - name: "heat_api"
+    proto: "http"
+    port: "{{ heat_service_port }}"
+    backend_port: "{{ heat_service_port }}"
+    make_public: true
+    group: "heat_api"
+    condition: "{{ groups['heat_api'] | length > 0 }}"
+
+  - name: "kibana_ssl"
+    proto: "tcp"
+    port: "{{ kibana_ssl_port }}"
+    backend_port: "{{ kibana_ssl_port }}"
+    make_public: true
+    backend_ssl: true
+    persist: true
+    group: "kibana"
+    mon_options:
+      - "defaults-from tcp"
+      - "destination '*:{{ kibana_ssl_port }}'"
+    condition: "{{ groups['kibana'] | length > 0 }}"
+
+  - name: "elasticsearch"
+    proto: "tcp"
+    port: "{{ elasticsearch_http_port }}"
+    backend_port: "{{ elasticsearch_http_port }}"
+    group: "elasticsearch"
+    mon_options:
+      - "defaults-from tcp"
+      - "destination '*:{{ elasticsearch_http_port }}'"
+    condition: "{{ groups['elasticsearch'] | length > 0 }}"
+
+  - name: "swift"
+    proto: "http"
+    port: "{{ swift_proxy_port }}"
+    backend_port: "{{ swift_proxy_port }}"
+    make_public: true
+    group: "swift_proxy"
+    condition: "{{ groups['swift_proxy'] | length > 0 }}"
+
+  - name: "repo"
+    proto: "http"
+    port: "{{ repo_server_port }}"
+    backend_port: "{{ repo_server_port }}"
+    group: "repo_all"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:{{ repo_server_port }}'"
+      - "recv '200 OK'"
+      - "send 'HEAD / HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ groups['repo_all'] | length > 0 }}"
+
+  - name: "repo_cache"
+    proto: "http"
+    port: "{{ repo_pkg_cache_port }}"
+    backend_port: "{{ repo_pkg_cache_port }}"
+    group: "repo_all"
+    mon_options:
+      - "defaults-from http"
+      - "destination '*:{{ repo_pkg_cache_port }}'"
+      - "recv '200 OK'"
+      - "send 'HEAD /acng-report.html HTTP/1.1\\r\\nHost: rpc\\r\\n\\r\\n'"
+    condition: "{{ groups['repo_all'] | length > 0 }}"
+
+  - name: "repo_git"
+    proto: "tcp"
+    port: "9418"
+    backend_port: "9418"
+    group: "repo_all"
+    mon_options:
+      - "defaults-from tcp"
+      - "destination '*:9418'"
+    condition: "{{ groups['repo_all'] | length > 0 }}"

--- a/rpcd/playbooks/roles/rpc_f5/meta/main.yml
+++ b/rpcd/playbooks/roles/rpc_f5/meta/main.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: rcbops
+  description: Generate BigIP F5 configurations for RPCO reference architecture
+  company: Rackspace
+  license: Apache2
+  min_ansible_version: 2.1.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+  categories:
+    - rackspace
+    - f5

--- a/rpcd/playbooks/roles/rpc_f5/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_f5/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+#- name: Set the snat pool address(es)
+#  set_fact:
+#    snat_pool_address: "{{ container_cidr.split('/')[0].split(".")[1]}}."
+#  when: snat_pool_address is not defined
+
+- name: Superman
+  debug:
+    msg: "{{ superman.split('\n') }}"
+
+- name: Write out f5 file
+  template:
+    src: f5_setup.sh.j2
+    dest: "{{ f5_destination_output_file }}"

--- a/rpcd/playbooks/roles/rpc_f5/templates/f5_setup.sh.j2
+++ b/rpcd/playbooks/roles/rpc_f5/templates/f5_setup.sh.j2
@@ -1,0 +1,115 @@
+#!/usr/bin/bash
+
+### CREATE RPC PARTITION ###
+create auth partition {{ partition_name }}
+
+### SET DISPLAY PORT NUMBERS ###
+modify cli global-settings service number
+
+### CREATE SNATPOOL ###
+create ltm snatpool /{{ partition_name }}/RPC_SNATPOOL { members replace-all-with { {{ ' '.join(snat_pool_addresses) }} } }
+
+### CREATE MONITORS ###
+{% for monitor in services %}
+{% if monitor.mon_options is defined and monitor.condition %}
+create ltm monitor {{ monitor.proto }} /{{ partition_name }}/RPC_MON_{{ monitor.proto.upper() }}_{{ monitor.name.upper() }} { {{ ' '.join(monitor.mon_options) }} }
+{% endif %}
+{% endfor %}
+
+### CREATE SECURITY iRULE ###
+run util bash
+tmsh create ltm rule /{{ partition_name }}/RPC_DISCARD_ALL when CLIENT_ACCEPTED { discard }
+exit
+### CREATE EXTERNAL MONITOR ###
+   --> Upload External monitor file to disk <--
+       run util bash
+       cd /config/monitors/
+       vi RPC-MON-EXT-ENDPOINT.monitor
+   --> Copy and Paste the External monitor into vi <--
+       create sys file external-monitor /{{ partition_name }}/RPC-MON-EXT-ENDPOINT { source-path file:///config/monitors/RPC-MON-EXT-ENDPOINT.monitor }
+       save sys config
+       create ltm monitor external /{{ partition_name }}/RPC-MON-EXT-ENDPOINT { interval 20 timeout 61 run /{{ partition_name }}/RPC-MON-EXT-ENDPOINT }
+
+### CREATE PERSISTENCE PROFILES ###
+create ltm persistence source-addr /{{ partition_name }}/RPC_PROF_PERSIST_IP { app-service none defaults-from /Common/source_addr match-across-services enabled timeout 3600 }
+create ltm persistence cookie /{{ partition_name }}/RPC_PROF_PERSIST_COOKIE { app-service none cookie-name RPC-COOKIE defaults-from /Common/cookie }
+
+### CREATE NODES ###
+{% for host in groups['all_containers'] %}
+{{ 'create ltm node /' ~ partition_name ~ '/RPC_NODE_' ~ host -}}
+{{ ' { address' ~ hostvars[host]['container_address'] ~ ' }' }}
+{% endfor %}
+
+### CREATE POOLS ###
+{% for service in services %}
+{% if service.condition %}
+{% set priority = 100 %}
+{{ 'create ltm pool /' ~ partition_name ~ '/RPC_POOL_' ~ service.name.upper() -}}
+{{ ' { load-balancing-mode fastest-node members replace-all-with' -}}
+{{ ' {' -}}
+{% for host in groups[service.group] -%}
+{{- ' RPC_NODE_' ~ host ~ ':' ~ service.backend_port -}}
+{%- if service.priority is defined and service.priority -%} 
+{{ ' { priority-group ' ~ priority ~ ' }' -}}
+{%- endif -%}
+{%- set priority = priority-5 -%}
+{%- endfor -%}
+{{ ' }' -}}
+{%- if service.priority is defined and service.priority -%}
+{{ ' min-active-members 1' -}}
+{%- endif -%}
+{{ ' monitor ' ~ service.mon_options is defined | bool | ternary('/' ~ partition_name ~ '/RPC_MON_' ~ service.proto.upper() ~ '_' ~ service.name.upper(), '/' ~ partition_name ~ '/RPC-MON-EXT-ENDPOINT') ~ ' }' }}
+{% endif %}
+{% endfor %}
+
+### CREATE VIRTUAL SERVERS ###
+{% for service in services %}
+{% if service.condition %}
+{{ 'create ltm virtual /' ~ partition_name ~ '/RPC_VS_' ~ service.name.upper() -}}
+{{ ' { destination ' ~ internal_lb_vip_address ~ ':' ~ service.port ~ ' ip-protocol tcp mask 255.255.255.255' -}}
+{{ ' pool /' ~ partition_name ~ '/RPC_POOL_' ~ service.name.upper() ~ ' profiles replace-all-with' -}}
+{{ ' { /Common/fastL4 { } }' -}}
+{% if service.persist is defined and service.persist %}
+{{ ' persist replace-all-with { /' ~ partition_name ~ '/RPC_PROF_PERSIST_IP }' -}}
+{%- endif -%}
+{{ ' source 0.0.0.0/0 source-address-translation' -}}
+{{ ' { pool /' ~ partition_name ~ '/RPC_SNAT_POOL type snat } }' }}
+{% endif %}
+{% endfor %}
+
+### CREATE PUBLIC SSL OFFLOADED VIRTUAL SERVERS ###
+{% for service in services %}
+{% if service.condition and (service.ssl_impossible is not defined or (not service.ssl_impossible)) and (service.make_public is defined and service.make_public) %}
+{{ 'create ltm virtual /' ~ partition_name  ~ '/RPC_PUB_SSL_VS_' ~ service.name.upper() -}}
+{{ ' { destination ' ~ external_lb_vip_address ~ ':' ~ service.port -}}
+{{ ' ip-protocol tcp pool /' ~ partition_name ~ '/RPC_POOL_' ~ service.name.upper() -}}
+{{ ' profiles replace-all-with { /Common/tcp { }' -}}
+{%- if service.backend_ssl is defined and service.backend_ssl -%}
+{{ ' /' ~ partition_name ~ '/RPC_PROF_SSL_SERVER { context serverside } /' ~ partition_name ~ '/RPC_PROF_SSL_' ~ ssl_domain_name ~ ' { context clientside } }' -}}
+{%- else -%}
+{{ ' /' ~ partition_name ~ '/RPC_PROF_SSL_' ~ ssl_domain_name ~ ' { context clientside } }' -}}
+{%- endif -%}
+{%- if service.persist is defined and service.persist -%}
+{{ ' persist replace-all-with { /' ~ partition_name ~ ' /RPC_PROF_PERSIST_IP }' -}}
+{%- endif -%}
+{{ ' source-address-translation { pool /' ~ partition_name ~ '/RPC_SNAT_POOL type snat } }' }}
+{% endif %}
+{% endfor %}
+
+### CREATE PUBLIC SSL PASS-THROUGH VIRTUAL SERVERS ###
+{% for service in services %}
+{% if service.condition and service.ssl_impossible is defined and service.ssl_impossible %}
+{{ 'create ltm virtual /' ~ partition_name ~ '/RPC_PUB_VS_' ~ service.name.upper() -}}
+{{ ' { destination ' ~ external_lb_vip_address ~ ':' ~ service.port -}}
+{{ ' ip-protocol tcp pool /' ~ partition_name ~ '/RPC_POOL_' ~ service.name.upper() -}}
+{{ ' profiles replace-all-with { /Common/fastL4 { } }' -}}
+{% if service.persist is defined and service.persist %}
+{{ ' persist replace-all-with { /' ~ partition_name ~ '/RPC_PROF_PERSIST_IP }' -}}
+{% endif %}
+{{ ' source-address-translation { pool /' ~ partition_name ~ '/RPC_SNATPOOL type snat } }' }}
+{% endif %}
+{% endfor %}
+
+save sys config
+
+run cm config-sync to-group SYNC-FAILOVER

--- a/rpcd/playbooks/rpc-f5.yml
+++ b/rpcd/playbooks/rpc-f5.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Setup hosts for rpc-support
+  hosts: localhost
+  user: root
+  roles:
+    - { role: "rpc_f5", tags: [ "rpc-support" ] }
+  vars_files:
+    - "/etc/ansible/roles/os_heat/defaults/main.yml"
+    - "/etc/ansible/roles/os_glance/defaults/main.yml"
+    - "/etc/ansible/roles/os_swift/defaults/main.yml"
+    - "/etc/ansible/roles/os_cinder/defaults/main.yml"
+    - "/opt/rpc-openstack/rpcd/playbooks/roles/kibana/defaults/main.yml"


### PR DESCRIPTION
This commit ports the f5-config.py script into an Ansible role.
This will make the ansible inventory and variables available for
building the F5 configurations necessary for our reference
architecture. As a result, the F5 configurations are now more dynamic,
only building out the pieces for the services deployed in an environment.

In addition, this commit adds a simpler method for adding any new
service into an RPCO F5 configuration. Services are now specified
in defaults/main.yml under the ``services`` list. This list can also
be overridden.

Options for each service have been documented in the roles README.

Connects https://github.com/rcbops/u-suk-dev/issues/836