### PR TITLE
[Backport - liberty-12.2] Pin libcloud to <2.0.0

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -496,6 +496,7 @@ maas_apt_packages:
 maas_pip_packages:
   - ipaddr
   - lxc-python2
+  - apache-libcloud<2.0.0
   - psutil
   - rackspace-monitoring-cli
   - swift


### PR DESCRIPTION
Version 2.0.0rc2 currently is causing setup-maas.yml to fail due to
https://issues.apache.org/jira/browse/LIBCLOUD-904https://issues.apache.org/jira/browse/LIBCLOUD-904
Pinning to a version <2.0.0 ensures that the rackspace monitoring
libaries have a libcloud version that works.

Connects https://github.com/rcbops/rpc-openstack/issues/2156

(cherry picked from commit 58dedc7a6cc1ef7eefcab9d7da87c1210cca0196)

Conflicts:
	rpcd/playbooks/roles/rpc_maas/defaults/main.yml