### PR TITLE
[Liberty] Use yaml.safe_load()

### DIFF
--- a/scripts/rpc-maas-tool.py
+++ b/scripts/rpc-maas-tool.py
@@ -200,7 +200,7 @@ class RpcMaasAgentConfig(object):
     def _parse_config_file(self, path):
         """Parse one yaml config file"""
         with open(path, 'r') as config_file:
-            blob = yaml.load(config_file)
+            blob = yaml.safe_load(config_file)
         return blob
 
 


### PR DESCRIPTION
Change yaml.load() to yaml.safe_load() to improve security.

Connects rcbops/rpc-openstack#2073
(cherry picked from commit 089d22dc82aee6e5f8e4bcf915a68f10c227c810)