### PR TITLE
Include OSA horizon fix

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -14,3 +14,10 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 1383d0db302c6fc400a50fae4f85e77bf1633581
+# Override the current horizon role until
+# https://github.com/openstack/openstack-ansible-os_horizon/commit/08e3924b6e825d1ddbc5b4536abde175734efbfc
+# gets taken into a SHA bump in OSA and RPC.
+- name: os_horizon
+  scm: git
+  src: https://github.com/openstack/openstack-ansible-os_horizon
+  version: 08e3924b6e825d1ddbc5b4536abde175734efbfc


### PR DESCRIPTION
OSA os_horizon has the fix to separate install and config tasks [1],
but RPC doesn't have it (yet).

This should fix it.

[1]: https://github.com/openstack/openstack-ansible-os_horizon/commit/146ac22e755ee24ff511ad27468930395a96a814

Connected https://github.com/rcbops/u-suk-dev/issues/1572