### PR TITLE
Add RPC-O apt source to LXC cache prep

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -232,6 +232,12 @@ repo_pkg_cache_enabled: no
 # all packages must come from our apt artifacts.
 lxc_package_repo_add: no
 
+# We need to ensure that the RPC-O repo containing apt
+# artifacts is included in the LXC container prep.
+lxc_container_cache_files:
+  - src: "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"
+    dest: "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"
+
 # For convenience
 rpco_apt_repo:
   repo: "{{ rpco_mirror_apt_deb_line }}"


### PR DESCRIPTION
In order to ensure that the LXC cache prep process
can use the RPC-O apt repo the corresponding sources
file needs to be in the list of files to copy into
the cache before it installs any packages.

Connects https://github.com/rcbops/u-suk-dev/issues/1400