### PR TITLE
Add newton-14.0 to toxtree and sphinx template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ language: python
 before_script:
 - pip install 'tox!=2.4.0,>=2.3'
 
+# By default travis clones the rpc-openstack repo
+# with --depth set to 50, creating a shallow clone. 
+# However, reno typically needs more (or all) of the
+# history to properly traverse the commit history
+# and generate release notes. This section deletes
+# the shallow clone that travis creates, then clones
+# the full repository
+install:
+  - git clone --recursive https://github.com/rcbops/rpc-openstack.git rcbops/rpc-openstack
+  - cd rcbops/rpc-openstack
+
 script: tox
 
 # Send notifications to #rpc-github in Slack
@@ -27,12 +38,3 @@ matrix:
       env: TOXENV=release-script
 
 sudo: false
-
-# By default travis clones the rpc-openstack repo
-# with --depth set to 50. However, reno typically
-# needs more (or all) of the history to properly
-# traverse the commit history and generate release
-# notes. Setting depth here to something
-# OVER 9000!!!!!
-git:
-  depth: 9001

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,3 @@
+---
+release_tag_re: '^r\d+\.\d+\.\d+(rc\d+)?'
+pre_release_tag_re: '(?P<pre_release>rc\d+$)'

--- a/releasenotes/notes/releasenotes-a800a042ad4e67cf.yaml
+++ b/releasenotes/notes/releasenotes-a800a042ad4e67cf.yaml
@@ -1,0 +1,6 @@
+---
+prelude: >
+    Reno release notes will now be provided as of newton-14.1!
+features:
+  - |
+    Reno release notes will now be provided as of newton-14.1!

--- a/releasenotes/source/index.rst
+++ b/releasenotes/source/index.rst
@@ -10,5 +10,5 @@ Series Release Notes
 
 .. toctree::
    :maxdepth: 1
-
-   unreleased
+   
+   newton-14.0

--- a/releasenotes/source/newton-14.0.rst
+++ b/releasenotes/source/newton-14.0.rst
@@ -3,3 +3,4 @@
 ==============================
 
 .. release-notes:: Release Notes
+    :branch: origin/newton-14.0


### PR DESCRIPTION
I hope I worded that right. Anywho, newton-14.0 has been added
into the source directory, so that sphinx will now build release
notes for the latest release, newton-14.0.

NOTE: The newton-14.0 reno release notes shouldn't be taken that
seriously, since we have not been diligent to create a release
file for most of the work done in newton-14.0. Reno releasenotes
should only be relied on for versions newton-14.1 and greater

An additional step is added into .travis.yml so that the
rpc-openstack clone is converted to an unshallow clone. This is
is reno can traverse all the needed refs in order for it to
function.

Connects https://github.com/rcbops/u-suk-dev/issues/216