### PR TITLE
[Backport - newton-14.0] Remove ssl_impossible from console services

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -265,7 +265,6 @@ POOL_PARTS = {
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_SPICE_CONSOLE',
         'group': 'nova_console',
         'hosts': [],
-        'ssl_impossible': True,
         'make_public': True,
         'persist': True
     },
@@ -275,7 +274,6 @@ POOL_PARTS = {
         'mon_type': '/' + PART + '/' + PREFIX_NAME + '_MON_HTTP_NOVA_NOVNC_CONSOLE',
         'group': 'nova_console',
         'hosts': [],
-        'ssl_impossible': True,
         'make_public': True,
         'persist': True
     },


### PR DESCRIPTION
Traffic to this service is now expected to be SSL-terminated
at the load balancer, which means a public, ssl virtual server
is needed.
This commit removes ``ssl_impossible`` from the console service's
POOL_PARTS. This will tell the script to create a public ssl
virtual server for the services.

Connects https://github.com/rcbops/rpc-openstack/issues/1977

(cherry picked from commit 62b07d58d4f48e171c3b205be3f43b47745496f3)