### PR TITLE
[WIP] Fix flake8 error in rpc-maas-tool.py

### DIFF
--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -669,7 +669,7 @@ class RpcMassCli(object):
         for check in checks:
             try:
                 result = self.rpcm.conn.test_existing_check(check)
-            except rackspace.RackspaceMonitoringValidationError as e:
+            except rackspace.RackspaceMonitoringValidationError:
                 completed = False
             else:
                 status = result[0]['status']


### PR DESCRIPTION
flake8 is currently failing on this script with:

F841 local variable 'e' is assigned to but never used

It looks like rpc-openstack is not linting correctly on master branch,
which is why the lint check passed on PR #2115.  This is currently
happening because of:

https://github.com/rcbops/rpc-openstack/blob/master/.travis.yml#L6-L15

@alextricity is going to address in a separate commit.