### PR TITLE
Use recent OSA key/repo management

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -228,8 +228,18 @@ galera_repo: "{{ rpco_apt_repo }}"
 galera_percona_xtrabackup_repo: "{{ rpco_apt_repo }}"
 
 # neutron, nova wiring
-uca_repo: "{{ rpco_mirror_apt_deb_line }}"
-uca_apt_source_list_filename: "{{ rpco_mirror_apt_filename }}"
+uca_enable: False
+user_external_repo_keys_list:
+  - id: "{{ rpco_gpg_key_id }}"
+    url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
+user_external_repos_list:
+  - "{{ rpco_apt_repo }}"
+# old wiring, to remove when https://review.openstack.org/#/c/438499/
+# is merged into rpc-o newton. Necessary to build artifacts meanwhile.
+user_external_repo_key:
+  id: "{{ rpco_gpg_key_id }}"
+  url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
+user_external_repo: "{{ rpco_apt_repo }}"
 
 # Elasticsearch
 elasticsearch_apt_repos:


### PR DESCRIPTION
The pip_install role added the key/repo management to be
consistent everywhere (when doing RDO/UCA). A patch was also
included in OSA to be able to define an alternative repo to UCA.

We can now in RPC leverage this feature, and therefore we need
to wire the variables to point to our mirror that holds the UCA
packages.

This should do the trick.

Note: This commit should wait for this commit to merge back into newton: https://review.openstack.org/#/c/438456/

Connected rcbops/u-suk-dev#1252