### PR TITLE
Add apt artifact staging

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -189,6 +189,9 @@ rpco_gpg_key_location: "{{ rpco_mirror_base_url }}/apt-mirror/"
 rpco_gpg_key_name: "rcbops-release-signing-key.asc"
 rpco_gpg_key_id: 22A9BF80 #SET IN STATIC (to force key verification per release).
 
+# We won't be using the repo package cache, as we'll have a full mirror.
+repo_pkg_cache_enabled: no
+
 # For convenience
 rpco_apt_repo:
   repo: "{{ rpco_mirror_apt_deb_line }}"

--- a/rpcd/playbooks/stage-apt-artifacts-mirror.list.j2
+++ b/rpcd/playbooks/stage-apt-artifacts-mirror.list.j2
@@ -1,0 +1,32 @@
+
+############# {{ ansible_managed }} ##################
+#
+set base_path    /var/spool/apt-mirror
+set mirror_path  {{ staging_path }}/{{ artifact_repo_path }}
+set skel_path    $base_path/skel
+set var_path     $base_path/var
+set cleanscript $var_path/clean.sh
+set postmirror_script $var_path/postmirror.sh
+set run_postmirror 1
+set nthreads     20
+set _tilde 0
+#
+############# end config ##############
+
+#
+# Mirror section
+#
+
+{% for mirror in mirrors %}
+{%   for distribution in mirror['distributions'] %}
+deb {{ mirror['url'] }} {{ distribution['name'] }} {{ distribution['components'] | join(' ') }}
+{%   endfor %}
+{% endfor %}
+
+#
+# Cleaning section
+#
+
+{% for mirror in mirrors %}
+clean {{ mirror['url'] }}
+{% endfor %}

--- a/rpcd/playbooks/stage-apt-artifacts.yml
+++ b/rpcd/playbooks/stage-apt-artifacts.yml
@@ -1,0 +1,88 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Stage the apt artifacts
+  hosts: "{{ staging_host | default('localhost') }}"
+  user: root
+  vars:
+    rpco_mirror_base_url: "https://rpc-repo.rackspace.com"
+    https_validate_certs: yes
+    artifact_repo_path: "mirror-data"
+    keys:
+      - "{{ rpco_mirror_base_url }}/apt-mirror/rcbops-release-signing-key.asc"
+    mirrors:
+      - url: "{{ rpco_mirror_base_url }}/apt-mirror/integrated"
+        distributions:
+          - name: "{{ rpc_release }}-trusty"
+            components:
+              - "main"
+          - name: "{{ rpc_release }}-xenial"
+            components:
+              - "main"
+      - url: "{{ rpco_mirror_base_url }}/apt-mirror/independant/hwraid-trusty"
+        distributions:
+          - name: "{{ rpc_release }}-trusty"
+            components:
+              - "main"
+      - url: "{{ rpco_mirror_base_url }}/apt-mirror/independant/hwraid-xenial"
+        distributions:
+          - name: "{{ rpc_release }}-xenial"
+            components:
+              - "main"
+  tasks:
+
+    - name: Set the staging path
+      set_fact:
+        staging_path: |-
+          {%- if (groups['repo_all'] is defined) and (groups['repo_all'] | length > 0) -%}
+          /openstack/{{ hostvars[groups['repo_all'][0]]['inventory_hostname'] }}/repo
+          {%- else -%}
+          /openstack/stage
+          {%- endif -%}
+
+    - name: Staging folders setup
+      file:
+        path: "{{ staging_path }}/{{ artifact_repo_path }}"
+        state: "directory"
+      tags: always
+
+    - name: Install apt-mirror
+      package:
+        name: "apt-mirror"
+        state: present
+
+    - name: Write the mirror configuration
+      template:
+        src: "stage-apt-artifacts-mirror.list.j2"
+        dest: "/etc/apt/mirror.list"
+
+    - name: Execute apt-mirror
+      command: "apt-mirror"
+
+    - name: Execute clean script
+      command: "/var/spool/apt-mirror/var/clean.sh"
+
+    - name: Implement the shorter link
+      file:
+        src: "{{ artifact_repo_path }}/{{ rpco_mirror_base_url | netloc_no_port }}/apt-mirror"
+        dest: "{{ staging_path }}/apt-mirror"
+        state: link
+
+    - name: Download the keys
+      get_url:
+        url: "{{ item }}"
+        dest: "{{ staging_path }}/apt-mirror/{{ item | basename }}"
+        validate_certs: "{{ https_validate_certs | bool }}"
+      with_items: "{{ keys }}"

--- a/scripts/bootstrap-artifacts.sh
+++ b/scripts/bootstrap-artifacts.sh
@@ -30,6 +30,7 @@ check_submodule_status
 
 # begin the bootstrap process
 pushd ${OA_DIR}
-    openstack-ansible ${RPCD_DIR}/playbooks/stage-python-artifacts.yml
+    openstack-ansible ${RPCD_DIR}/playbooks/stage-apt-artifacts.yml
     openstack-ansible ${RPCD_DIR}/playbooks/stage-container-artifacts.yml
+    openstack-ansible ${RPCD_DIR}/playbooks/stage-python-artifacts.yml
 popd


### PR DESCRIPTION
This patch adds apt mirror staging as an option for
rpc-openstack.

Connects https://github.com/rcbops/u-suk-dev/issues/1234