### PR TITLE
MaaS: Pin python-novaclient<7.0.0

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -492,6 +492,8 @@ maas_pip_packages:
 #
 # maas_pip_dependencies: These are pip packages we depend on, but should already be built in
 #                        openstack-ansible
+# NOTE: python-novaclient 7.x changes how the list() method works and requires
+#       more work.
 maas_pip_dependencies:
   - cryptography
   - requests
@@ -501,7 +503,7 @@ maas_pip_dependencies:
   - python-heatclient
   - python-keystoneclient
   - python-neutronclient
-  - python-novaclient
+  - python-novaclient<7.0.0
   - python-memcached
 
 maas_source_plugin_dir: plugins/


### PR DESCRIPTION
``python-novaclient`` 7.x changes how the ``list()`` and related methods work.
This patch adds a pin to limit the version to ``<7.0.0``.

We should probably revisit this later for a more permanent fix.

Connects rcbops/rpc-openstack#1982