### PR TITLE
change the ceph client to jewel

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -131,7 +131,7 @@ fetch_directory: /etc/openstack_deploy/ceph_fetch
 # Use stable version of ceph
 ceph_stable: true
 # Specify ceph release name
-ceph_stable_release: hammer
+ceph_stable_release: jewel
 # Ceph stable repo URL
 ceph_stable_repo: "http://download.ceph.com/debian-{{ ceph_stable_release }}/"
 


### PR DESCRIPTION
This change updates the RPC release of the ceph client. This is being done so an RPC deployment can function with a modern ceph client against a modern ceph cluster.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Connects https://github.com/rcbops/u-suk-dev/issues/1536