### PR TITLE
Restrict Ubuntu updates for build/deploy

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -14,3 +14,15 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 1383d0db302c6fc400a50fae4f85e77bf1633581
+# Allow the Trusty backport repo addition to be disabled
+#   https://review.openstack.org/442592
+- name: lxc_hosts
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
+  version: 26b1ca68425d035728c7c129363962c8a4832238
+# Ensure that the tags are appropriate
+#   https://review.openstack.org/444408
+- name: pip_install
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-pip_install
+  version: dc91246e5c825227db1083fba39a3b405fabf6eb

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -228,6 +228,10 @@ rpco_gpg_key_id: 52AA252F #SET IN STATIC (to force key verification per release)
 # We won't be using the repo package cache, as we'll have a full mirror.
 repo_pkg_cache_enabled: no
 
+# We don't want the Trusty backports repo to be added because
+# all packages must come from our apt artifacts.
+lxc_package_repo_add: no
+
 # For convenience
 rpco_apt_repo:
   repo: "{{ rpco_mirror_apt_deb_line }}"

--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Configure the default apt sources for RPC-O
+  hosts: "{{ apt_target_group | default('hosts') }}"
+  user: root
+  tasks:
+
+    - name: Determine the existing Ubuntu repo configuration
+      shell: 'grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)" /etc/apt/sources.list'
+      register: _ubuntu_repo
+      when:
+        - host_ubuntu_repo is not defined
+      changed_when: false
+      delegate_to: "{{ physical_host | default(omit) }}"
+
+    - name: Replace the apt sources file with our content
+      copy:
+        content: |
+          # {{ ansible_managed }}
+
+          # Base repository
+          deb {{ host_ubuntu_repo | default(_ubuntu_repo.stdout_lines[0]) }} {{ ansible_distribution_release }} main universe
+        dest: "/etc/apt/sources.list"
+        backup: yes
+      tags:
+        - always
+

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -87,6 +87,15 @@ patch_all_roles
 
 # Run playbooks
 cd /opt/rpc-openstack/openstack-ansible/playbooks
+
+# The host must only have the base Ubuntu repository configured.
+# All updates (security and otherwise) must come from the RPC-O apt artifacting.
+# The host sources are modified to ensure that when the containers are prepared
+# they have our mirror included as the default. This happens because in the
+# lxc_hosts role the host apt sources are copied into the container cache.
+openstack-ansible ${RPCD_DIR}/playbooks/configure-apt-sources.yml -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu"
+
+# Setup the host
 openstack-ansible setup-hosts.yml --limit lxc_hosts,hosts
 
 # Move back to artifacts-building dir

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -48,8 +48,16 @@ echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifa
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 echo "repo_build_venv_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 
-# Setup the repo container and build the artifacts
+# Prepare to run the playbooks
 cd /opt/rpc-openstack/openstack-ansible/playbooks
+
+# The host must only have the base Ubuntu repository configured.
+# All updates (security and otherwise) must come from the RPC-O apt artifacting.
+# This is also being done to ensure that the python artifacts are built using
+# the same sources as the container artifacts will use.
+openstack-ansible ${RPCD_DIR}/playbooks/configure-apt-sources.yml -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu"
+
+# Setup the repo container and build the artifacts
 openstack-ansible setup-hosts.yml -e container_group=repo_all
 openstack-ansible repo-install.yml
 

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -36,6 +36,7 @@
 - name: Execute the OSA AIO bootstrap
   include: "{{ lookup('env', 'OA_DIR') }}/tests/bootstrap-aio.yml"
   vars:
+    bootstrap_host_apt_distribution_suffix_list: []
     scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -33,6 +33,16 @@ export ANSIBLE_ROLE_FETCH_MODE=${ANSIBLE_ROLE_FETCH_MODE:-galaxy}
 # Check the openstack-ansible submodule status
 check_submodule_status
 
+# The deployment host must only have the base Ubuntu repository configured.
+# All updates (security and otherwise) must come from the RPC-O apt artifacting.
+# This is being done via bash because Ansible is not bootstrapped yet, and the
+# apt artifacts used for bootstrapping Ansible must also come from the RPC-O
+# artifact repo.
+sed -i '/^deb-src /d' /etc/apt/sources.list
+sed -i '/-backports /d' /etc/apt/sources.list
+sed -i '/-security /d' /etc/apt/sources.list
+sed -i '/-updates /d' /etc/apt/sources.list
+
 # begin the bootstrap process
 pushd ${OA_DIR}
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -59,18 +59,6 @@ export DEPLOY_AIO="yes"
 export DEPLOY_ELK="no"
 export DEPLOY_RPC="no"
 
-# Allow container creation based on variant property
-#   https://github.com/rcbops/u-suk-dev/issues/1297
-pushd /etc/ansible/roles/lxc_container_create
-  git checkout stable/newton
-popd
-
-# Ability to set a different default variant
-#   https://github.com/rcbops/u-suk-dev/issues/1314
-pushd /etc/ansible/roles/lxc_hosts
-  git checkout stable/newton
-popd
-
 #
 # End: Temporary Hacks for artifacted deployment
 #
@@ -142,6 +130,10 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
 
   cd ${OA_DIR}/playbooks/
 
+  # The hosts must only have the base Ubuntu repository configured.
+  # All updates (security and otherwise) must come from the RPC-O apt artifacting.
+  run_ansible ${RPCD_DIR}/playbooks/configure-apt-sources.yml
+
   # NOTE(mhayden): V-38642 must be skipped when using an apt repository with
   # unsigned/untrusted packages.
   # NOTE(mhayden): V-38660 halts the playbook run when it finds SNMP v1/2
@@ -152,6 +144,15 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   else
     run_ansible setup-hosts.yml --skip-tags=V-38660
   fi
+
+  # The containers must only have the base Ubuntu repository configured.
+  # All updates (security and otherwise) must come from the RPC-O apt artifacting.
+  # The container artifacts will have mirror.rackspace.com configured as the source,
+  # but in a CDC there may be a local mirror that's used instead. This ensures that
+  # after the container is built it is reconfigured ot use that local mirror. If
+  # this is not done then the apt-get update tasks will fail when we try to deploy
+  # the services.
+  run_ansible ${RPCD_DIR}/playbooks/configure-apt-sources.yml -e apt_target_group=all_containers
 
   if [[ "$DEPLOY_CEPH" == "yes" ]]; then
     pushd ${RPCD_DIR}/playbooks/


### PR DESCRIPTION
For the deployment to be repeatable it is crucial that
the apt sources do not include -security, -updates,
-backports, etc. All this must be provided through the
source added for the apt artifacts repo. For the build
and deployment to match in packages used, the build must
also be restricted.

Hosts and containers must only be enabled for the
'trusty' / 'xenial' repository which should, by default,
use the rackspace mirror. This mirror should be
unchanging after the initial distribution release.

For deployments in CDC's or in other environments with
a local mirror, we detect the existing host repository
and use it for the deployment.

The pip-install bit is required to make the build pass.

Connects https://github.com/rcbops/u-suk-dev/issues/1310