### PR TITLE
Add default container artifacting

### DIFF
--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -19,10 +19,6 @@
   vars_files:
     - container-vars.yml
   tasks:
-    - name: Remove cache
-      file:
-        path: "/var/cache/lxc/download/ubuntu/trusty/amd64/default/"
-        state: absent
     - name: Remove base container
       lxc_container:
         name: "LXC_NAME"
@@ -36,7 +32,7 @@
         template_options: >
           --dist {{ ansible_distribution | lower }}
           --release {{ ansible_distribution_release | lower }}
-          --arch "{{ architecture_mapping.get( ansible_architecture ) }}"
+          --arch {{ architecture_mapping.get( ansible_architecture ) }}
           --force-cache
           --server images.linuxcontainers.org
           --keyserver hkp://p80.pool.sks-keyservers.net:80
@@ -85,15 +81,16 @@
   roles:
     - role: "{{ role_name }}"
   post_tasks:
-    - name: chroot resolv cleanup
+    - name: chroot cleanup
       shell: |
-        if [ -a /etc/resolv.conf.org ]; then
+        if [ -e /etc/resolv.conf.org ]; then
           mv /etc/resolv.conf.org /etc/resolv.conf
         else
           rm -f /etc/resolv.conf
         fi
         apt-get clean
         rm -rf /root/.cache/pip/
+        rm -rf /root/.ssh
         umount /proc || true
       tags:
         - always

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -80,10 +80,9 @@ openstack-ansible setup-hosts.yml --limit lxc_hosts,hosts
 cd /opt/rpc-openstack/scripts/artifacts-building/
 
 # Build it!
-ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_keystone -v" "install" "config"
-ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_cinder -v" "install" "config"
-ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=rabbitmq_server -v" "install" "config"
+openstack-ansible containers/artifact-build-chroot.yml -e role_name=pip_install -e image_name=default -v
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=galera_server -v" "install" "config"
+ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_cinder -v" "install" "config"
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_glance -v" "install" "config"
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_heat -v" "install" "config"
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_horizon -v" "install" "config"
@@ -93,6 +92,7 @@ ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e ro
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_nova -v" "install" "config"
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_swift -v" "install" "config"
 ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=os_tempest -v" "install" "config"
+ansible_tag_filter "openstack-ansible containers/artifact-build-chroot.yml -e role_name=rabbitmq_server -v" "install" "config"
 
 # Ensure no remnants (not necessary if ephemeral host, but useful for dev purposes
 rm -f /tmp/list


### PR DESCRIPTION
This patch adds the artifacting process for the default
container cache and ensures that the cache prep done by
the lxc_hosts role is not removed when preparing other
container artifacts.

Connects https://github.com/rcbops/u-suk-dev/issues/1242