### PR TITLE
Fixing Horizon CSS issues for horizon_extensions

### DIFF
--- a/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
+++ b/rpcd/playbooks/roles/horizon_extensions/tasks/main.yml
@@ -54,7 +54,8 @@
 
 - name: Collect and compress static files
   command: "{{ item }}"
-  become: true
+  become: yes
+  become_user: "{{ horizon_system_user_name }}"
   with_items:
     - "{{ horizon_venv_bin }}/horizon-manage.py collectstatic --noinput"
     - "{{ horizon_venv_bin }}/horizon-manage.py compress --force"


### PR DESCRIPTION
The horizon_extensions was omitting the horizon system user configuration
and generating static files with the root user.
This can lead to permission issues where existing files are owned as
horizon system user vs. root

Closes-Bug: #1994