### PR TITLE
Use new repo build structure

### DIFF
--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -41,6 +41,10 @@ export BASE_DIR=${PWD}
 # This ensures that there is no race condition with the artifacts-git job
 export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 
+# We want to verify if artifacts exist for this OS and architecture
+export DISTRO=${DISTRO:-ubuntu-14.04}
+export ARCH=${ARCH:-x86_64}
+
 ## Main ----------------------------------------------------------------------
 
 # The derive-artifact-version.py script expects the git clone to
@@ -96,7 +100,7 @@ openstack-ansible repo-install.yml \
                   ${ANSIBLE_PARAMETERS}
 
 # Check whether there are already containers for this release
-existing_artifacts=$(curl http://rpc-repo.rackspace.com/os-releases/${RPC_RELEASE}/MANIFEST.in)
+existing_artifacts=$(curl http://rpc-repo.rackspace.com/os-releases/${RPC_RELEASE}/${DISTRO}-${ARCH}/MANIFEST.in)
 
 # Only push to the mirror if PUSH_TO_MIRROR is set to "YES" and
 # REPLACE_ARTIFACTS is "YES" or there are no existing artifacts

--- a/scripts/artifacts-building/python/upload-python-artifacts.yml
+++ b/scripts/artifacts-building/python/upload-python-artifacts.yml
@@ -78,7 +78,7 @@
         src: "{{ repo_local_path }}/os-releases/{{ rpc_release }}"
         dest: "{{ repo_remote_path }}/os-releases/"
         mode: push
-        delete: yes
+        delete: no
         recursive: yes
         rsync_opts:
           - "--chown=nginx:www-data"


### PR DESCRIPTION
Because repo-build has changed in OSA Newton, we need to adapt.

Connected https://github.com/rcbops/u-suk-dev/issues/1408