### PR TITLE
Fetch PR refspec, checkout commit to be tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_script:
 install:
   - git clone --recursive https://github.com/rcbops/rpc-openstack.git rcbops/rpc-openstack
   - cd rcbops/rpc-openstack
+  - "if [ $TRAVIS_PULL_REQUEST != 'false' ];then git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge;fi"
+  - git checkout -qf $TRAVIS_COMMIT
 
 script: tox
 

--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -669,7 +669,7 @@ class RpcMassCli(object):
         for check in checks:
             try:
                 result = self.rpcm.conn.test_existing_check(check)
-            except rackspace.RackspaceMonitoringValidationError as e:
+            except rackspace.RackspaceMonitoringValidationError:
                 completed = False
             else:
                 status = result[0]['status']


### PR DESCRIPTION
This commit fetchs the PR refspec after doing a full
clone of rpc-openstack, then checks out the commit that
the current build is testing.

This commit also fixes a linting issue that was hidden
because tests were not being run.

Connects https://github.com/rcbops/rpc-openstack/issues/2142