### PR TITLE
Tag cleanup

### DIFF
--- a/rpcd/playbooks/roles/kibana/tasks/main.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/main.yml
@@ -28,3 +28,4 @@
 - include: kibana_dashboards.yml
   tags:
     - kibana-dashboard
+    - kibana-config


### PR DESCRIPTION
Artifacting separated CONFIG/INSTALL tasks.
Kibana dashboards tasks are not marked either and run.

This causes issues during artifacting, which runs only the install
tasks.

Connected https://github.com/rcbops/u-suk-dev/issues/1610