### PR TITLE
Update artifacted deployment settings and staging process

### DIFF
--- a/rpcd/etc/openstack_deploy/env.d/galera.yml
+++ b/rpcd/etc/openstack_deploy/env.d/galera.yml
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-container_skel:
-  galera_container:
-    properties:
-      log_directory: mysql_logs
-      service_name: galera
-      lxc_container_variant: "galera_server-{{ rpc_release }}"
+# TODO(odyssey4me):
+# Remove this remark once the following work is complete:
+#  https://github.com/rcbops/u-suk-dev/issues/1251
+#container_skel:
+#  galera_container:
+#    properties:
+#      log_directory: mysql_logs
+#      service_name: galera
+#      lxc_container_variant: "galera_server-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/horizon.yml
+++ b/rpcd/etc/openstack_deploy/env.d/horizon.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-container_skel:
-  horizon_container:
-    properties:
-      service_name: horizon
-      lxc_container_variant: "horizon-{{ rpc_release }}"
+# TODO(odyssey4me):
+# Remove this remark once the following work is complete:
+#   https://github.com/rcbops/u-suk-dev/issues/1334
+#container_skel:
+#  horizon_container:
+#    properties:
+#      service_name: horizon
+#      lxc_container_variant: "horizon-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/keystone.yml
+++ b/rpcd/etc/openstack_deploy/env.d/keystone.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-container_skel:
-  keystone_container:
-    properties:
-      service_name: keystone
-      lxc_container_variant: "keystone-{{ rpc_release }}"
+# TODO(odyssey4me):
+# Remove this remark once the following work is complete:
+#  https://github.com/rcbops/u-suk-dev/issues/1332
+#container_skel:
+#  keystone_container:
+#    properties:
+#      service_name: keystone
+#      lxc_container_variant: "keystone-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/memcache.yml
+++ b/rpcd/etc/openstack_deploy/env.d/memcache.yml
@@ -17,4 +17,4 @@ container_skel:
   memcached_container:
     properties:
       service_name: memcached
-      lxc_container_variant: "memcached-{{ rpc_release }}"
+      lxc_container_variant: "memcached_server-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/rabbitmq.yml
+++ b/rpcd/etc/openstack_deploy/env.d/rabbitmq.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-container_skel:
-  rabbit_mq_container:
-    properties:
-      service_name: rabbitmq
-      lxc_container_variant: "rabbitmq_server-{{ rpc_release }}"
+# TODO(odyssey4me):
+# Remove this remark once the following work is complete:
+#  https://github.com/rcbops/u-suk-dev/issues/1331
+#container_skel:
+#  rabbit_mq_container:
+#    properties:
+#      service_name: rabbitmq
+#      lxc_container_variant: "rabbitmq_server-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -188,18 +188,32 @@ rpco_mirror_base_url: "http://rpc-repo.rackspace.com"
 lxc_image_cache_server: "{{ rpco_mirror_base_url | netloc_no_port }}"
 
 # TODO(odyssey4me)
-# This will need adjustment if https://review.openstack.org/438449 merges
-# and a backport to Newton merges and is available to rpc-openstack.
-# Also, no-validate should be removed once this work is done:
+# This requires https://review.openstack.org/439201 to work.
+# The 'no-validate' option should be removed once this work is done:
 #   https://github.com/rcbops/u-suk-dev/issues/1296
-lxc_container_download_template_options: >
-  --dist ubuntu
-  --release {{ hostvars[physical_host]['ansible_distribution_release'] }}
-  --arch amd64
-  --force-cache
-  --server {{ lxc_image_cache_server }}
-  --variant={{ properties['lxc_container_variant'] | default(lxc_container_variant) }}
-  --no-validate
+lxc_cache_default_variant: "default-{{ rpc_release }}"
+lxc_cache_download_template_extra_options: "--no-validate"
+
+# TODO(odyssey4me)
+# This requires https://review.openstack.org/438449 to work.
+# The 'no-validate' option should be removed once this work is done:
+#   https://github.com/rcbops/u-suk-dev/issues/1296
+lxc_container_variant: "{{ lxc_cache_default_variant }}"
+lxc_container_download_template_extra_options: "--no-validate"
+
+# As we pre-build our container images, they have no ssh keys in them.
+# The ssh keys are required in order for delegation from a container to
+# another container to work. eg: os-keystone-install delegates the
+# rabbitmq and mariadb tasks from the keystone container to the
+# respective rabbit/mariadb container.
+lxc_container_commands: |
+  key="{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+  mkdir -p /root/.ssh
+  chmod 700 /root/.ssh
+  if [[ ! "$(grep -q "$key" /root/.ssh/authorized_keys)" ]]; then
+    echo "$key" | tee -a /root/.ssh/authorized_keys
+  fi
+  chmod 700 /root/.ssh/authorized_keys
 
 #
 # Set RPC deployments to make use of the apt artifacts repository

--- a/rpcd/playbooks/stage-python-artifacts.yml
+++ b/rpcd/playbooks/stage-python-artifacts.yml
@@ -56,8 +56,40 @@
       tags:
         - always
 
+    # TODO(odyssey4me)
+    # Remove this and adjust the fact setting once
+    # https://review.openstack.org/439659 is available
+    - name: Fetch the list of files in the releases folder
+      uri:
+        url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/"
+        return_content: yes
+        validate_certs: "{{ https_validate_certs | bool }}"
+      register: releases_index
+      tags:
+        - always
+
     - name: Derive the lists of artifacts to download
       set_fact:
+        #
+        # The MANIFEST.in file gives us entries like this for wheels:
+        #
+        # pools/alembic/alembic-0.8.7-py2.py3-none-any.whl
+        # os-releases/r14.0.0rc1/alembic-0.8.7-py2.py3-none-any.whl
+        #
+        # The first is the pool location, the second is the release
+        # folder location. The wheel name is always the same.
+        #
+        # We only need to download from one accessible location to
+        # the pools folder, then implement the symlinks from the
+        # releases and links folder as is done in the repo-build
+        # process. As such, we filter the list we get based on the
+        # 'pools' path. The wheel list is separated from the venv
+        # list due to the symlinking that needs to happen later
+        # for wheels only.
+        #
+        # The resulting list has entries such as:
+        # pools/alembic/alembic-0.8.7-py2.py3-none-any.whl
+        #
         python_wheel_list: |
           {%- set content_list = manifest.content.split('\n') -%}
           {%- set result_list = [] -%}
@@ -67,6 +99,20 @@
           {%-   endif -%}
           {%- endfor -%}
           {{- result_list -}}
+        #
+        # The MANIFEST.in file gives us entries like this for git
+        # repositories:
+        #
+        # openstackgit/nova
+        #
+        # As we download the git data differently to the wheels,
+        # we need to seperate this manifest data from the wheels.
+        # As such, we filter the list we get based on the
+        # 'openstackgit' path.
+        #
+        # The resulting list is therefore an unchanged list of
+        # only the git folders.
+        #
         git_folder_list: |
           {%- set content_list = manifest.content.split('\n') -%}
           {%- set result_list = [] -%}
@@ -76,6 +122,32 @@
           {%-   endif -%}
           {%- endfor -%}
           {{- result_list -}}
+        #
+        # The MANIFEST.in does not currently have the python venvs
+        # included in the file. This will be resolved once we are
+        # able to complete a python artifact build with the
+        # following patch included:
+        #   https://review.openstack.org/433152
+        #
+        # As such we have instead used the repo server's index of
+        # files in the folder in order to get the file listing.
+        # The data we get is HTML that looks something like this:
+        #
+        # <html>
+        # <head><title>Index of /venvs/r14.0.0rc1/ubuntu/</title></head>
+        # <body bgcolor=\"white\">
+        # <h1>Index of /venvs/r14.0.0rc1/ubuntu/</h1><hr><pre><a href=\"../\">../</a>
+        # <a href=\"aodh-r14.0.0rc1-x86_64.checksum\">aodh-r14.0.0rc1-x86_64.checksum</a>                    27-Feb-2017 17:52                  41
+        # <a href=\"aodh-r14.0.0rc1-x86_64.tgz\">aodh-r14.0.0rc1-x86_64.tgz</a>                         27-Feb-2017 17:52            33403695
+        #
+        # To retrieve the file names we have to split the content
+        # into a list by line feeds, then find the link tags and
+        # grab just the file name from inside the link tag.
+        #
+        # The resulting list has entries such as:
+        # aodh-r14.0.0rc1-x86_64.checksum
+        # aodh-r14.0.0rc1-x86_64.tgz
+        #
         python_venv_list: |
           {%- set content_list = venv_index.content.split('\r\n') -%}
           {%- set result_list = [] -%}
@@ -83,6 +155,48 @@
           {%-   if item | search("<a href.*>.*</a>") -%}
           {%-     set item_clean = item | regex_replace(".*<a href.*>(.*)</a>.*", "\\1") -%}
           {%-     if item_clean != "../" -%}
+          {%-       set _ = result_list.append(item_clean) -%}
+          {%-     endif -%}
+          {%-   endif -%}
+          {%- endfor -%}
+          {{- result_list -}}
+        #
+        # The MANIFEST.in does not currently have the non-wheel items
+        # from the releases folder included in the file. This will be
+        # resolved once we are able to complete a python artifact
+        # build with the following patch included:
+        #   https://review.openstack.org/439659
+        #
+        # As such we have instead used the repo server's index of
+        # files in the folder in order to get the file listing.
+        # The data we get is HTML that looks something like this:
+        #
+        # <html>
+        # <head><title>Index of /os-releases/r14.0.0rc1</title></head>
+        # <body bgcolor=\"white\">
+        # <h1>Index of /os-releases/r14.0.0rc1</h1><hr><pre><a href=\"../\">../</a>
+        # <a href=\"get-pip.py\">get-pip.py</a>                                         27-Feb-2017 17:41             1595408
+        # <a href=\"requirements_absolute_requirements.txt\">requirements_absolute_requirements.txt</a>             27-Feb-2017 17:50                6221
+        # <a href=\"requirements_constraints.txt\">requirements_constraints.txt</a>                       27-Feb-2017 17:44               13036
+        #
+        # To retrieve the file names we have to split the content
+        # into a list by line feeds, then find the link tags and
+        # grab just the file name from inside the link tag. We
+        # also need to ignore the wheels in the folder as we already
+        # have the wheel listing.
+        #
+        # The resulting list has entries such as:
+        # get-pip.py
+        # requirements_absolute_requirements.txt
+        # requirements_constraints.txt
+        #
+        releases_file_list: |
+          {%- set content_list = releases_index.content.split('\r\n') -%}
+          {%- set result_list = [] -%}
+          {%- for item in content_list -%}
+          {%-   if item | search("<a href.*>.*</a>") -%}
+          {%-     set item_clean = item | regex_replace(".*<a href.*>(.*)</a>.*", "\\1") -%}
+          {%-     if item_clean != "../" and (item_clean | search(".txt") or item_clean == "get-pip.py") -%}
           {%-       set _ = result_list.append(item_clean) -%}
           {%-     endif -%}
           {%-   endif -%}
@@ -137,6 +251,10 @@
           {{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ item }}
             dir={{ staging_path }}/venvs/{{ rpc_release }}/ubuntu
           {% endfor %}
+          {% for item in releases_file_list %}
+          {{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ item }}
+            dir={{ staging_path }}/os-releases/{{ rpc_release }}
+          {% endfor %}
         dest: "{{ aria_input_file }}"
       tags:
         - python
@@ -155,8 +273,8 @@
 
     - name: Python releases symlinks
       file:
-        src: "{{ staging_path }}/{{ item }}"
-        dest: "{{ staging_path }}/os-releases/{{ rpc_release }}/{{ item | regex_replace(item | dirname ~ '/', '') }}"
+        src: "../../{{ item }}"
+        dest: "{{ staging_path }}/os-releases/{{ rpc_release }}/{{ item | basename }}"
         state: "link"
       with_items: "{{ python_wheel_list }}"
       tags:
@@ -164,8 +282,8 @@
 
     - name: Python links symlinks
       file:
-        src: "{{ staging_path }}/{{ item }}"
-        dest: "{{ staging_path }}/links/{{ item | regex_replace(item | dirname ~ '/', '') }}"
+        src: "../{{ item }}"
+        dest: "{{ staging_path }}/links/{{ item | basename }}"
         state: "link"
       with_items: "{{ python_wheel_list }}"
       tags:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,8 +38,43 @@ fi
 # Check the openstack-ansible submodule status
 check_submodule_status
 
+#################################################
+#
+# Begin: Temporary Hacks for artifacted deployment
+#
+
+# Ensure that we're using git checkouts instead of
+# the ansible-galaxy download.
+export ANSIBLE_ROLE_FETCH_MODE="git-clone"
+
 # Bootstrap Ansible
 source "$(dirname "${0}")/bootstrap-ansible.sh"
+
+# As the current testing is AIO only, and skips the
+# RPC-O bits in order to keep things simple. We will
+# enable those bits later once we've got a working
+# base OSA deployment.
+
+export DEPLOY_AIO="yes"
+export DEPLOY_ELK="no"
+export DEPLOY_RPC="no"
+
+# Allow container creation based on variant property
+#   https://github.com/rcbops/u-suk-dev/issues/1297
+pushd /etc/ansible/roles/lxc_container_create
+  git checkout stable/newton
+popd
+
+# Ability to set a different default variant
+#   https://github.com/rcbops/u-suk-dev/issues/1314
+pushd /etc/ansible/roles/lxc_hosts
+  git checkout stable/newton
+popd
+
+#
+# End: Temporary Hacks for artifacted deployment
+#
+#################################################
 
 # bootstrap the AIO
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
@@ -50,6 +85,12 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   # set the ansible inventory hostname to the host's name
   sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
   sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
+
+  # TODO(odyssey4me):
+  # Remove this once we have published artifacts
+  # for a real tagged version.
+  # Set the rpc_release to the next guessed version.
+  echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 
 fi
 
@@ -118,8 +159,18 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
     popd
   fi
 
-  # setup the infrastructure
-  run_ansible setup-infrastructure.yml
+
+  # setup infrastructure
+  run_ansible unbound-install.yml
+  run_ansible ${RPCD_DIR}/playbooks/stage-python-artifacts.yml
+  run_ansible repo-server.yml
+  run_ansible haproxy-install.yml
+  run_ansible memcached-install.yml
+  run_ansible galera-install.yml
+  run_ansible rabbitmq-install.yml
+  run_ansible etcd-install.yml
+  run_ansible utility-install.yml
+  run_ansible rsyslog-install.yml
 
   # setup openstack
   run_ansible setup-openstack.yml


### PR DESCRIPTION
The following fixes are implemented in this patch with the purpose of getting to a deployment that converges using apt, python and container artifacts:

1. The setup-infrastructure step in deploy.sh now uses
   the python staging process instead of the repo build
   process.
2. The default variables are updated to include additional
   settings to ensure that the container artifacts are
   used.
3. The python artifact staging process is updated to
   include downloading the non *.whl files.
4. The galera_server, horizon, keystone, rabbitmq artifacts
   are not used and will need to be adjusted to work properly.
   [1], [2], [3], [4] have been registered to get this resolved.
5. The artifact name for the memcached_server role did not
   match the setting in env.d so it has been corrected.

Some deploy.sh hacks are added to ease testing using an
AIO.

[1] https://github.com/rcbops/u-suk-dev/issues/1251
[2] https://github.com/rcbops/u-suk-dev/issues/1334
[3] https://github.com/rcbops/u-suk-dev/issues/1332
[4] https://github.com/rcbops/u-suk-dev/issues/1331

Connects https://github.com/rcbops/u-suk-dev/issues/1315