### PR TITLE
Revert to using http for rpc-repo

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -178,7 +178,9 @@ neutron_legacy_ha_tool_enabled: true
 #
 # Set variables used for enabling/disabling the use of staged apt/container artifacts
 #
-rpco_mirror_base_url: "https://rpc-repo.rackspace.com"
+# TODO(odyssey4me): Switch this to HTTPS before we use this in production
+# but only once the container artifact build issues with https are figured out
+rpco_mirror_base_url: "http://rpc-repo.rackspace.com"
 
 #
 # Set RPC deployments to make use of the apt artifacts repository

--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -1,4 +1,18 @@
 ---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 build_id: "{{ ansible_date_time.date | replace('-','') }}"
 lxc_index_path: "{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}/{{ architecture_mapping.get( ansible_architecture ) }}"
 lxc_index_entry: "{{ ansible_distribution | lower }};{{ ansible_distribution_release | lower }};{{ architecture_mapping.get( ansible_architecture ) }}"
@@ -15,8 +29,8 @@ architecture_mapping:
   x86_64: amd64
   ppc64le: ppc64el
 role_vars:
-  "venv_download_url": "{{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
-  "venv_tag": "{{ rpc_release }}"
-  "developer_mode": False
+  venv_download_url: "{{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
+  venv_tag: "{{ rpc_release }}"
+  developer_mode: False
 webserver_owner: "nginx"
 webserver_group: "www-data"


### PR DESCRIPTION
There appears to be an issue with using https to rpc-repo
which results in the get_url tasks failing.

This patch reverts the setting to use http to bypass that
issue, unblocking other work that is ongoing.

The license boilerplate is also added and some keys are
cleaned up in the vars file used for the container artifact
build.

Connects https://github.com/rcbops/u-suk-dev/issues/1294