### PR TITLE
Specify hosts for verify_maas

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Verify MaaS setup
-  hosts: hosts
+  hosts: shared-infra_hosts:compute_hosts:storage_hosts:swift_hosts:log_hosts
   tasks:
     - name: ensure remote directory
       file:


### PR DESCRIPTION
The host targeting for the verify-maas playbook has been
changed to be more explicit. Instead of using the general group
hosts, it is now using a set of groups that constitutes all
of the hosts that verify-maas operates on.


Connects #2107