### PR TITLE
Reduce LXC cache prep package list

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -238,6 +238,17 @@ lxc_container_cache_files:
   - src: "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"
     dest: "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"
 
+# The default Trusty set in OSA is very large, unnecessary,
+# and causes the image cache prep to fail due to package conflicts.
+lxc_cache_distro_packages:
+  - apt-transport-https
+  - ca-certificates
+  - iptables
+  - openssh-server
+  - python2.7
+  - systemd-shim
+  - time
+
 # For convenience
 rpco_apt_repo:
   repo: "{{ rpco_mirror_apt_deb_line }}"


### PR DESCRIPTION
For the LXC cache prep process to work using
the RPC-O apt artifacts we need to reduce the
packages installed into it to be a smaller
list. This reduces conflicts and produces
leaner cache images.

Connects https://github.com/rcbops/u-suk-dev/issues/1400