### PR TITLE
Allow the use of fqdn in neutron_service_check.py

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/files/plugins/neutron_service_check.py
+++ b/rpcd/playbooks/roles/rpc_maas/files/plugins/neutron_service_check.py
@@ -36,6 +36,8 @@ def check(args):
     # gather nova service states
     if args.host:
         agents = neutron.list_agents(host=args.host)['agents']
+    elif args.fqdn:
+        agents = neutron.list_agents(host=args.fqdn)['agents']
     else:
         agents = neutron.list_agents()['agents']
 


### PR DESCRIPTION
This change allows for use of either hostname or fqdns when running
the neutron_service_check.py plugin. It did not find the host when
fqdn was used.

Connects #1603