### PR TITLE
Refactor aptly to use env vars

### DIFF
--- a/scripts/artifacts-building/apt/aptly-all.yml
+++ b/scripts/artifacts-building/apt/aptly-all.yml
@@ -23,21 +23,24 @@
 - include: aptly-install-and-mirror.yml
   vars:
     aptly_mirror_do_updates: "True"
+# The behavior is changed if RECREATE_SNAPSHOTS is true.
 - include: aptly-snapshot-create.yml
   vars:
-    distribution_release: "trusty"
-- include: aptly-snapshot-create.yml
+    distribution_release: "{{ item }}"
+  with_items:
+    - trusty
+    - xenial
+- include: aptly-snapshot-publish.yml
+  when: "{{ (lookup('ENV','PUBLISH_SNAPSHOT') | default(True,True)) | bool }}"
   vars:
-    distribution_release: "xenial"
-- include: aptly-snapshot-merge-and-publish.yml
-  vars:
-    distribution_release: "trusty"
-- include: aptly-snapshot-merge-and-publish.yml
-  vars:
-    distribution_release: "xenial"
+    distribution_release: "{{ item }}"
+  with_items:
+    - trusty
+    - xenial
 - include: sync-with-mirror.yml
+  when: "{{ (lookup('ENV','PUSH_TO_MIRROR') | default(True,True)) | bool }}"
   vars:
-    action: "push-aptly"
-- include: sync-with-mirror.yml
-  vars:
-    action: "push-gpg"
+    action: "{{ item }}"
+  with_items:
+    - push-aptly
+    - push-gpg

--- a/scripts/artifacts-building/apt/aptly-snapshot-create.yml
+++ b/scripts/artifacts-building/apt/aptly-snapshot-create.yml
@@ -83,3 +83,13 @@
     - name: Output the full list of tuples distribution/artifact version
       debug:
         msg: "Full list of snapshots for this distribution/artifact version: {{ aptly_snapshot_list.stdout_lines }}"
+    - name: Merge the snapshots together
+      shell: "aptly snapshot merge {{ aptly_snapshot_merge_flags }} miko-{{ artifacts_version }}-{{ distribution_release }} {{ aptly_miko_mapping.get(distribution_release) | join(' ') }}"
+      register: aptly_snapshot_merge_create
+      failed_when:
+        - aptly_snapshot_merge_create.rc != 0
+        - aptly_snapshot_merge_create.stderr.find('already exists') == -1
+      changed_when: aptly_snapshot_merge_create.stderr.find('already exists') == -1
+      tags:
+        - aptly_snapshot_merge
+        - aptly_snapshot

--- a/scripts/artifacts-building/apt/aptly-snapshot-publish.yml
+++ b/scripts/artifacts-building/apt/aptly-snapshot-publish.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Publish Aptly Mirror
+- name: Publish Aptly Snapshots
   hosts: localhost
   connection: local
   gather_facts: no
@@ -29,16 +29,6 @@
           - artifacts_version is defined
           - distribution_release is defined
         msg: You need to define what you are releasing!
-    - name: Merge the snapshots together
-      shell: "aptly snapshot merge {{ aptly_snapshot_merge_flags }} miko-{{ artifacts_version }}-{{ distribution_release }} {{ aptly_miko_mapping.get(distribution_release) | join(' ') }}"
-      register: aptly_snapshot_merge_create
-      failed_when:
-        - aptly_snapshot_merge_create.rc != 0
-        - aptly_snapshot_merge_create.stderr.find('already exists') == -1
-      changed_when: aptly_snapshot_merge_create.stderr.find('already exists') == -1
-      tags:
-        - aptly_snapshot_merge
-        - aptly_snapshot
     - name: Publish snapshot into public/integrated/ folder
       shell: 'aptly publish snapshot -distribution="{{ artifacts_version }}-{{ distribution_release }}" miko-{{ artifacts_version }}-{{ distribution_release }} integrated'
       register: aptly_snapshot_publish


### PR DESCRIPTION
This would make possible in CI system to trigger parts of the
process, depending on the need. The default is to run everything.

The idea is we could have a functional test that downloads,
updates repositories, create snapshots, publish them locally
on a throwaway node to exercice the building process, and
not push at the end of the process to rpc-repo.