### PR TITLE
MaaS: Improve 'swift_async_avg_check'

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -325,7 +325,7 @@ swift_container_replication_failure_percentage_threshold: 5.0
 swift_container_replication_growth_rate_threshold: 10.0
 swift_container_replication_avg_time_threshold: 50.0
 swift_async_pending_failure_percentage_threshold: 5.0
-swift_async_pending_average_threshold: 25.0
+swift_async_pending_average_threshold: 1000.0
 
 # cloud level resource thresholds
 cloud_resource_warning_memory: 80.0


### PR DESCRIPTION
Bumps swift_async_pending_average_threshold
to 1000 from 25.

Connects rcbops/u-suk-dev#1192