### PR TITLE
Remove async for unmerged snapshots

### DIFF
--- a/scripts/artifacts-building/apt/aptly-snapshot-merge-and-publish.yml
+++ b/scripts/artifacts-building/apt/aptly-snapshot-merge-and-publish.yml
@@ -60,19 +60,10 @@
       shell: 'aptly publish snapshot -distribution="{{ artifacts_version }}-{{ distribution_release }}" {{ item.src }} independant/{{ item.dest }}'
       with_items: "{{ aptly_n_mapping.get(distribution_release) }}"
       register: aptly_snapshot_nomerge_publish
+      failed_when: aptly_snapshot_nomerge_publish.rc != 0 and aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
+      changed_when: aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
       #This can run for maximum 23h.
       async: 82800
       poll: 0
-      tags:
-        - aptly_publish
-    # To avoid CI build timeouts, we want to make sure ansible outputs to
-    # the console regularily. We do this using an async_status task.
-    - name: Poll async status
-      async_status: jid={{ aptly_snapshot_nomerge_publish.ansible_job_id }}
-      register: job_unmerged_snapshot_publish_result
-      until: job_unmerged_snapshot_publish_result.finished
-      failed_when: job_unmerged_snapshot_publish_result.rc != 0 and job_unmerged_snapshot_publish_result.stderr.find('already used') == -1
-      changed_when: job_unmerged_snapshot_publish_result.stderr.find('already used') == -1
-      retries: 16560
       tags:
         - aptly_publish


### PR DESCRIPTION
They are faster and not worth the hassle.