### PR TITLE
[Backport - Mitaka] MaaS: Modify ceph alarm evaluations

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_cluster_stats.yaml.j2
@@ -26,5 +26,5 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 1) {
-                return new AlarmStatus(WARNING, "Ceph cluster warning.");
+                return new AlarmStatus(CRITICAL, "Ceph cluster warning.");
             }

--- a/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/ceph_mon_stats.yaml.j2
@@ -26,5 +26,5 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 1) {
-                return new AlarmStatus(WARNING, "Ceph mon warning.");
+                return new AlarmStatus(CRITICAL, "Ceph mon warning.");
             }


### PR DESCRIPTION
Changes ceph_cluster_stats and ceph_mon_stats WARN alarms
to critical.

Connects rcbops/u-suk-dev#1403