### PR TITLE
Properly check if wheels needs push

### DIFF
--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -100,7 +100,7 @@ openstack-ansible repo-install.yml \
                   ${ANSIBLE_PARAMETERS}
 
 # Check whether there are already containers for this release
-existing_artifacts=$(curl http://rpc-repo.rackspace.com/os-releases/${RPC_RELEASE}/${DISTRO}-${ARCH}/MANIFEST.in)
+existing_artifacts=$(curl --fail http://rpc-repo.rackspace.com/os-releases/${RPC_RELEASE}/${DISTRO}-${ARCH}/MANIFEST.in 1>&2 2>/dev/null)
 
 # Only push to the mirror if PUSH_TO_MIRROR is set to "YES" and
 # REPLACE_ARTIFACTS is "YES" or there are no existing artifacts


### PR DESCRIPTION
To avoid pushing python artifacts when they already exist, we do
a check in the build process.

This check was returning the same rc for failures (404) as
successes (200).

Connected https://github.com/rcbops/u-suk-dev/issues/1544