### PR TITLE
[WIP] Installs sos report tooling on physical hosts

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/defaults/main.yml
@@ -93,3 +93,11 @@ magnum_kubectl_version: 'v1.5.3'
 magnum_kubectl_url: 'https://storage.googleapis.com/kubernetes-release/release/{{ magnum_kubectl_version }}/bin/linux/amd64/kubectl'
 magnum_carina_version: 'v2.1.3'
 magnum_carina_url: 'https://download.getcarina.com/carina/{{ magnum_carina_version }}/Linux/x86_64/carina'
+
+sos_git_repo: https://github.com/rcbops/sos.git
+sos_git_install_branch: "master"
+sos_git_dest: "/opt/sos"
+sos_packages:
+  - gettext
+sos_pip_dependencies:
+  - six

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -101,3 +101,7 @@
 
 - include: create_default_flavors.yml
   when:  inventory_hostname == groups['utility'][0]
+
+- include: sos.yml
+  when:
+    - inventory_hostname in groups['hosts']

--- a/rpcd/playbooks/roles/rpc_support/tasks/sos.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/sos.yml
@@ -1,0 +1,48 @@
+---
+
+- name: Install packages required by sos
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 600
+  with_items: "{{ sos_packages }}"
+  when: sos_packages is defined
+
+- name: Install sos pip dependencies
+  pip:
+    name: "{{ item }}"
+    state: latest
+    extra_args: "{{ pip_install_options|default('') }}"
+  with_items: "{{ sos_pip_dependencies }}"
+  when: sos_pip_dependencies is defined
+  register: pip_install
+  until: pip_install|success
+  retries: 3
+
+- name: Get sos package from git
+  git:
+    repo: "{{ sos_git_repo }}"
+    dest: "{{ sos_git_dest }}"
+    version: "{{ sos_git_install_branch }}"
+  register: git_clone
+  ignore_errors: yes
+  until: git_clone|success
+  retries: 5
+
+- name: Install sos binary
+  pip:
+    name: "{{ sos_git_dest }}"
+    state: latest
+    extra_args: "{{ pip_install_options|default('') }}"
+  register: pip_install
+  until: pip_install|success
+  retries: 5
+  async: 1800
+  delay: 5
+  poll: 5
+
+- name: Copy sos.conf to physical host
+  template:
+    src: sos.conf.j2
+    dest: /etc/sos.conf

--- a/rpcd/playbooks/roles/rpc_support/templates/sos.conf.j2
+++ b/rpcd/playbooks/roles/rpc_support/templates/sos.conf.j2
@@ -1,0 +1,8 @@
+[plugins]
+
+#disable = rpm, selinux, dovecot
+
+[tunables]
+
+#rpm.rpmva = off
+#general.syslogsize = 15


### PR DESCRIPTION
Currently uses forked rcbops/sos repo that includes
openstack-ansible plugins until we can get it merged
upstream.

Installs source into /opt/sos.

Connects rcbops/u-suk-dev#1422

Using generic sos.conf file for now, would like to get feedback on if any need to be disabled by default.