### PR TITLE
Add RPC-O roles to Ansible role search path

### DIFF
--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -72,4 +72,8 @@ pushd ${OA_DIR}
     exit 99
   fi
 
+  # RPC-O has roles in its own git tree, so we need to add it to the
+  # path for Ansible to search.
+  sed -i "s|/etc/ansible/roles:roles|/etc/ansible/roles:roles:${RPCD_DIR}/playbooks/roles|" /usr/local/bin/openstack-ansible.rc
+
 popd


### PR DESCRIPTION
In order to ensure that the RPC-O roles are always available
to Ansible, the path for roles in the git tree are added to
the search path.

Connects https://github.com/rcbops/u-suk-dev/issues/1404