### PR TITLE
Revert explicit host targeting 

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/meta/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/meta/main.yml
@@ -31,4 +31,4 @@ galaxy_info:
     - openstack
 
 dependencies:
-- pip_install
+  - pip_install

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -20,7 +20,7 @@
     - ceph.ceph-common
 
 - name: Install MaaS
-  hosts: shared-infra_hosts:compute_hosts:storage_hosts:swift_hosts:log_hosts:all_containers
+  hosts: hosts:all_containers
   gather_facts: true
   roles:
     - role: "rpc_maas"


### PR DESCRIPTION
Not using hosts like what was done previously could
cause the hardware checks to be missed on hosts that
were not part of the groups listed before.
For more information, please see:
#2177 (comment)

Connects #2164