### PR TITLE
Use yaml.safe_load()

### DIFF
--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -212,7 +212,7 @@ class RpcMaasAgentConfig(object):
     def _parse_config_file(self, path):
         """Parse one yaml config file"""
         with open(path, 'r') as config_file:
-            blob = yaml.load(config_file)
+            blob = yaml.safe_load(config_file)
         return blob
 
 


### PR DESCRIPTION
Change `yaml.load()` to `yaml.safe_load()` to improve security.

Connects rcbops/rpc-openstack#2073