### PR TITLE
Change novnc_auto.html to vnc_auto.html

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -69,7 +69,7 @@ MONITORS = [
     r' defaults-from http destination *:6082 recv "200 OK" send "HEAD /spice_auto.html'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
     r'create ltm monitor http /' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_NOVNC_CONSOLE {'
-    r' defaults-from http destination *:6080 recv "200 OK" send "HEAD /novnc_auto.html'
+    r' defaults-from http destination *:6080 recv "200 OK" send "HEAD /vnc_auto.html'
     r' HTTP/1.1\r\nHost: rpc\r\n\r\n" }',
     r'create ltm monitor https /' + PART + '/' + PREFIX_NAME + '_MON_HTTPS_HORIZON_SSL { defaults-from'
     r' https destination *:443 recv "302 FOUND" send "HEAD / HTTP/1.1\r\nHost:'


### PR DESCRIPTION
The correct path for this monitor to use is vnc_auto.html,
not novnc_auto.html. This commit corrects that.

Connects https://github.com/rcbops/rpc-openstack/issues/1973