### PR TITLE
Resolve python artifact build failure

### DIFF
--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -28,6 +28,11 @@ cd /opt/rpc-openstack
 ./scripts/bootstrap-ansible.sh
 ./scripts/bootstrap-aio.sh
 
+# Remove the env.d configurations that set the build to use
+# container artifacts. We don't want this because container
+# artifacts are built using python artifacts.
+sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/env.d/*.yml
+
 # Set override vars for the artifact build
 echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -118,18 +118,25 @@
         src: "{{ rpco_cfg_src_path }}/{{ item.name }}"
         dest: "/etc/openstack_deploy/{{ item.name }}"
         mode: "{{ item.mode | default(omit) }}"
+      when: "{{ (item.condition | default(True)) | bool }}"
       with_items:
         - name: "user_osa_variables_defaults.yml"
           mode: "0440"
         - name: "user_rpco_variables_defaults.yml"
           mode: "0440"
         - name: "env.d/cinder.yml"
+        - name: "env.d/elasticsearch.yml"
+          condition: "{{ rpco_deploy_elk | bool }}"
         - name: "env.d/galera.yml"
         - name: "env.d/glance.yml"
         - name: "env.d/heat.yml"
         - name: "env.d/horizon.yml"
         - name: "env.d/ironic.yml"
         - name: "env.d/keystone.yml"
+        - name: "env.d/kibana.yml"
+          condition: "{{ rpco_deploy_elk | bool }}"
+        - name: "env.d/logstash.yml"
+          condition: "{{ rpco_deploy_elk | bool }}"
         - name: "env.d/magnum.yml"
         - name: "env.d/memcache.yml"
         - name: "env.d/neutron.yml"
@@ -159,12 +166,6 @@
               ceph_osd_container:
                 properties:
                   is_metal: false
-        - name: "env.d/elasticsearch.yml"
-          condition: "{{ rpco_deploy_elk | bool }}"
-        - name: "env.d/kibana.yml"
-          condition: "{{ rpco_deploy_elk | bool }}"
-        - name: "env.d/logstash.yml"
-          condition: "{{ rpco_deploy_elk | bool }}"
 
     - name: Update the RPC-O secrets
       shell: "{{ rpco_base_dir }}/scripts/update-secrets.sh"


### PR DESCRIPTION
This patch does two things:

1. Resolve a build failure due to the bootstrap-host
   role trying to interpret the ELK env.d files which
   have reference to rpc_release. It moved their
   placement into the copy task instead of the
   config_template task.

2. It removes the lxc_container_variant config entry
   from all the env.d files when building python
   artifacts to prevent a circular dependency. The
   container artifacts depend on the python artifacts
   so we can't use the container artifacts to deploy
   the containers used for building python artifacts.

Connects https://github.com/rcbops/u-suk-dev/issues/1360