### PR TITLE
Remove logstash log from filebeat

### DIFF
--- a/releasenotes/notes/remove-logstash-from-filebeat-dd09be25d7f1c37f.yaml
+++ b/releasenotes/notes/remove-logstash-from-filebeat-dd09be25d7f1c37f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - Having logstash process it's own log can lead to a "feedback" loop
+    wherein an error that is logged into the logstash log will be
+    re-logged ad-infinitum, eventually filling the disk and crashing
+    logstash. This removes the filebeat shipping of the logstash.log
+    file to logstash.

--- a/rpcd/playbooks/roles/filebeat/defaults/main.yml
+++ b/rpcd/playbooks/roles/filebeat/defaults/main.yml
@@ -292,12 +292,6 @@ filebeat_logging_paths:
     - infrastructure
     - logging
   - paths:
-    - '/var/log/logstash/*.log'
-    tags:
-    - logstash
-    - infrastructure
-    - logging
-  - paths:
     - '/var/log/ceph/ceph-mon.*.log'
     multiline:
       pattern: '^[a-z_]* '


### PR DESCRIPTION
Having logstash process it's own log can lead to a "feedback" loop
wherein an error that is logged into the logstash log will be
re-logged ad-infinitum, eventually filling the disk and crashing
logstash.  This removes the filebeat shipping of the logstash.log
file to logstash.

connects #2064