### PR TITLE
Remove lxc artifact config from python build

### DIFF
--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -33,6 +33,16 @@ cd /opt/rpc-openstack
 # artifacts are built using python artifacts.
 sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/env.d/*.yml
 
+# Remove the RPC-O default configurations that are necessary
+# for deployment, but cause the build to break due to the fact
+# that they require the container artifacts to be available,
+# but those are not yet built.
+sed -i.bak '/lxc_image_cache_server: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_cache_default_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_cache_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+
 # Set override vars for the artifact build
 echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml


### PR DESCRIPTION
In the python artifact build we cannot use container
artifacts. They are created in the next step afterwards.
However the AIO bootstrap process puts configuration in
place to ensure that container artifacts are used when
doing production deployments.

This patch does a simple removal of those settings so
that the LXC default artifacts are used instead.

Connects https://github.com/rcbops/u-suk-dev/issues/1360