### PR TITLE
Add environment configuration to consume container artifacts

### DIFF
--- a/rpcd/etc/openstack_deploy/env.d/cinder.yml
+++ b/rpcd/etc/openstack_deploy/env.d/cinder.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  cinder_api_container:
+    properties:
+      service_name: cinder
+      lxc_container_variant: "cinder-{{ rpc_release }}"
+  cinder_scheduler_container:
+    properties:
+      service_name: cinder
+      lxc_container_variant: "cinder-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/galera.yml
+++ b/rpcd/etc/openstack_deploy/env.d/galera.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  galera_container:
+    properties:
+      log_directory: mysql_logs
+      service_name: galera
+      lxc_container_variant: "galera_server-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/glance.yml
+++ b/rpcd/etc/openstack_deploy/env.d/glance.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  glance_container:
+    properties:
+      service_name: glance
+      container_fs_size: 12G
+      lxc_container_variant: "glance-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/heat.yml
+++ b/rpcd/etc/openstack_deploy/env.d/heat.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  heat_apis_container:
+    properties:
+      service_name: heat
+      lxc_container_variant: "heat-{{ rpc_release }}"
+  heat_engine_container:
+    properties:
+      service_name: heat
+      lxc_container_variant: "heat-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/horizon.yml
+++ b/rpcd/etc/openstack_deploy/env.d/horizon.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  horizon_container:
+    properties:
+      service_name: horizon
+      lxc_container_variant: "horizon-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/ironic.yml
+++ b/rpcd/etc/openstack_deploy/env.d/ironic.yml
@@ -1,0 +1,30 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+container_skel:
+  ironic_api_container:
+    properties:
+      service_name: ironic
+      lxc_container_variant: "ironic-{{ rpc_release }}"
+  ironic_conductor_container:
+    properties:
+      service_name: ironic
+      lxc_container_variant: "ironic-{{ rpc_release }}"
+  ironic_compute_container:
+    properties:
+      is_metal: false
+      service_name: nova
+      lxc_container_variant: "ironic-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/keystone.yml
+++ b/rpcd/etc/openstack_deploy/env.d/keystone.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  keystone_container:
+    properties:
+      service_name: keystone
+      lxc_container_variant: "keystone-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/magnum.yml
+++ b/rpcd/etc/openstack_deploy/env.d/magnum.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+container_skel:
+  magnum_container:
+    properties:
+      service_name: magnum
+      lxc_container_variant: "magnum-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/neutron.yml
+++ b/rpcd/etc/openstack_deploy/env.d/neutron.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+container_skel:
+  neutron_agents_container:
+    properties:
+      service_name: neutron
+      lxc_container_variant: "neutron-{{ rpc_release }}"
+  neutron_server_container:
+    properties:
+      service_name: neutron
+      lxc_container_variant: "neutron-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/nova.yml
+++ b/rpcd/etc/openstack_deploy/env.d/nova.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2014-2017, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,32 @@
 # limitations under the License.
 
 container_skel:
+  nova_api_metadata_container:
+    properties:
+      service_name: nova
+      lxc_container_variant: "nova-{{ rpc_release }}"
+  nova_api_os_compute_container:
+    properties:
+      service_name: nova
+      lxc_container_variant: "nova-{{ rpc_release }}"
+  nova_cert_container:
+    properties:
+      service_name: nova
+      lxc_container_variant: "nova-{{ rpc_release }}"
   nova_compute_container:
     contains:
       - neutron_linuxbridge_agent
       - neutron_openvswitch_agent
       - nova_compute
+  nova_conductor_container:
+    properties:
+      service_name: nova
+      lxc_container_variant: "nova-{{ rpc_release }}"
+  nova_scheduler_container:
+    properties:
+      service_name: nova
+      lxc_container_variant: "nova-{{ rpc_release }}"
+  nova_console_container:
+    properties:
+      service_name: nova
+      lxc_container_variant: "nova-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/rabbitmq.yml
+++ b/rpcd/etc/openstack_deploy/env.d/rabbitmq.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  rabbit_mq_container:
+    properties:
+      service_name: rabbitmq
+      lxc_container_variant: "rabbitmq_server-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/swift.yml
+++ b/rpcd/etc/openstack_deploy/env.d/swift.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  swift_proxy_container:
+    properties:
+      service_name: swift
+      lxc_container_variant: "swift-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/utility.yml
+++ b/rpcd/etc/openstack_deploy/env.d/utility.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+container_skel:
+  utility_container:
+    properties:
+      service_name: utility
+      lxc_container_variant: "tempest-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -181,6 +181,25 @@ neutron_legacy_ha_tool_enabled: true
 rpco_mirror_base_url: "https://rpc-repo.rackspace.com"
 
 #
+# Set the LXC container creation to use the container repository
+#
+lxc_image_cache_server: "{{ rpco_mirror_base_url | netloc_no_port }}"
+
+# TODO(odyssey4me)
+# This will need adjustment if https://review.openstack.org/438449 merges
+# and a backport to Newton merges and is available to rpc-openstack.
+# Also, no-validate should be removed once this work is done:
+#   https://github.com/rcbops/u-suk-dev/issues/1296
+lxc_container_download_template_options: >
+  --dist ubuntu
+  --release {{ hostvars[physical_host]['ansible_distribution_release'] }}
+  --arch amd64
+  --force-cache
+  --server {{ lxc_image_cache_server }}
+  --variant={{ properties['lxc_container_variant'] | default(lxc_container_variant) }}
+  --no-validate
+
+#
 # Set RPC deployments to make use of the apt artifacts repository
 #
 rpco_mirror_apt_deb_line: "deb {{ rpco_mirror_apt_url }} {{ rpc_release }}-{{ ansible_distribution_release }} main"

--- a/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+++ b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
@@ -24,3 +24,10 @@ apply_security_hardening: False
 # a repo container so we override the default group_var to
 # ensure that we re-use the python artifacts in rpc-repo.
 openstack_repo_url: "{{ rpco_mirror_base_url }}"
+
+# When building container artifacts we need to ensure that
+# the lxc_hosts role prepares the default container based
+# on the upstream default variant instead of the rpc-repo
+# default variant.
+lxc_image_cache_server: images.linuxcontainers.org
+

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -123,7 +123,19 @@
           mode: "0440"
         - name: "user_rpco_variables_defaults.yml"
           mode: "0440"
+        - name: "env.d/cinder.yml"
+        - name: "env.d/galera.yml"
+        - name: "env.d/glance.yml"
+        - name: "env.d/heat.yml"
+        - name: "env.d/horizon.yml"
+        - name: "env.d/ironic.yml"
+        - name: "env.d/keystone.yml"
+        - name: "env.d/magnum.yml"
+        - name: "env.d/neutron.yml"
         - name: "env.d/nova.yml"
+        - name: "env.d/rabbitmq.yml"
+        - name: "env.d/swift.yml"
+        - name: "env.d/utility.yml"
 
     - name: Template the RPC-O config files
       config_template:


### PR DESCRIPTION
This patch ensures that the containers are built using the
prepared artifact variants.

Connects https://github.com/rcbops/u-suk-dev/issues/1189