### PR TITLE
Convert filebeat role and play to run on the rsyslog containers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,13 +227,15 @@ For example, the filebeat configurations for the cinder logs will look like the 
 ```yaml
 
 filebeat_logging_paths:
-  - paths:
-    - '/var/log/cinder/*.log'
+  - groups:
+      - cinder_all
+    paths:  # This is a log file filter, if present it will limit the file glob to only the files provided.
+      - cinder.log
     document_type: openstack
     tags:
-    - openstack
-    - oslofmt
-    - cinder
+      - openstack
+      - oslofmt
+      - cinder
     multiline:
       pattern: "{{ multiline_openstack_pattern }}"
       negate: 'true'

--- a/rpcd/playbooks/filebeat.yml
+++ b/rpcd/playbooks/filebeat.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Setup Filebeat log shiping
-  hosts: all
-  max_fail_percentage: 20
+  hosts: rsyslog_all
+  user: root
   roles:
     - role: "filebeat"


### PR DESCRIPTION
This change is moving the filebeat process from every host and container
within an environment to only the rsyslog server container on a given
logging node.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [UG-651](https://rpc-openstack.atlassian.net/browse/UG-651)