### PR TITLE
Downgrade LXC cache packages when necessary

### DIFF
--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -48,6 +48,7 @@ sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_d
 echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 echo "repo_build_venv_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
+cp scripts/artifacts-building/user_rcbops_artifacts_building.yml /etc/openstack_deploy/
 
 # Prepare to run the playbooks
 cd /opt/rpc-openstack/openstack-ansible/playbooks

--- a/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+++ b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
@@ -31,3 +31,66 @@ openstack_repo_url: "{{ rpco_mirror_base_url }}"
 # default variant.
 lxc_image_cache_server: images.linuxcontainers.org
 
+# When we build python/container artifacts we pull the default LXC cache
+# variant from LXC upstream which may have packages installed which are more
+# recent than those we have available in our artifacted apt repository. Here
+# we figure out which packages are installed, but not available in a
+# configured source, then we downgrade them to the latest available in the
+# configured sources.
+#
+# By way of reference, typically the output of 'apt list --installed' will
+# produce output such as the following:
+#
+# adduser/trusty,now 3.113+nmu3ubuntu3 all [installed]
+# ca-certificates/r14.0.0rc1-trusty,now 20160104ubuntu0.14.04.1 all [installed]
+# libc6/now 2.19-0ubuntu6.11 amd64 [installed,local]
+# libglib2.0-0/r14.0.0rc1-trusty,now 2.40.2-0ubuntu1 amd64 [installed,automatic]
+#
+# The format of the output is the following:
+# <package name>/<list of dist sources> <version> <arch> <flags>
+#
+# If a package is flagged as 'installed' and 'local' then it indicates that
+# the package has been installed from an apt source which is not currently
+# configured. These are the packages which need to be downgraded to a version
+# in an available apt source.
+#
+lxc_cache_prep_pre_commands: |
+    # If there is a configured resolver, save it.
+    if [ -a /etc/resolv.conf ]; then
+      mv /etc/resolv.conf /etc/resolv.conf.org
+    fi
+    # Use the LXC host's dnsmasq service as a resolver
+    echo "nameserver {{ lxc_net_address | default('10.0.3.1') }}" > /etc/resolv.conf
+    # Add the host's repository keys, including the RPC-O keys
+    apt-key add /root/repo.keys
+    # Update the apt cache
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    # Check whether there are any installed packages which
+    # are not available in a configured source.
+    if apt list --installed 2>/dev/null | egrep '\[.*local.*\]'; then
+      # Create a list of those packages.
+      pkg_downgrade_list=$(apt list --installed 2>/dev/null | egrep '\[.*local.*\]' | cut -d/ -f1)
+      # Work through the list, checking for the latest available version of
+      # each package in the configured sources. Put together a list of the
+      # packages and their versions in the format that 'apt-get install'
+      # expects it.
+      pkg_downgrade_list_versioned=""
+      for pkg_name in ${pkg_downgrade_list}; do
+        # 'apt-cache madison' provides an easy to parse format:
+        #   libc-bin | 2.19-0ubuntu6.9 | http://rpc-repo.rackspace.com/apt-mirror/integrated/ r14.0.0rc1-trusty/main amd64 Packages
+        #   libc-bin | 2.19-0ubuntu6 | http://mirror.rackspace.com/ubuntu/ trusty/main amd64 Packages
+        # The top entry is always the latest package available from a configured source.
+        pkg_version=$(apt-cache madison ${pkg_name} | head -n 1 | awk '{ print $3 }')
+        pkg_downgrade_list_versioned="${pkg_downgrade_list_versioned} ${pkg_name}=${pkg_version}"
+      done
+      # Execute the downgrade of all the packages at the same time so that
+      # we reduce the likelihood of conflicts.
+      apt-get install -y --force-yes ${pkg_downgrade_list_versioned}
+    fi
+    # Return the resolver to its previous state.
+    if [ -a /etc/resolv.conf.org ]; then
+      mv /etc/resolv.conf.org /etc/resolv.conf
+    else
+      rm -f /etc/resolv.conf
+    fi


### PR DESCRIPTION
When we build python/container artifacts we pull the default
LXC cache variant from LXC upstream which may have packages
installed which are more recent than those we have available
in our artifacted apt repository. Here we figure out which
packages are installed, but not available in a configured
source, then we downgrade them to the latest available in
the configured sources.

Connects https://github.com/rcbops/u-suk-dev/issues/1449