### PR TITLE
[Backport - Liberty] MaaS: Swift time-sync validation and alarming

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -452,6 +452,7 @@ swift_recon_checks_list:
   - { name: "swift_object_replication_check", group: "swift_proxy" }
   - { name: "swift_proxy_server_check", group: "swift_proxy" }
   - { name: "swift_quarantine_check", group: "swift_proxy" }
+  - { name: "swift_time_sync_check", group: "swift_proxy" }
 
 openstack_service_remote_checks_list:
   - { name: "lb_api_check_cinder", group: "cinder_api" }

--- a/rpcd/playbooks/roles/rpc_maas/templates/swift_time_sync_check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/swift_time_sync_check.yaml.j2
@@ -1,0 +1,20 @@
+{% set label = "swift_time_sync_check" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : swift-recon.py
+    args    : ["time"]
+alarms      :
+    swift_time_sync_check :
+        label                   : swift_time_sync_check--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('swift_time_sync_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["time_sync_time_differ"] > 30) {
+                return new AlarmStatus(CRITICAL, "Time synchonization error");
+            }


### PR DESCRIPTION
Backport for Swift time-sync validation and alarming

Cherry picked and amended to exclude venvs from check.

Connects rcbops/u-suk-dev#1217