### PR TITLE
Override the check_firewall var in ceph role

### DIFF
--- a/releasenotes/notes/setcheckfirewallvariabletofalse-de49a72bbad0e7db.yaml
+++ b/releasenotes/notes/setcheckfirewallvariabletofalse-de49a72bbad0e7db.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``check_firewall`` variable is now set to false because the 
+    ``check firewall`` tasks are incompatible with Ansible 2.1.5. This 
+    fix allows for our ceph playbooks to run successfully.

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -155,3 +155,7 @@ secure_cluster: true
 # List of secure flags to set on for a pool (options for the list are nodelete, nopgchange, nosizechange - prevents deletion, pg from changing and size from changing respectively).
 secure_cluster_flags:
   - nodelete
+
+# this variable is required for ceph.ceph-common to function properly as our ceph playbooks
+# are not suppported by Ansible 2.1.5
+check_firewall: False


### PR DESCRIPTION
This variable is required for ceph.ceph-common to function properly as
our ceph playbooks are not suppported by Ansible 2.1.5.

Connects rcbops/u-suk-dev#1552