### PR TITLE
Bump version of reno to 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,12 @@ matrix:
       env: TOXENV=release-script
 
 sudo: false
+
+# By default travis clones the rpc-openstack repo
+# with --depth set to 50. However, reno typically
+# needs more (or all) of the history to properly
+# traverse the commit history and generate release
+# notes. Setting depth here to something
+# OVER 9000!!!!!
+git:
+  depth: 9001

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,17 +7,10 @@ mccabe==0.2.1 # capped for flake8
 bashate>=0.2 # Apache-2.0
 
 
-# this is required for the docs build jobs
+# This is required for the docs build jobs
 sphinx>=1.3.4
 oslosphinx>=2.5.0 # Apache-2.0
-# TODO (alextricity25)
-# We need to investigate reno > 2.0.0
-# and why it isn't working with our
-# repository. This pin should not be
-# removed until then.
-# See:
-# https://github.com/rcbops/u-suk-dev/issues/687
-reno==1.9.0 #Apache-2.0
+reno==2.2.0 # Apache-2.0. Latest version as of 03-20-2017
 sphinx_rtd_theme>=0.1.9
 
 # release.py testing


### PR DESCRIPTION
We need to include some fixes that were made into the reno
code base in order for RPCO to start utilizing reno. This
commit bumps the version to the latest as of March 20th, 2017.

Connects https://github.com/rcbops/u-suk-dev/issues/1421