### PR TITLE
Do not rewrite apt sources when building apt artifacts

### DIFF
--- a/scripts/artifacts-building/apt/build-apt-artifacts.sh
+++ b/scripts/artifacts-building/apt/build-apt-artifacts.sh
@@ -33,6 +33,9 @@ export RPC_ARTIFACTS_FOLDER=${RPC_ARTIFACTS_FOLDER:-/var/www/artifacts}
 export RPC_ARTIFACTS_PUBLIC_FOLDER=${RPC_ARTIFACTS_PUBLIC_FOLDER:-/var/www/repo}
 export RPC_REPO_BRANCH=${RPC_REPO_BRANCH:-artifacts-14.0}
 
+# We do not want to rewrite the host apt sources when executing bootstrap-ansible
+export HOST_SOURCES_REWRITE="no"
+
 ## Main ----------------------------------------------------------------------
 
 if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -35,11 +35,17 @@ check_submodule_status
 
 # The deployment host must only have the base Ubuntu repository configured.
 # All updates (security and otherwise) must come from the RPC-O apt artifacting.
+#
 # This is being done via bash because Ansible is not bootstrapped yet, and the
 # apt artifacts used for bootstrapping Ansible must also come from the RPC-O
 # artifact repo.
-apt_sources_back_to_stock
-apt_sources_use_rpc_apt_artifacts
+#
+# This has the ability to be disabled for the purpose of reusing the
+# bootstrap-ansible script for putting together the apt artifacts.
+if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]]; then
+  apt_sources_back_to_stock
+  apt_sources_use_rpc_apt_artifacts
+fi
 
 # begin the bootstrap process
 pushd ${OA_DIR}

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -40,6 +40,7 @@ export RPCD_SECRETS='/etc/openstack_deploy/user_rpco_secrets.yml'
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-''}
 export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 
+export HOST_SOURCES_REWRITE=${HOST_SOURCES_REWRITE:-"yes"}
 export HOST_UBUNTU_REPO=${HOST_UBUNTU_REPO:-"http://mirror.rackspace.com/ubuntu"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com/apt-mirror"}
 


### PR DESCRIPTION
In order to build the apt artifacts we cannot use the
artifacts we're building. We need to use the standard
Ubuntu artifacts.

Connects https://github.com/rcbops/u-suk-dev/issues/1310