### PR TITLE
Fix configure-apt-sources playbook

### DIFF
--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -26,13 +26,20 @@
       changed_when: false
       delegate_to: "{{ physical_host | default(omit) }}"
 
+    - name: Set host_ubuntu_repo fact
+      set_fact:
+        host_ubuntu_repo: "{{ _ubuntu_repo.stdout_lines[0] }}"
+      when:
+        - host_ubuntu_repo is not defined
+        - _ubuntu_repo.stdout_lines is defined
+
     - name: Replace the apt sources file with our content
       copy:
         content: |
           # {{ ansible_managed }}
 
           # Base repository
-          deb {{ host_ubuntu_repo | default(_ubuntu_repo.stdout_lines[0]) }} {{ ansible_distribution_release }} main universe
+          deb {{ host_ubuntu_repo }} {{ ansible_distribution_release }} main universe
         dest: "/etc/apt/sources.list"
         backup: yes
       tags:


### PR DESCRIPTION
The play fails due to an undefined default. This
resolves that.