### PR TITLE
Normalise the execution of all artifact builds

### DIFF
--- a/scripts/artifacts-building/apt/aptly-all.yml
+++ b/scripts/artifacts-building/apt/aptly-all.yml
@@ -18,7 +18,7 @@
     aptly_mirror_do_updates: "False"
 
 - include: sync-with-mirror.yml
-  when: "{{ (lookup('ENV','DOWNLOAD_FIRST') | default(True,True)) | bool }}"
+  when: "{{ (lookup('ENV','PULL_FROM_MIRROR') | bool }}"
   vars:
     action: "pull-aptly"
 
@@ -36,21 +36,21 @@
     distribution_release: "xenial"
 
 - include: aptly-snapshot-publish.yml
-  when: "{{ (lookup('ENV','PUBLISH_SNAPSHOT') | default(True,True)) | bool }}"
+  when: "{{ (lookup('ENV','PUBLISH_SNAPSHOT') | bool }}"
   vars:
     distribution_release: "trusty"
 
 - include: aptly-snapshot-publish.yml
-  when: "{{ (lookup('ENV','PUBLISH_SNAPSHOT') | default(True,True)) | bool }}"
+  when: "{{ (lookup('ENV','PUBLISH_SNAPSHOT') | bool }}"
   vars:
     distribution_release: "xenial"
 
 - include: sync-with-mirror.yml
-  when: "{{ (lookup('ENV','PUSH_TO_MIRROR') | default(True,True)) | bool }}"
+  when: "{{ (lookup('ENV','PUSH_TO_MIRROR') | bool }}"
   vars:
     action: "push-aptly"
 
 - include: sync-with-mirror.yml
-  when: "{{ (lookup('ENV','PUSH_TO_MIRROR') | default(True,True)) | bool }}"
+  when: "{{ (lookup('ENV','PUSH_TO_MIRROR') | bool }}"
   vars:
     action: "push-gpg"

--- a/scripts/artifacts-building/apt/aptly-snapshot-create.yml
+++ b/scripts/artifacts-building/apt/aptly-snapshot-create.yml
@@ -50,7 +50,7 @@
       shell: "aptly publish drop {{ item.split(' ')[1] }} {{ item.split(' ')[0] }}"
       with_items: "{{ aptly_existing_published_snapshots_list.stdout_lines }}"
       when:
-        - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | default('NO') == 'YES' }}"
+        - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | bool }}"
         - "item.find('{{ artifacts_version }}') != -1"
         - "item.find('{{ distribution_release }}') != -1"
       failed_when: false
@@ -58,14 +58,14 @@
       shell: "aptly snapshot drop {{ item }}"
       with_items: "{{ aptly_existing_snapshots_list.stdout_lines }}"
       when:
-        - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | default('NO') == 'YES' }}"
+        - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | bool }}"
         - "item.find('miko-{{ artifacts_version }}-{{ distribution_release }}') != -1"
       failed_when: false
     - name: Delete old snapshots for this distro/artifacts version
       shell: "aptly snapshot drop {{ item }}"
       with_items: "{{ aptly_existing_snapshots_list.stdout_lines }}"
       when:
-        - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | default('NO') == 'YES' }}"
+        - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | bool }}"
         - "item.find('slushie-{{ artifacts_version }}') != -1"
         - "item.find('{{ distribution_release }}') != -1 or item.find('ALL') != -1"
       failed_when: false

--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -19,54 +19,87 @@ set -e -u -x
 
 ## Vars ----------------------------------------------------------------------
 
-export BASE_DIR=${PWD}
+# To provide flexibility in the jobs, we have the ability to set any
+# parameters that will be supplied on the ansible-playbook CLI.
+export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:--v}
+
+# Set this to NO if you do not want to pull any existing data from rpc-repo.
+export PULL_FROM_MIRROR=${PULL_FROM_MIRROR:-yes}
+
+# Set this to YES if you want to push any changes made in this job to rpc-repo.
 export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
+
+# The BASE_DIR needs to be set to ensure that the scripts
+# know it and use this checkout appropriately.
+export BASE_DIR=${PWD}
+
+# We want the role downloads to be done via git
+# This ensures that there is no race condition with the artifacts-git job
+export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 
 ## Main ----------------------------------------------------------------------
 
-# bootstrap Ansible and the AIO config
+# Bootstrap Ansible
 ./scripts/bootstrap-ansible.sh
 
-# Only pull from the mirror if these env vars are set
-# This enables tests by hand.
-if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
-    echo "Skipping download from rpc-repo as the REPO_* env vars are not set."
+# Only pull from the mirror if PULL_FROM_MIRROR is set to "YES"
+#
+# This should be avoided when used along with PUSH_TO_MIRROR == "YES"
+# as it will remove any git repositories that are there for older
+# releases. The use-case for this is a repo that changes name or is
+# removed from OSA/RPC - for the tag that included this repo to still
+# work it must have access to the git repo as it was at the time the
+# tag was published.
+#
+if [[ "$(echo ${PULL_FROM_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
+    if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
+        echo "Cannot download from rpc-repo as the REPO_* env vars are not set."
+        exit 1
+    else
+        # Prep the ssh key for uploading to rpc-repo
+        mkdir -p ~/.ssh/
+        set +x
+        REPO_KEYFILE=~/.ssh/repo.key
+        cat $REPO_USER_KEY > ${REPO_KEYFILE}
+        chmod 600 ${REPO_KEYFILE}
+        set -x
+
+        # Ensure that the repo server public key is a known host
+        grep "${REPO_HOST}" ~/.ssh/known_hosts || echo "${REPO_HOST} $(cat $REPO_HOST_PUBKEY)" >> ~/.ssh/known_hosts
+
+        # Create the Ansible inventory for the upload
+        echo '[mirrors]' > /opt/inventory
+        echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='${REPO_KEYFILE}' " >> /opt/inventory
+
+        # Download the artifacts from rpc-repo
+        openstack-ansible -i /opt/inventory \
+                          ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml \
+                          ${ANSIBLE_PARAMETERS}
+    fi
 else
-    # Prep the ssh key for uploading to rpc-repo
-    mkdir -p ~/.ssh/
-    set +x
-    REPO_KEYFILE=~/.ssh/repo.key
-    cat $REPO_USER_KEY > ${REPO_KEYFILE}
-    chmod 600 ${REPO_KEYFILE}
-    set -x
-
-    # Ensure that the repo server public key is a known host
-    grep "${REPO_HOST}" ~/.ssh/known_hosts || echo "${REPO_HOST} $(cat $REPO_HOST_PUBKEY)" >> ~/.ssh/known_hosts
-
-    # Create the Ansible inventory for the upload
-    echo '[mirrors]' > /opt/inventory
-    echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='${REPO_KEYFILE}' " >> /opt/inventory
-
-    # Download the artifacts from rpc-repo
-    openstack-ansible -vvv -i /opt/inventory \
-                      ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-pull-from-mirror.yml
+    echo "Skipping download from rpc-repo as the PULL_FROM_MIRROR env var is not set to 'YES'."
 fi
 
 # Fetch all the git repositories
 # The openstack-ansible CLI is used to ensure that the library path is set
-openstack-ansible -vvv -i /opt/inventory \
-                  ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-update.yml
+#
+openstack-ansible -i /opt/inventory \
+                  ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-update.yml \
+                  ${ANSIBLE_PARAMETERS}
 
 # Only push to the mirror if PUSH_TO_MIRROR is set to "YES"
+#
 # This enables PR-based tests which do not change the artifacts
+#
 if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
     if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
         echo "Skipping upload to rpc-repo as the REPO_* env vars are not set."
         exit 1
     else
         # Upload the artifacts to rpc-repo
-        openstack-ansible -vvv -i /opt/inventory \
-                          ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-push-to-mirror.yml
+        openstack-ansible -i /opt/inventory \
+                          ${BASE_DIR}/scripts/artifacts-building/git/openstackgit-push-to-mirror.yml \
+                          ${ANSIBLE_PARAMETERS}
     fi
 else
     echo "Skipping upload to rpc-repo as the PUSH_TO_MIRROR env var is not set to 'YES'."

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -19,15 +19,41 @@ set -e -u -x
 
 ## Vars ----------------------------------------------------------------------
 
-export DEPLOY_AIO=yes
+# To provide flexibility in the jobs, we have the ability to set any
+# parameters that will be supplied on the ansible-playbook CLI.
+export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:--v}
+
+# Set this to NO if you do not want to pull any existing data from rpc-repo.
+export PULL_FROM_MIRROR=${PULL_FROM_MIRROR:-yes}
+
+# Set this to YES if you want to replace any existing artifacts for the current
+# release with those built in this job.
+export REPLACE_ARTIFACTS=${REPLACE_ARTIFACTS:-no}
+
+# Set this to YES if you want to push any changes made in this job to rpc-repo.
 export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 
+# The BASE_DIR needs to be set to ensure that the scripts
+# know it and use this checkout appropriately.
+export BASE_DIR=${PWD}
+
+# We want the role downloads to be done via git
+# This ensures that there is no race condition with the artifacts-git job
+export ANSIBLE_ROLE_FETCH_MODE="git-clone"
+
 ## Main ----------------------------------------------------------------------
+
+# The derive-artifact-version.py script expects the git clone to
+# be at /opt/rpc-openstack, so we link the current folder there.
+ln -sfn ${PWD} /opt/rpc-openstack
 
 # bootstrap Ansible and the AIO config
 cd /opt/rpc-openstack
 ./scripts/bootstrap-ansible.sh
 ./scripts/bootstrap-aio.sh
+
+# Figure out the release version
+export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py)"
 
 # Remove the env.d configurations that set the build to use
 # container artifacts. We don't want this because container
@@ -45,7 +71,7 @@ sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/user_osa_variables
 sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
 
 # Set override vars for the artifact build
-echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
+echo "rpc_release: ${RPC_RELEASE}" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 echo "repo_build_venv_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 cp scripts/artifacts-building/user_rcbops_artifacts_building.yml /etc/openstack_deploy/
@@ -57,14 +83,33 @@ cd /opt/rpc-openstack/openstack-ansible/playbooks
 # All updates (security and otherwise) must come from the RPC-O apt artifacting.
 # This is also being done to ensure that the python artifacts are built using
 # the same sources as the container artifacts will use.
-openstack-ansible /opt/rpc-openstack/rpcd/playbooks/configure-apt-sources.yml -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu"
+openstack-ansible /opt/rpc-openstack/rpcd/playbooks/configure-apt-sources.yml \
+                  -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu" \
+                  ${ANSIBLE_PARAMETERS}
 
 # Setup the repo container and build the artifacts
-openstack-ansible setup-hosts.yml -e container_group=repo_all
-openstack-ansible repo-install.yml
+openstack-ansible setup-hosts.yml \
+                  -e container_group=repo_all \
+                  ${ANSIBLE_PARAMETERS}
 
-# Only push to the mirror if PUSH_TO_MIRROR is set to "YES"
-# This enables PR-based tests which do not change the artifacts
+openstack-ansible repo-install.yml \
+                  ${ANSIBLE_PARAMETERS}
+
+# Check whether there are already containers for this release
+existing_artifacts=$(curl http://rpc-repo.rackspace.com/os-releases/${RPC_RELEASE}/MANIFEST.in)
+
+# Only push to the mirror if PUSH_TO_MIRROR is set to "YES" and
+# REPLACE_ARTIFACTS is "YES" or there are no existing artifacts
+# for this release.
+#
+# This enables PR-based tests which do not change the artifacts,
+# and also prevents periodic tests from overwriting artifacts that
+# have already been published.
+#
+if ${existing_artifacts} && [[ "$(echo ${REPLACE_ARTIFACTS} | tr [a-z] [A-Z])" != "YES" ]]; then
+  export PUSH_TO_MIRROR="NO"
+fi
+
 if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
   if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then
     echo "Skipping upload to rpc-repo as the REPO_* env vars are not set."
@@ -86,9 +131,10 @@ if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
     echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='${REPO_KEYFILE}' " >> /opt/inventory
 
     # Upload the artifacts to rpc-repo
-    openstack-ansible -vvv -i /opt/inventory \
+    openstack-ansible -i /opt/inventory \
                       /opt/rpc-openstack/scripts/artifacts-building/python/upload-python-artifacts.yml \
-                      -e repo_container_name=$(lxc-ls '.*_repo_' '|' head -n1)
+                      -e repo_container_name=$(lxc-ls '.*_repo_' '|' head -n1) \
+                      ${ANSIBLE_PARAMETERS}
   fi
 else
   echo "Skipping upload to rpc-repo as the PUSH_TO_MIRROR env var is not set to 'YES'."


### PR DESCRIPTION
All artifact builds have three options that are necessary:

1. Should it download the existing data from rpc-repo?
2. Should it replace the existing artifacts for the rpc_release it's building for?
3. Should it publish the artifacts it builds?

These options should be set out in all the scripts and in the jobs.
This patch makes that happen.

Connects https://github.com/rcbops/u-suk-dev/issues/1501