### PR TITLE
Update git artifact build scripts for rpc-gating

### DIFF
--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -e -u -x
+
+## Vars ----------------------------------------------------------------------
+
+export BASE_DIR=${PWD}
+export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
+
+## Main ----------------------------------------------------------------------
+
+# bootstrap Ansible and the AIO config
+./scripts/bootstrap-ansible.sh
+
+# Only pull from the mirror if these env vars are set
+# This enables tests by hand.
+if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
+    echo "Skipping download from rpc-repo as the REPO_* env vars are not set."
+else
+    # Prep the ssh key for uploading to rpc-repo
+    mkdir -p ~/.ssh/
+    set +x
+    REPO_KEYFILE=~/.ssh/repo.key
+    cat $REPO_USER_KEY > ${REPO_KEYFILE}
+    chmod 600 ${REPO_KEYFILE}
+    set -x
+
+    # Ensure that the repo server public key is a known host
+    grep "${REPO_HOST}" ~/.ssh/known_hosts || echo "${REPO_HOST} $(cat $REPO_HOST_PUBKEY)" >> ~/.ssh/known_hosts
+
+    # Create the Ansible inventory for the upload
+    echo '[mirrors]' > /opt/inventory
+    echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='${REPO_KEYFILE}' " >> /opt/inventory
+
+    # Download the artifacts from rpc-repo
+    openstack-ansible -vvv -i /opt/inventory \
+                      ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml
+fi
+
+# Fetch all the git repositories
+# The openstack-ansible CLI is used to ensure that the library path is set
+openstack-ansible -vvv -i /opt/inventory \
+                  ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-update.yml
+
+# Only push to the mirror if PUSH_TO_MIRROR is set to "YES"
+# This enables PR-based tests which do not change the artifacts
+if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
+    if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
+        echo "Skipping upload to rpc-repo as the REPO_* env vars are not set."
+        exit 1
+    else
+        # Upload the artifacts to rpc-repo
+        openstack-ansible -vvv -i /opt/inventory \
+                          ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-push-to-mirror.yml
+    fi
+else
+    echo "Skipping upload to rpc-repo as the PUSH_TO_MIRROR env var is not set to 'YES'."
+fi

--- a/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml
+++ b/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This playbook's function is to download all existing git clones
+# from rpc-repo.
+
+- name: Pull the current openstackgit folder from rpc-repo
+  hosts: mirrors
+  vars:
+    working_dir: "{{ lookup('ENV', 'PWD') }}"
+  tasks:
+
+    - name: Pull the data from rpc-repo
+      synchronize:
+        src: "/var/www/repo/openstackgit"
+        dest: "{{ working_dir }}/"
+        mode: pull
+        delete: yes
+        recursive: yes
+      register: synchronize
+      until: synchronize | success
+      retries: 5
+      delay: 5

--- a/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml
+++ b/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml
@@ -17,7 +17,7 @@
 # from rpc-repo.
 
 - name: Pull the current openstackgit folder from rpc-repo
-  hosts: mirrors
+  hosts: mirrors[0]
   vars:
     working_dir: "{{ lookup('ENV', 'PWD') }}"
   tasks:

--- a/scripts/artifacts-building/git/openstackgit-push-to-mirror.yml
+++ b/scripts/artifacts-building/git/openstackgit-push-to-mirror.yml
@@ -1,0 +1,37 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This playbook's function is to upload the git clones for all
+# git repositories use by RPC-O to rpc-repo.
+
+- name: Push the updated clones to rpc-repo
+  hosts: mirrors
+  vars:
+    working_dir: "{{ lookup('ENV', 'PWD') }}"
+  tasks:
+
+    - name: Push updated git clones to rpc-repo
+      synchronize:
+        src: "{{ working_dir }}/openstackgit"
+        dest: "/var/www/repo/"
+        mode: push
+        delete: yes
+        recursive: yes
+        rsync_opts:
+          - "--chown=nginx:www-data"
+      register: synchronize
+      until: synchronize | success
+      retries: 5
+      delay: 5

--- a/scripts/artifacts-building/git/openstackgit-update.yml
+++ b/scripts/artifacts-building/git/openstackgit-update.yml
@@ -13,35 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This playbook's function is to update the git clones for all
-# git repositories use by the OpenStack-Ansible integrated build.
+# This playbook's function is to download the git clones for all
+# git repositories use by RPC-O, for the purpose of later uploading
+# them to rpc-repo.
 #
 # The playbook intentionally clones the full repository to ensure
 # that it's usable by all RPC releases, regardless of branch.
-#
-# The playbook also intentionally uses the OSA master branch as it
-# is expected to contain more repositories than RPC will need, but
-# will always have a complete set.
-
-- name: Pull the current openstackgit folder from rpc-repo
-  hosts: mirrors
-  vars:
-    working_dir: "{{ lookup('ENV', 'PWD') }}"
-  tasks:
-
-    - name: Pull the data from rpc-repo
-      synchronize:
-        src: "/var/www/repo/openstackgit"
-        dest: "{{ working_dir }}/"
-        mode: pull
-        delete: yes
-        recursive: yes
-      register: synchronize
-      until: synchronize | success
-      retries: 5
-      delay: 5
-
-
 
 - name: Update the openstackgit data
   hosts: localhost
@@ -66,27 +43,5 @@
       with_items: "{{ local_packages.results.0.item.remote_package_parts }}"
       register: git_clone
       until: git_clone | success
-      retries: 5
-      delay: 5
-
-
-
-- name: Push the updated clones to rpc-repo
-  hosts: mirrors
-  vars:
-    working_dir: "{{ lookup('ENV', 'PWD') }}"
-  tasks:
-
-    - name: Push updated git clones to rpc-repo
-      synchronize:
-        src: "{{ working_dir }}/openstackgit"
-        dest: "/var/www/repo/"
-        mode: push
-        delete: yes
-        recursive: yes
-        rsync_opts:
-          - "--chown=nginx:www-data"
-      register: synchronize
-      until: synchronize | success
       retries: 5
       delay: 5


### PR DESCRIPTION
This patch properly splits the download/upload playbooks
so that the artifact build can be executed by hand, in
PR's or through the pipeline. It also ensures that it
can be executed on a temporal node instead of a long
lived node.

Connects https://github.com/rcbops/u-suk-dev/issues/1454