### PR TITLE
[WIP] Add lxc to all hosts

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -506,6 +506,7 @@ maas_apt_packages:
 #
 maas_requires_pip_packages:
   - virtualenv
+  - lxc-python2
 
 #
 # maas_pip_packages: These packages are installed inside the virtualenv.


### PR DESCRIPTION
This will add the lxc package to all of the hosts, because some of
the checks require lxc package.

Connects rcbops/rpc-openstack#2026