### PR TITLE
[Backport - Liberty] MaaS: Remove older legacy HP checks

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/hp.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/hp.yml
@@ -16,3 +16,12 @@
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ hp_checks_list }}"
+
+- name: Remove legacy HP checks as they are combined into one now
+  file:
+    path: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}--{{ inventory_hostname }}.yaml"
+    state: absent
+  with_items:
+    - "hp-memory"
+    - "hp-processors"
+    - "hp-vdisk"


### PR DESCRIPTION
Ensures previously used HP checks are no longer present.

Connects rcbops/u-suk-dev#1320