### PR TITLE
Fix async job

### DIFF
--- a/scripts/artifacts-building/apt/aptly-snapshot-merge-and-publish.yml
+++ b/scripts/artifacts-building/apt/aptly-snapshot-merge-and-publish.yml
@@ -32,7 +32,9 @@
     - name: Merge the snapshots together
       shell: "aptly snapshot merge {{ aptly_snapshot_merge_flags }} miko-{{ artifacts_version }}-{{ distribution_release }} {{ aptly_miko_mapping.get(distribution_release) | join(' ') }}"
       register: aptly_snapshot_merge_create
-      failed_when: aptly_snapshot_merge_create.rc != 0 and aptly_snapshot_merge_create.stderr.find('already exists') == -1
+      failed_when:
+        - aptly_snapshot_merge_create.rc != 0
+        - aptly_snapshot_merge_create.stderr.find('already exists') == -1
       changed_when: aptly_snapshot_merge_create.stderr.find('already exists') == -1
       tags:
         - aptly_snapshot_merge
@@ -45,13 +47,18 @@
       poll: 0
       tags:
         - aptly_publish
+    # let ansible a few seconds (Nyquist rate) to build the dict for the async job.
+    - command: sleep 10
     # To avoid CI build timeouts, we want to make sure ansible outputs to
     # the console regularily. We do this using an async_status task.
     - name: Poll async status
-      async_status: jid={{ aptly_snapshot_publish.ansible_job_id }}
+      async_status:
+        jid: "{{ aptly_snapshot_publish.ansible_job_id }}"
       register: job_merged_snapshot_publish_result
       until: job_merged_snapshot_publish_result.finished
-      failed_when: job_merged_snapshot_publish_result.rc != 0 and job_merged_snapshot_publish_result.stderr.find('already used') == -1
+      failed_when:
+        - job_merged_snapshot_publish_result.rc != 0
+        - job_merged_snapshot_publish_result.stderr.find('already used') == -1
       changed_when: job_merged_snapshot_publish_result.stderr.find('already used') == -1
       retries: 16560
       tags:
@@ -60,7 +67,9 @@
       shell: 'aptly publish snapshot -distribution="{{ artifacts_version }}-{{ distribution_release }}" {{ item.src }} independant/{{ item.dest }}'
       with_items: "{{ aptly_n_mapping.get(distribution_release) }}"
       register: aptly_snapshot_nomerge_publish
-      failed_when: aptly_snapshot_nomerge_publish.rc != 0 and aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
+      failed_when:
+        - aptly_snapshot_nomerge_publish.rc != 0
+        - aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
       changed_when: aptly_snapshot_nomerge_publish.stderr.find('already used') == -1
       tags:
         - aptly_publish


### PR DESCRIPTION
Ansible needs some time to build the job dict.
This ensures at least one period of time has passed before forcing
the review of results.