### PR TITLE
Ensure that the apt cache is refreshed

### DIFF
--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -38,6 +38,16 @@
         src: configure-apt-sources.j2
         dest: "/etc/apt/sources.list"
         backup: yes
+      register: apt_sources_configure
+      tags:
+        - always
+
+    - name: Update apt-cache
+      apt:
+        update_cache: yes
+      when:
+        - apt_sources_configure is defined
+        - apt_sources_configure | changed
       tags:
         - always
 


### PR DESCRIPTION
When the sources are changed, the apt cache must be refreshed.
If this is not done, apt's cache is stale and package installs
fail.

Connects https://github.com/rcbops/u-suk-dev/issues/1449