### PR TITLE
Fixing the venv fetch path

### DIFF
--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -27,8 +27,10 @@ xz_bin:
 architecture_mapping:
   x86_64: amd64
   ppc64le: ppc64el
+os_distro_version: "{{ ansible_distribution | lower }}-{{ ansible_distribution_version.split('.')[:2] | join('.') }}-{{ ansible_architecture | lower }}"
 role_vars:
-  venv_download_url: "{{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
+  # We can't use the group vars, we need to override ourselves.
+  venv_download_url: "{{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/{{ os_distro_version }}/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
   venv_tag: "{{ rpc_release }}"
   developer_mode: False
 webserver_owner: "nginx"


### PR DESCRIPTION
The variable to download the venv is overriden in a group_var
per role. Because we don't add temp containers to group and
setup to get their vars, we override the vars ourselves.

This commit ensure we override the url for the venv fetch to
http://rpc-repo.rackspace.com/venvs/r14.0.0rc1/ubuntu-14.04-x86_64/
instead of
http://rpc-repo.rackspace.com/venvs/r14.0.0rc1/ubuntu/ like it
was before the SHA bump that changed the repo build behavior.

Connected https://github.com/rcbops/u-suk-dev/issues/1562