### PR TITLE
Updating release.py

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,6 +37,7 @@
      ```
     git push REMOTE --delete OLD_BRANCH
     ```
+- [ ] Edit the rpc_release version number in ```rpcd/playbooks/group_vars/all.yml``` and ```rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml```, commit, and push. This is to prepare next development cycle.
 - [ ] If creating or deleting a branch, update the [issue template](https://github.com/rcbops/rpc-openstack/blob/master/.github/ISSUE_TEMPLATE.md) to include it in the list.
 - [ ] Update the [GitHub release notes](https://github.com/rcbops/rpc-openstack/releases) with output from rpc-differ, remember to tick pre-release if the tag is for a release candidate.
 
@@ -68,7 +69,7 @@ If your environment variables contain RPC_GITHUB_TOKEN, you can even run it like
 ```
 
 ## Other versions
-The guess work currently done for patch and rc>1 isn't applicable for other versions.
+The calculation of next tag currently only work for patch and rc>1.
 In certain cases, you'll want to specify the version number that will be used
 for the next development cycle (Remember you'd still need to be in the proper branch)
 You may issue this:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ If your environment variables contain RPC_GITHUB_TOKEN, you can even run it like
 ```
 
 ## Other versions
-The calculation of next tag currently only work for patch and rc>1.
+The calculation of next tag currently only work for patch releases and rc>1.
 In certain cases, you'll want to specify the version number that will be used
 for the next development cycle (Remember you'd still need to be in the proper branch)
 You may issue this:
@@ -88,6 +88,12 @@ branch still needs to be created on the remote beforehand.
 
 On top of it, if you want to skip certain parts of the workflow, you can use
 the --do-not-<worfklow part> in the CLI to skip them.
+
+The workflow parts are:
+* --do-not-publish-release: Do not publish a github release for this tag
+* --do-not-update-milestones: Do not update github milestones
+* --do-not-file-docs-issue: Do not create a docs issue for this release
+  --do-not-change-files-with-release-version: Do not update code intree.
 
 Example:
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,20 +51,55 @@
 # Using the release script
 
 The python script ``release.py`` in the scripts directory can be used to automate
-the release process for patch releases and release candidates after the first one has
-been made.
+the release process as long as the branch to release already exists.
 
-To release a patch release or a release candidate after rc1, run the ``release.py``
-script like so:
+To use it, please first install the script dependencies listed in test-requirements.
+
+## Patch releases or rc>1
+To release a patch release or a release candidate after rc1, first ensure you're
+checked out in the proper branch, and then run the release.py script like so:
 ```
-./release.py --github-token <YOUR-TOKEN> --tag <TAG> --commit <COMMIT>
+./release.py --github-token YOUR_TOKEN --tag <TAG> --commit <COMMIT>
 ```
 
+If your environment variables contain RPC_GITHUB_TOKEN, you can even run it like
+```
+./release.py --tag <TAG> --commit <COMMIT>
+```
+
+## Other versions
+The guess work currently done for patch and rc>1 isn't applicable for other versions.
+In certain cases, you'll want to specify the version number that will be used
+for the next development cycle (Remember you'd still need to be in the proper branch)
+You may issue this:
+
+```
+./release.py --tag <TAG> --commit <COMMIT> --future-tag <FUTURE_TAG>
+```
+
+You could also use the --branch argument (experimental!) to force the checkout of
+a branch, instead of using the current branch name.
+```
+./release.py --tag <TAG> --commit <COMMIT> --future-tag <FUTURE_TAG> --branch <BRANCH>
+```
+Like before, this branch will be checked out from the origin repo, therefore the
+branch still needs to be created on the remote beforehand.
+
+On top of it, if you want to skip certain parts of the workflow, you can use
+the --do-not-<worfklow part> in the CLI to skip them.
+
+Example:
+```
+./release.py --tag <TAG> --commit <COMMIT> --future-tag <FUTURE_TAG> --branch <BRANCH> --do-not-change-files-with-release-version --do-not-file-docs-issue
+```
+
+
+## Test before using it
 To test the ``release.py`` script, override the repo URLs so the tag and the release
 is not created in the offical repository, but rather a forked version of it.
 For example:
 ```
-./release.py --github-token YOUR_TOKEN --tag TAG --commit COMMIT \
-    --repo-url 'ssh://git@github.com/git-harry/rpc-openstack.git' \
-    --docs-repo-url 'ssh://git@github.com/git-harry/docs-rpc.git'
+./release.py --github-token YOUR_TOKEN --tag TAG --commit COMMIT --future-tag NTAG \
+    --repo-url 'ssh://git@github.com/alextricity25/rpc-openstack.git' \
+    --docs-repo-url 'ssh://git@github.com/alextricity25/docs-rpc.git'
 ```

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -240,11 +240,12 @@ class Release(object):
         return self.release_date + datetime.timedelta(days=14)
 
     def _generate_release_diff(self):
+        print("Generating release diff...")
         diff = sh.rpc_differ(self.tag.previous,
                              self.tag,
                              "--rpc-repo-url", self.repo.url,
                              update=True
-                            ).stdout
+                             ).stdout
         return sh.pandoc(
             '--from', 'rst',
             '--to', 'markdown_github',
@@ -542,8 +543,10 @@ def main():
 
     if not args.existing_release:
         if not args.do_not_publish_release:
+            print("Publishing github release...")
             release.publish_release()
         if not args.do_not_update_milestones:
+            print("Updating github milestones...")
             release.update_milestones()
 
     if (not args.do_not_file_docs_issue and

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -612,7 +612,7 @@ def main():
             not release.pre_release):
         docs_repo = Repo(url=args.docs_repo_url, cache_dir=args.cache_dir,
                          bare=False)
-        request_doc_update(token, docs_repo, release)
+        request_doc_update(args.github_token, docs_repo, release)
 
     if not args.do_not_change_files_with_release_version:
         logging.info("The new dev cycle for branch {} will be: {}"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -22,6 +22,7 @@ import re
 import sys
 import yaml
 import logging
+import shutil
 
 import github3
 import sh
@@ -528,9 +529,6 @@ def validate_args(args):
     '''
     # Store tag as a string on top of as a tag object
     args.tag_str = str(args.tag)
-    # Future_tag must be str or None
-    if args.future_tag:
-        args.future_tag_str = str(args.future_tag)
     # args.branch is always a string, discovered or not
     if not args.branch:
         branches = (b.strip() for b in
@@ -553,7 +551,7 @@ def validate_args(args):
         chk_state = args.rpc_version_check
     else:
         chk_state = os.environ.get('RPC_VERSION_CHECK', 'yes')
-    args.version_check = True if chk_state == 'yes' else False
+    args.version_check = True if chk_state != 'no' else False
     return args
 
 
@@ -579,7 +577,7 @@ def main():
 
     # Instantiate a repo.
     if args.delete_cache_dir:
-        sh.rm(args.cache_dir, '-rf')
+        shutil.rmtree(args.cache_dir, ignore_errors=True)
     rpco_repo = Repo(url=args.repo_url, cache_dir=args.cache_dir, bare=False)
 
     if args.version_check:
@@ -614,7 +612,7 @@ def main():
         logging.info("The new dev cycle for branch {} will be: {}"
                      .format(args.branch, release.next_release))
         update_repo_with_new_ver_number(rpco_repo, args.branch,
-                                        args.future_tag_str)
+                                        str(release.next_release))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -450,6 +450,13 @@ def main():
     if proceed != 'YES':
         return
 
+    if args.github_token
+        token = args.github_token
+    elif os.environ['RPC_GITHUB_TOKEN']:
+        token = os.environ['RPC_GITHUB_TOKEN']
+    else:
+        return
+
     rpco_repo = Repo(url=args.repo_url, cache_dir=args.cache_dir, bare=True)
 
     if args.existing_release:
@@ -460,7 +467,7 @@ def main():
             tag_str=str(args.tag), commit=args.commit, message=tag_message
         )
 
-    release = Release(rpco_tag, github_token=args.github_token)
+    release = Release(rpco_tag, github_token=token)
 
     if not args.existing_release:
         release.publish_release()
@@ -468,7 +475,7 @@ def main():
     if not release.pre_release:
         docs_repo = Repo(url=args.docs_repo_url, cache_dir=args.cache_dir,
                          bare=False)
-        request_doc_update(args.github_token, docs_repo, release)
+        request_doc_update(token, docs_repo, release)
 
 
 if __name__ == '__main__':

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -293,12 +293,8 @@ class Release(object):
                 )
             else:
                 raise
-        else:
-            if not milestone_rc:
-                raise Exception(
-                    'None object Returned (Probably a 404 due to auth issues)',
-                    'cannot create milestone'
-                )
+        if not milestone_rc:
+            raise SystemExit("Milestone was not created")
         for milestone in self.gh.milestones():
             if milestone.title == self.tag:
                 milestone.update(state='closed')

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -242,7 +242,7 @@ class Release(object):
         return self.release_date + datetime.timedelta(days=14)
 
     def _generate_release_diff(self):
-        logging.info("Generating release diff...")
+        logging.warning("Generating release diff...")
         diff = sh.rpc_differ(self.tag.previous,
                              self.tag,
                              "--rpc-repo-url", self.repo.url,
@@ -313,7 +313,7 @@ def chk_devel_version(repo, branch, expected_release):
         current_release = yaml.load(content)['rpc_release']
         version_check = os.getenv('RPC_VERSION_CHECK', True)
         if (current_release != expected_release and
-                version_check not in [ 'False', 'no', 'FALSE' ]):
+                version_check not in ['False', 'no', 'FALSE', 'NO']):
             raise Exception('{} in {} does not match expected version {}'
                             .format(current_release, filename,
                                     expected_release))
@@ -573,10 +573,10 @@ def main():
 
     if not args.existing_release:
         if not args.do_not_publish_release:
-            logging.info("Publishing github release...")
+            logging.warning("Publishing github release...")
             release.publish_release()
         if not args.do_not_update_milestones:
-            logging.info("Updating github milestones...")
+            logging.warning("Updating github milestones...")
             release.update_milestones(next_version=future_tag)
 
     if (not args.do_not_file_docs_issue and
@@ -586,8 +586,8 @@ def main():
         request_doc_update(token, docs_repo, release)
 
     if not args.do_not_change_files_with_release_version:
-        logging.info("The new dev cycle for branch {} will be: {}"
-                     .format(branch, str(future_tag)))
+        logging.warning("The new dev cycle for branch {} will be: {}"
+                        .format(branch, str(future_tag)))
         update_repo_with_new_ver_number(rpco_repo, branch,
                                         str(future_tag))
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,6 +14,9 @@ reno==2.2.0 # Apache-2.0. Latest version as of 03-20-2017
 sphinx_rtd_theme>=0.1.9
 
 # release.py testing
-github3.py
+github3.py>=1.0.0a4
 mock
 sh
+rpc_differ>=0.2.1
+pandoc>=1.0.0b2
+osa_differ>=0.2.2


### PR DESCRIPTION
This PR is to update release.py and its documentation to our latest standards.

This feature branch included:
- Fixes to test-requirements
- New feature (use RPC_GITHUB_TOKEN) env var
- Update the tool to deal with new artifacts workflow
   (this behavior can be skipped for older branches)
- Be more verbose by default, instead of staying in the dark of what's happening
- Fixes milestone creation

Connected https://github.com/rcbops/u-suk-dev/issues/1483