### PR TITLE
Make magnum.sh more idempotent

### DIFF
--- a/contrib/scripts/magnum.sh
+++ b/contrib/scripts/magnum.sh
@@ -1,21 +1,28 @@
-if [[ "$DEPLOY_MAGNUM" == "yes" ]]; then
+if [ "$DEPLOY_MAGNUM" == "yes" ]; then
+
+  export OA_DIR=${OA_DIR:-/opt/rpc-openstack/openstack-ansible}
+  export CONTRIB_DIR=${CONTRIB_DIR:-/opt/rpc-openstack/contrib}
+
   if [ `grep -c magnum /etc/openstack_deploy/user_osa_secrets.yml` -eq 0 ]; then
-    cat >> /etc/openstack_deploy/user_osa_secrets.yml <<'EOF'
+    grep -q magnum_service_password /etc/openstack_deploy/user_osa_secrets.yml || cat >> /etc/openstack_deploy/user_osa_secrets.yml <<'EOF'
 magnum_service_password:
 magnum_galera_password:
 magnum_rabbitmq_password:
 magnum_trustee_password:
 EOF
-    cat >> $OA_DIR/ansible-role-requirements.yml <<'EOF'
+
+    grep -q os_magnum $OA_DIR/ansible-role-requirements.yml || cat >> $OA_DIR/ansible-role-requirements.yml <<'EOF'
 - name: os_magnum
   src: https://github.com/rcbops/openstack-ansible-os_magnum.git
   version: 578467da105ceffd0063cf8e5309f2e9d3d42c19
 EOF
-#Re-running ansible-galaxy install to include Magnum role
+
+    #Re-running ansible-galaxy install to include Magnum role
     ansible-galaxy install --role-file=/opt/rpc-openstack/ansible-role-requirements.yml --force \
                                --roles-path=/opt/rpc-openstack/rpcd/playbooks/roles
-#Distribute Magnum configuration files and settings
-    cat > /etc/openstack_deploy/user_osa_variables_defaults.yml <<'EOF'
+
+    #Distribute Magnum configuration files and settings
+    grep -q magnum_config_overrides /etc/openstack_deploy/user_osa_variables_defaults.yml || cat >> /etc/openstack_deploy/user_osa_variables_defaults.yml <<'EOF'
 # These configuration entries for Keystone configure some settings for Trusts to
 # function properly
 keystone_keystone_conf_overrides:
@@ -66,16 +73,19 @@ magnum_rabbitmq_userid: magnum
 magnum_rabbitmq_vhost: /magnum
 
 EOF
-  # TODO(chris_hultin):
-  # Remove this section upon transition to Newton
-  # This is required so that repo_build.yml does not attempt to build a different version of Magnum
-    cat >> $OA_DIR/playbooks/defaults/repo_packages/openstack_services.yml <<'EOF'
+
+    # TODO(chris_hultin):
+    # Remove this section upon transition to Newton
+    # This is required so that repo_build.yml does not attempt to build a different version of Magnum
+    grep -q magnum_git_repo $OA_DIR/playbooks/defaults/repo_packages/openstack_services.yml ||  cat >> $OA_DIR/playbooks/defaults/repo_packages/openstack_services.yml <<'EOF'
 magnum_git_repo: https://git.openstack.org/openstack/magnum
 magnum_git_install_branch: stable/mitaka
 magnum_git_dest: "/opt/magnum_{{ magnum_git_install_branch | replace('/', '_') }}"
 EOF
+
     cp $CONTRIB_DIR/magnum/os-magnum-install.yml $OA_DIR/playbooks/
     cp $CONTRIB_DIR/magnum/magnum.yml /etc/openstack_deploy/env.d/magnum.yml
-    echo "- include: os-magnum-install.yml" >> $OA_DIR/playbooks/setup-openstack.yml
+
+    grep -q os-magnum-install.yml $OA_DIR/playbooks/setup-openstack.yml || echo "- include: os-magnum-install.yml" >> $OA_DIR/playbooks/setup-openstack.yml
   fi
 fi


### PR DESCRIPTION
This fix allows for running deploy.sh multiple times without overwriting  user_osa_variables_defaults.yml or adding over and over the same config values