### PR TITLE
do final deploy tweaks for artifacts

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -35,3 +35,15 @@
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-repo_build
   version: c53992c81b97a66da765f1757d699a64d7b880ef
+# Ensure that the log folder exists
+#   https://review.openstack.org/443061
+- name: os_keystone
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-os_keystone
+  version: 1210ef99af69119f2b8860548afb3247f1527666
+# Ensure the log folder exists
+#   https://review.openstack.org/443276
+- name: os_horizon
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-os_horizon
+  version: 1e5c7ae77c223647d3a41d5f0599115bee592d16

--- a/rpcd/etc/openstack_deploy/env.d/horizon.yml
+++ b/rpcd/etc/openstack_deploy/env.d/horizon.yml
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(odyssey4me):
-# Remove this remark once the following work is complete:
-#   https://github.com/rcbops/u-suk-dev/issues/1334
-#container_skel:
-#  horizon_container:
-#    properties:
-#      service_name: horizon
-#      lxc_container_variant: "horizon-{{ rpc_release }}"
+container_skel:
+  horizon_container:
+    properties:
+      service_name: horizon
+      lxc_container_variant: "horizon-{{ rpc_release }}"

--- a/rpcd/etc/openstack_deploy/env.d/keystone.yml
+++ b/rpcd/etc/openstack_deploy/env.d/keystone.yml
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(odyssey4me):
-# Remove this remark once the following work is complete:
-#  https://github.com/rcbops/u-suk-dev/issues/1332
-#container_skel:
-#  keystone_container:
-#    properties:
-#      service_name: keystone
-#      lxc_container_variant: "keystone-{{ rpc_release }}"
+container_skel:
+  keystone_container:
+    properties:
+      service_name: keystone
+      lxc_container_variant: "keystone-{{ rpc_release }}"

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -40,6 +40,7 @@
     scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"
+    uca_enable: no
     confd_overrides:
       swift:
         - name: cinder.yml.aio

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,31 +38,8 @@ fi
 # Check the openstack-ansible submodule status
 check_submodule_status
 
-#################################################
-#
-# Begin: Temporary Hacks for artifacted deployment
-#
-
-# Ensure that we're using git checkouts instead of
-# the ansible-galaxy download.
-export ANSIBLE_ROLE_FETCH_MODE="git-clone"
-
 # Bootstrap Ansible
 source "$(dirname "${0}")/bootstrap-ansible.sh"
-
-# As the current testing is AIO only, and skips the
-# RPC-O bits in order to keep things simple. We will
-# enable those bits later once we've got a working
-# base OSA deployment.
-
-export DEPLOY_AIO="yes"
-export DEPLOY_ELK="no"
-export DEPLOY_RPC="no"
-
-#
-# End: Temporary Hacks for artifacted deployment
-#
-#################################################
 
 # bootstrap the AIO
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then


### PR DESCRIPTION
We already clean up the apt sources when bootstrapping
Ansible, then setup our own apt repo. We don't want UCA
to interfere with our packages.

Connects https://github.com/rcbops/u-suk-dev/issues/1405

The keystone/horizon container artifacts now
work with the updated roles. Ensure that the
roles used are updated and use the artifacts
again.

Connects https://github.com/rcbops/u-suk-dev/issues/1334
Connects https://github.com/rcbops/u-suk-dev/issues/1332
Connects https://github.com/rcbops/u-suk-dev/issues/1378

Return ELK/RPC execution to deploy.sh
These were disabled temporarily for testing purposes.
It's time to return them back to the deployment
process.