### PR TITLE
Pin libcloud to <2.0.0

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -522,6 +522,7 @@ maas_pip_packages:
   - ipaddr
   - lxml
   - psutil<=1.2.1
+  - apache-libcloud<2.0.0
   - rackspace-monitoring-cli
   - python-cinderclient
   - python-glanceclient


### PR DESCRIPTION
Version 2.0.0rc2 currently is causing setup-maas.yml to fail due to
https://issues.apache.org/jira/browse/LIBCLOUD-904https://issues.apache.org/jira/browse/LIBCLOUD-904
Pinning to a version <2.0.0 ensures that the rackspace monitoring
libraries have a libcloud version that works.

Connects https://github.com/rcbops/rpc-openstack/issues/2156