### PR TITLE
Make aptly use the first key only

### DIFF
--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -21,7 +21,7 @@ aptly_clone_this_first:
 
 aptly_custom_gpg_key_file: "{{ artifacts_root_folder }}/aptly.private.key"
 aptly_custom_gpg_pubkey_file: "{{ artifacts_root_folder }}/aptly.public.key"
-aptly_custom_gpg_key_id: "{{ lookup('pipe','gpg ' ~ aptly_custom_gpg_pubkey_file ~ '| cut -f 2 -d \"/\" | cut -f 1 -d \" \" ') }}"
+aptly_custom_gpg_key_id: "{{ lookup('pipe','gpg ' ~ aptly_custom_gpg_pubkey_file ~ '| cut -f 2 -d \"/\" | cut -f 1 -d \" \" | head -n 1') }}"
 aptly_system_archive_gpg_keys_import: True
 aptly_user_home: "{{ artifacts_aptrepos_dest_folder }}"
 aptly_user: aptly


### PR DESCRIPTION
When multiple key ids are listed, just import the top one.

Aptly roles uses the aptly key id as basis to know if the key
needs to be imported or not.

We are using a var for that, and that var is dynamically fetching
the id from the key that is in the CI system.

That should be enough for now.

Connected https://github.com/rcbops/u-suk-dev/issues/1351