### PR TITLE
MaaS: Restrict swift-recon checks to two proxies

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -423,16 +423,18 @@ cinder_backup_checks_list:
   - { name: "cinder_backup_check", group: "cinder_backup" }
 
 swift_checks_list:
-  - { name: "swift_object_server_check", group: "swift_obj" }
   - { name: "swift_account_server_check", group: "swift_acc" }
   - { name: "swift_container_server_check", group: "swift_cont" }
+  - { name: "swift_object_server_check", group: "swift_obj" }
+
+swift_recon_checks_list:
+  - { name: "swift_account_replication_check", group: "swift_proxy" }
+  - { name: "swift_async_check", group: "swift_proxy" }
+  - { name: "swift_container_replication_check", group: "swift_proxy" }
+  - { name: "swift_md5_check", group: "swift_proxy" }
+  - { name: "swift_object_replication_check", group: "swift_proxy" }
   - { name: "swift_proxy_server_check", group: "swift_proxy" }
-  - { name: "swift_md5_check", group: "swift_hosts" }
-  - { name: "swift_quarantine_check", group: "swift_hosts" }
-  - { name: "swift_async_check", group: "swift_hosts" }
-  - { name: "swift_object_replication_check", group: "swift_obj" }
-  - { name: "swift_account_replication_check", group: "swift_acc" }
-  - { name: "swift_container_replication_check", group: "swift_cont" }
+  - { name: "swift_quarantine_check", group: "swift_proxy" }
 
 openstack_service_remote_checks_list:
   - { name: "lb_api_check_cinder", group: "cinder_api" }

--- a/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/swift.yml
@@ -31,3 +31,10 @@
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ swift_checks_list }}"
+
+# Setup Swift Recon checks on Proxy nodes
+- include: ensure_local_checks.yml
+  vars:
+    checks: "{{ swift_recon_checks_list }}"
+  when:
+    - inventory_hostname in groups['swift_proxy'][0-1]


### PR DESCRIPTION
Restrict swift-recon checks to proxy hosts.

Connects rcbops/u-suk-dev#1212