### PR TITLE
MaaS: Add swift-object-expirer to Swift process checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -371,6 +371,7 @@ swift_object_process_names:
   - swift-object-replicator
   - swift-object-updater
   - swift-object-auditor
+  - swift-object-expirer
 
 swift_account_process_names:
   - swift-account-server


### PR DESCRIPTION
MaaS: Add swift-object-expirer to Swift process checks, needs backport to Mitaka and Newton only.

Connects rcbops/u-suk-dev#1253