### PR TITLE
Remove galera from artifact building

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -113,11 +113,11 @@ openstack-ansible containers/artifact-build-chroot.yml \
 
 # Build the list of roles to build containers for
 role_list=""
-role_list="${role_list} elasticsearch kibana galera_server logstash"
-role_list="${role_list} memcached_server os_cinder os_glance os_heat"
 role_list="${role_list} os_horizon os_ironic os_keystone os_neutron os_nova"
 role_list="${role_list} os_swift os_tempest rabbitmq_server repo_server"
+role_list="${role_list} memcached_server os_cinder os_glance os_heat"
 role_list="${role_list} rsyslog_server"
+role_list="${role_list} elasticsearch kibana logstash"
 
 # Build all the containers
 for cnt in ${role_list}; do


### PR DESCRIPTION
Because Galera artifact building is currently broken and needs
a complete overhaul (because of it's different nature in OSA),
we need to temporarily remove it from the build.

Connected https://github.com/rcbops/u-suk-dev/issues/1554