### PR TITLE
Remove RabbitMQ default version

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -115,11 +115,6 @@ maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled }}"
 cloud_resource_cpu_allocation_ratio: "{{ nova_cpu_allocation_ratio }}"
 cloud_resource_mem_allocation_ratio: "{{ nova_ram_allocation_ratio }}"
 
-# update the rabbitmq version to at least 3.6.6-1
-# https://github.com/rcbops/rpc-openstack/issues/1790
-rabbitmq_package_url: "http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.6/rabbitmq-server_3.6.6-1_all.deb"
-rabbitmq_package_sha256: "44e3a6b0a594d5c7bc4b4b74bd93ed0111777c6ebcbca44e6b49400bb55f3044"
-
 # Ceph options
 # fsid is the unique identifier for your object store.
 fsid: '{{ fsid_uuid }}'


### PR DESCRIPTION
Upstream OpenStack-Ansible has used this version since release
14.0.7 (2017-02-14). This variable isn't needed any longer.

Connects rcbops/rpc-openstack#2167