### PR TITLE
Fix failed check validation in rpc-maas-tool.py

### DIFF
--- a/releasenotes/notes/fix-rpc-maas-tool-check-validation-a5190a72be5830f6.yaml
+++ b/releasenotes/notes/fix-rpc-maas-tool-check-validation-a5190a72be5830f6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - | 
+    `rpc-maas-tool.py` is modified so that validating the status of checks
+    correctly reports when there are failures. This tool is used by the
+    playbook `verify-maas.yml`.

--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -667,22 +667,19 @@ class RpcMassCli(object):
                         continue
                     checks.append(check)
         for check in checks:
-                validation_error = ""
-                try:
-                    result = self.rpcm.conn.test_existing_check(check)
-                except rackspace.RackspaceMonitoringValidationError as e:
-                    validation_error = " Validation Error: {s}:".format(
-                        s=e.message
-                    )
-                    break
-
+            try:
+                result = self.rpcm.conn.test_existing_check(check)
+            except rackspace.RackspaceMonitoringValidationError:
+                completed = False
+            else:
                 status = result[0]['status']
                 completed = result[0]['available']
                 check.state = (" Completed:%(completed)s Status:%(status)s"
                                % {'completed': completed, 'status': status})
-                if completed is False or validation_error != "":
-                    check.bullet = "!"
-                    failed_checks.append(check)
+
+            if not completed:
+                check.bullet = "!"
+                failed_checks.append(check)
 
         return (checks, failed_checks)
 


### PR DESCRIPTION
The function `_get_failed_checks` uses the Rackspace monitoring API to
confirm that the defined checks are working. The function always reports
there are no failed checks due to the use of `break` in the for-loop
resulting in it being exited when encountering the first
`RackspaceMonitoringValidationError`. The result of this is that
`failed_checks` is not updated with the failure and, unless the failure
happens on the last check, not all the checks are validated.

This commit simplifies the logic and removes the use of `break` so that
all the checks are validated and all failed checks are added to
`failed_checks`.

Co-Authored-By: git-harry <git-harry@live.co.uk>

Connects rcbops/u-suk-dev#1532
Connects rcbops/u-suk-dev#1564
Related https://github.com/rcbops/rpc-openstack/issues/2142

(cherry picked from commit 2f3a0a76689122da4741b284200d3c594900e408)