### PR TITLE
ELK stack tag cleanup

### DIFF
--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -26,7 +26,6 @@
   with_items: elasticsearch_apt_packages
   tags:
     - elasticsearch-apt-packages
-    - elasticsearch-install
 
 - name: Install pip packages
   pip:
@@ -40,9 +39,10 @@
   with_items: elasticsearch_pip_packages
   tags:
     - elasticsearch-pip-packages
-    - elasticsearch-install
 
-- name: Enable ElasticSearch Service
-  service:
-    name: elasticsearch
-    enabled: yes
+- name: Create /var/lib/elasticsearch
+  file:
+    path: "/var/lib/elasticsearch"
+    state: directory
+    owner: elasticsearch
+    group: elasticsearch

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Create /var/lib/elasticsearch
-  file:
-    path: "/var/lib/elasticsearch"
-    state: directory
-    owner: elasticsearch
-    group: elasticsearch
+- name: Enable ElasticSearch Service
+  service:
+    name: elasticsearch
+    enabled: yes
 
 - name: Deploy ElasticSearch configuration files
   template:
@@ -30,8 +28,6 @@
     - elasticsearch.yml
     - logging.yml
   notify: Restart ElasticSearch
-  tags:
-    - elasticsearch-post-install
 
 - name: Deploy ElasticSearch service configuration file
   template:
@@ -42,8 +38,6 @@
   with_items:
     - elasticsearch
   notify: Restart ElasticSearch
-  tags:
-    - elasticsearch-post-install
 
 - name: Restart ElasticSearch before proceeding
   meta: flush_handlers
@@ -52,8 +46,6 @@
   wait_for:
     host: "{{ ansible_ssh_host }}"
     port: "9200"
-  tags:
-    - elasticsearch-post-install
 
 - name: Setup the ElasticSearch Curator cron job
   cron:
@@ -63,8 +55,6 @@
     user: "root"
     job: "/usr/local/bin/curator --host {{ hostvars[inventory_hostname]['container_address'] }} delete indices --older-than {{ elasticsearch_prune_days }} --time-unit 'days' --timestring '%Y.%m.%d' --prefix 'logstash'"
     cron_file: "elasticsearch_curator"
-  tags:
-    - elasticsearch-post-install
 
 - name: Get ElasticSearch version
   uri:
@@ -73,7 +63,6 @@
     status_code: 200
   register: escontent
   tags:
-    - elasticsearch-post-install
     - elasticsearch-version
 
 - name: Verify ElasticSearch version
@@ -81,5 +70,4 @@
     msg: "Incorrect version of ElasticSearch {{ escontent.json.version.number }} is installed."
   when: escontent.json.version.number != '2.4.1'
   tags:
-    - elasticsearch-post-install
     - elasticsearch-version

--- a/rpcd/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/main.yml
@@ -27,10 +27,24 @@
 - include: upgrade_pre_flight.yml
   when:
     - logging_upgrade | bool
+  tags:
+    - elasticsearch-upgrade
+
 - include: upgrade_elasticsearch_pre.yml
   when:
     - logging_upgrade | bool
     - proceed_with_upgrade | bool
+  tags:
+    - elasticsearch-upgrade
+
 - include: elasticsearch_pre_install.yml
+  tags:
+    - elasticsearch-install
+
 - include: elasticsearch_install.yml
+  tags:
+    - elasticsearch-install
+
 - include: elasticsearch_post_install.yml
+  tags:
+    - elasticsearch-config

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_dashboards.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_dashboards.yml
@@ -19,7 +19,7 @@
     chdir: "/opt/kibana/"
   register: kibana_version
   tags:
-    - kibana-post-install
+    - kibana-package-version
 
 - name: Import Kibana's LS index configuration in ES
   uri:
@@ -39,7 +39,7 @@
     - where: "/config/{{ kibana_version.stdout }}"
       what: '{"defaultIndex" : "logstash-*"}'
   tags:
-    - kibana-post-install
+    - kibana-import
 
 - name: Uploading JSON configuration files
   uri:
@@ -56,5 +56,4 @@
     - "visualization/*.json"
     - "dashboard/*.json"
   tags:
-    - kibana-post-install
     - kibana-rax-dashboard

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
@@ -26,7 +26,6 @@
   with_items: "{{ kibana_apt_packages }}"
   tags:
     - kibana-apt-packages
-    - kibana-install
 
 - name: Install pip packages
   pip:
@@ -40,9 +39,4 @@
   with_items: kibana_pip_packages
   tags:
     - kibana-pip-packages
-    - kibana-install
 
-- name: Enable Kibana Service
-  service:
-    name: kibana
-    enabled: yes

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_post_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_post_install.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Enable Kibana Service
+  service:
+    name: kibana
+    enabled: yes
 
 - name: Deploy Kibana configuration files
   template:
@@ -21,8 +25,6 @@
     owner: "root"
     group: "root"
   notify: Restart Kibana
-  tags:
-    - kibana-post-install
 
 - name: Deploy Kibana service configuration file
   template:
@@ -31,8 +33,6 @@
     owner: "root"
     group: "root"
   notify: Restart Kibana
-  tags:
-    - kibana-post-install
 
 - name: Restart Kibana before proceeding
   meta: flush_handlers
@@ -41,8 +41,6 @@
   wait_for:
     host: "127.0.0.1"
     port: "{{ kibana_app_port }}"
-  tags:
-    - kibana-post-install
 
 - name: create self-signed SSL cert
   command: >
@@ -56,7 +54,6 @@
   when: kibana_self_signed is defined and kibana_self_signed == true
   tags:
     - kibana-self-signed-cert
-    - kibana-post-install
 
 - name: Enable apache modules
   command: a2enmod "{{ item }}"
@@ -64,7 +61,6 @@
   tags:
     - kibana-apache-modules
     - kibana-apache
-    - kibana-post-install
 
 - name: Template Kibana Apache Config
   template:
@@ -77,7 +73,6 @@
   notify: Restart Apache
   tags:
     - kibana-apache
-    - kibana-post-install
 
 - name: Drop Apache2 Ports File
   template:
@@ -90,7 +85,6 @@
   notify: Restart Apache
   tags:
     - kibana-apache
-    - kibana-post-install
 
 - name: Link Kibana Site
   file:
@@ -102,7 +96,6 @@
   notify: Restart Apache
   tags:
     - kibana-apache
-    - kibana-post-install
 
 - name: Remove Apache Default Site
   file:
@@ -111,7 +104,6 @@
   notify: Restart Apache
   tags:
     - kibana-apache
-    - kibana-config
 
 - name: Create kibana http_auth user
   htpasswd:
@@ -126,4 +118,3 @@
   notify: Restart Apache
   tags:
     - kibana-apache
-    - kibana-post-install

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_pre_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_pre_install.yml
@@ -25,7 +25,6 @@
   delay: 2
   tags:
     - kibana-apt-keys
-    - kibana-pre-install
 
 - name: Add kibana apt repositories
   apt_repository:
@@ -40,4 +39,3 @@
   delay: 2
   tags:
     - kibana-apt-repos
-    - kibana-pre-install

--- a/rpcd/playbooks/roles/kibana/tasks/main.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/main.yml
@@ -14,6 +14,17 @@
 # limitations under the License.
 
 - include: kibana_pre_install.yml
+  tags:
+    - kibana-install
+
 - include: kibana_install.yml
+  tags:
+    - kibana-install
+
 - include: kibana_post_install.yml
+  tags:
+    - kibana-config
+
 - include: kibana_dashboards.yml
+  tags:
+    - kibana-dashboard

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_install.yml
@@ -26,4 +26,12 @@
   with_items: logstash_apt_packages
   tags:
     - logstash-apt-packages
-    - logstash-install
+
+- name: Create patterns directory
+  file:
+    name: "/opt/logstash/patterns"
+    owner: "logstash"
+    group: "logstash"
+    state: directory
+  tags:
+    - logstash-patterns

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_post_install.yml
@@ -13,16 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Create patterns directory
-  file:
-    name: "/opt/logstash/patterns"
-    owner: "logstash"
-    group: "logstash"
-    state: directory
-  tags:
-    - logstash-patterns
-    - logstash-post-install
-
 - name: Logstash Extra Patterns
   template:
     src: "{{ item }}"
@@ -34,7 +24,6 @@
   notify: Restart Logstash
   tags:
     - logstash-patterns
-    - logstash-post-install
 
 - name: Deploy Logstash configuration files
   template:
@@ -101,7 +90,6 @@
   notify: Restart Logstash
   tags:
     - logstash-post-install
-
 
 - name: Enable Logstash Plugins
   command: "/opt/logstash/bin/logstash-plugin install {{ item }}"

--- a/rpcd/playbooks/roles/logstash/tasks/logstash_pre_install.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/logstash_pre_install.yml
@@ -25,7 +25,6 @@
   delay: 2
   tags:
     - logstash-apt-keys
-    - logstash-pre-install
 
 - name: Add apt repositories
   apt_repository:
@@ -39,4 +38,3 @@
   delay: 2
   tags:
     - logstash-apt-repos
-    - logstash-pre-install

--- a/rpcd/playbooks/roles/logstash/tasks/main.yml
+++ b/rpcd/playbooks/roles/logstash/tasks/main.yml
@@ -25,6 +25,17 @@
     - always
 
 - include: upgrade_logstash_pre.yml
+  tags:
+    - logstash-upgrade
+
 - include: logstash_pre_install.yml
+  tags:
+    - logstash-install
+
 - include: logstash_install.yml
+  tags:
+    - logstash-install
+
 - include: logstash_post_install.yml
+  tags:
+    - logstash-config


### PR DESCRIPTION
For artifacting, we are checking if the tags don't hold the term config
and hold the term "install".

With this commit, we can artifact ELK. Please note some tasks were
moved from post-install to install to reduce the amount of tags: lines
while keeping the same behavior.

Signed-off-by: Jean-Philippe Evrard <jean-philippe@evrard.me>