### PR TITLE
[Backport - newton-14.0] Added pip_install as meta dependency to rpc_maas

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/meta/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/meta/main.yml
@@ -29,3 +29,6 @@ galaxy_info:
     - MaaS
     - development
     - openstack
+
+dependencies:
+  - pip_install


### PR DESCRIPTION
To ensure maas pip packages are installed from the repo server,
the meta role depedency ``pip_install`` has been added.

Connects https://github.com/rcbops/rpc-openstack/issues/2164