### PR TITLE
Force Artifact version temporarily

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -21,7 +21,7 @@
 # The release tag to use
 # Note that this is set here so that the openstack_release override in osa_defaults
 # is able to use it.
-rpc_release: "{{ lookup('pipe', 'cd /opt/rpc-openstack && git describe --tags --abbrev=0') }}"
+rpc_release: "r14.0.0rc1"
 
 ## Rackspace Cloud Details
 rackspace_cloud_auth_url: https://identity.api.rackspacecloud.com/v2.0

--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -18,7 +18,7 @@ rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 # rpc-openstack version
 # Note that this is also set in the user_*.yml files so that the
 # openstack_release override in osa_defaults is able to use it.
-rpc_release: "{{ lookup('pipe', 'cd /opt/rpc-openstack && git describe --tags --abbrev=0') }}"
+rpc_release: "r14.0.0rc1"
 
 # Definitions for the repo server, these should match your openstack-ansible
 # deployment


### PR DESCRIPTION
Later we'll have to change the release.py process or change
these variables to be a lookup of rev parse head.

But to finish Q1 quarter, we need stable artifacts for testing.
This should unlock Apt artifact building.