### PR TITLE
Allow LXC install from the RPC-O artifacts

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -16,10 +16,11 @@
   version: 1383d0db302c6fc400a50fae4f85e77bf1633581
 # Allow the Trusty backport repo addition to be disabled
 #   https://review.openstack.org/442592
+#   https://review.openstack.org/445944
 - name: lxc_hosts
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
-  version: 26b1ca68425d035728c7c129363962c8a4832238
+  version: d61f4185b7759427cad96f0c1e19388dad55b761
 # Ensure that the tags are appropriate
 #   https://review.openstack.org/444408
 - name: pip_install


### PR DESCRIPTION
With the inclusion of https://review.openstack.org/445944
the LXC installation on Trusty will work when using the
RPC-O repository.

Connects https://github.com/rcbops/u-suk-dev/issues/1400