### PR TITLE
Make possible to skip first download

### DIFF
--- a/scripts/artifacts-building/apt/aptly-all.yml
+++ b/scripts/artifacts-building/apt/aptly-all.yml
@@ -17,6 +17,7 @@
   vars:
     aptly_mirror_do_updates: "False"
 - include: sync-with-mirror.yml
+  when: "{{ (lookup('ENV','DOWNLOAD_FIRST') | default(True,True)) | bool }}"
   vars:
     action: "pull-aptly"
 - include: aptly-install-and-mirror.yml


### PR DESCRIPTION
If the repo is corrupted or anything wrong happened, we should
have a way to override the download from the external source
first.

This makes possible to have in the CI a variable named
DOWNLOAD_FIRST. If this variable is set to False (or similar),
it will skip the download.

Connected https://github.com/rcbops/u-suk-dev/issues/1351