### PR TITLE
Added pip_install as meta dependency to rpc_maas

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/meta/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/meta/main.yml
@@ -29,3 +29,6 @@ galaxy_info:
     - MaaS
     - development
     - openstack
+
+dependencies:
+- pip_install

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -22,7 +22,7 @@
     - ceph.ceph-common
 
 - name: Install MaaS
-  hosts: hosts:all_containers
+  hosts: shared-infra_hosts:compute_hosts:storage_hosts:swift_hosts:log_hosts:all_containers
   roles:
     - role: "rpc_maas"
       tags: [ "maas-setup" ]


### PR DESCRIPTION
To ensure maas pip packages are installed from the repo server,
the meta role depedency ``pip_install`` has been added.

In addtion, host targeting for the setup-maas playbook has been
changed to be more explicit. Instead of using the general group
`hosts`, it is now using a set of groups that constitutes all
of the hosts that setup-maas operates on.

Connects https://github.com/rcbops/rpc-openstack/issues/2164