### PR TITLE
Update RPC-O GPG Key

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -223,7 +223,7 @@ rpco_mirror_apt_url: "{{ rpco_mirror_base_url }}/apt-mirror/integrated/"
 rpco_mirror_apt_filename: rpco
 rpco_gpg_key_location: "{{ rpco_mirror_base_url }}/apt-mirror/"
 rpco_gpg_key_name: "rcbops-release-signing-key.asc"
-rpco_gpg_key_id: 9EBBA735 #SET IN STATIC (to force key verification per release).
+rpco_gpg_key_id: 52AA252F #SET IN STATIC (to force key verification per release).
 
 # We won't be using the repo package cache, as we'll have a full mirror.
 repo_pkg_cache_enabled: no


### PR DESCRIPTION
A newly generated GPG key requires a new verification ID.

Process was the following:
- Generate new key (gpg v1 only!)
- Upload private/public key to CI
- Update the gpg_key_id for the update apt job
- Start apt job (override the existing artifacts with new keys).

Connected rcbops/u-suk-dev#1003