### PR TITLE
Prevent the timeout of build

### DIFF
--- a/scripts/artifacts-building/apt/aptly-snapshot-merge-and-publish.yml
+++ b/scripts/artifacts-building/apt/aptly-snapshot-merge-and-publish.yml
@@ -42,6 +42,18 @@
       register: aptly_snapshot_publish
       failed_when: aptly_snapshot_publish.rc != 0 and aptly_snapshot_publish.stderr.find('already used') == -1
       changed_when: aptly_snapshot_publish.stderr.find('already used') == -1
+      #This can run for maximum 23h.
+      async: 82800
+      poll: 0
+      tags:
+        - aptly_publish
+    # To avoid CI build timeouts, we want to make sure ansible outputs to
+    # the console regularily. We do this using an async_status task.
+    - name: Poll async status
+      async_status: jid={{ aptly_snapshot_publish.ansible_job_id }}
+      register: job_merged_snapshot_publish_result
+      until: job_merged_snapshot_publish_result.finished
+      retries: 16560
       tags:
         - aptly_publish
     - name: Publish snapshot into public folder (no merge)
@@ -50,5 +62,17 @@
       register: aptly_snapshot_nomerge_publish
       failed_when: aptly_snapshot_nomerge_publish.rc != 0 and aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
       changed_when: aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
+      #This can run for maximum 23h.
+      async: 82800
+      poll: 0
+      tags:
+        - aptly_publish
+    # To avoid CI build timeouts, we want to make sure ansible outputs to
+    # the console regularily. We do this using an async_status task.
+    - name: Poll async status
+      async_status: jid={{ aptly_snapshot_nomerge_publish.ansible_job_id }}
+      register: job_unmerged_snapshot_publish_result
+      until: job_unmerged_snapshot_publish_result.finished
+      retries: 16560
       tags:
         - aptly_publish


### PR DESCRIPTION
We need to report that something is happening during the build,
therefore we are using an async "fire and forget" job, and
regularily test if it's finished. The test should output the lines
we need to not timeout. When the task is finished, then we
can continue the play forward.

Connected https://github.com/rcbops/u-suk-dev/issues/1392