### PR TITLE
Force Artifact version build temporarily

### DIFF
--- a/scripts/artifacts-building/apt/artifacting-vars.yml
+++ b/scripts/artifacts-building/apt/artifacting-vars.yml
@@ -20,7 +20,7 @@ artifact_extradownloads_dest_folder: "{{ artifacts_root_folder }}/downloads"
 ansible_roles_folder: "/etc/ansible/roles"
 
 # Generic details
-artifacts_version: "{{ lookup('pipe', '/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.py') }}"
+artifacts_version: "r14.0.0rc1"
 
 # rpc-repo mirror details
 webservice_owner: "nginx"


### PR DESCRIPTION
Later we'll have to change the release.py process or change
these variables to be a lookup of rev parse head.

But to finish Q1 quarter, we need to build (and not only
consume) stable artifacts for testing.

Connected https://github.com/rcbops/u-suk-dev/issues/1555