### PR TITLE
[Backport - newton-14.0] MaaS: Pin python-novaclient<7.0.0

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -517,6 +517,8 @@ maas_pip_packages:
 #
 # maas_pip_dependencies: These are pip packages we depend on, but should already be built in
 #                        openstack-ansible
+# NOTE: python-novaclient 7.x changes how the list() method works and requires
+#       more work.
 maas_pip_dependencies:
   - cryptography
   - requests
@@ -526,7 +528,7 @@ maas_pip_dependencies:
   - python-heatclient
   - python-keystoneclient
   - python-neutronclient
-  - python-novaclient
+  - python-novaclient<7.0.0
   - python-memcached
 
 maas_source_plugin_dir: plugins/


### PR DESCRIPTION
python-novaclient 7.x changes how the list() and related methods work.
This patch adds a pin to limit the version to <7.0.0.

We should probably revisit this later for a more permanent fix.

Connects rcbops/rpc-openstack#1982

(cherry picked from commit ad59f6b9729db5cab203a90cd40905dcfad30590)