### PR TITLE
Bump keepalived role

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -14,3 +14,7 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 1383d0db302c6fc400a50fae4f85e77bf1633581
+- name: keepalived
+  scm: git
+  src: https://github.com/evrardjp/ansible-keepalived
+  version: 2.6.0


### PR DESCRIPTION
The keepalived role prior to version 2.6.0 is defect in how it
configured keepalived to execute the VRRP check scripts, leading
to undefined results or in worst case failing keepalived instances.
This change increases the version required for this product to 2.6.0

connects #2037