### PR TITLE
Remove nova_cross_az_attach default override

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -56,7 +56,6 @@ nova_cpu_allocation_ratio: 2.0
 nova_ram_allocation_ratio: 1.0
 
 # Nova config overrides
-nova_cross_az_attach: False
 nova_console_type: novnc
 
 # RabbitMQ overrides


### PR DESCRIPTION
Per nova documentation:
"If False, volumes attached to an instance must be in the same availability
zone in Cinder as the instance availability zone in Nova. This also means
care should be taken when booting an instance from a volume where source
is not “volume” because Nova will attempt to create a volume using the same
availability zone as what is assigned to the instance. If that AZ is not in
Cinder (or allow_availability_zone_fallback=False in cinder.conf), the volume
create request will fail and the instance will fail the build request. By
default there is no availability zone restriction on volume attach."[1]

Adding this override means that creating instances from volumes will not
work with an RPCO default deployment, which doesn't implement cinder AZs.
For more information, please see the Connected card and it's comments.

[1] https://docs.openstack.org/newton/config-reference/compute/config-options.html

Connects https://github.com/rcbops/rpc-openstack/issues/2095