### PR TITLE
Add an extra conditonal to check cinder_backends

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/main.yml
@@ -72,6 +72,7 @@
   vars:
     checks: "{{ cinder_vg_checks_list }}"
   when:
+    - cinder_backends is defined
     - cinder_backends['lvm'] is defined
 
 - include: swift.yml


### PR DESCRIPTION
Not having this conditional causes failures with ansible 2.1.5
due to the dictionary cinder_backends not being defined.

This commit addes an extra conditional statement to check
if cinder_backends is defined.

Connects https://github.com/rcbops/rpc-openstack/issues/2150