### PR TITLE
Comment out nova_cross_az_attach

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -56,7 +56,11 @@ nova_cpu_allocation_ratio: 2.0
 nova_ram_allocation_ratio: 1.0
 
 # Nova config overrides
-nova_cross_az_attach: False
+# NOTE: Due to a bug with nova, this variable cannot be set to true
+# if the environment needs to be able to boot an instance from
+# a volume
+# https://bugs.launchpad.net/nova/+bug/1648324
+#nova_cross_az_attach: False
 nova_console_type: novnc
 
 # RabbitMQ overrides


### PR DESCRIPTION
This will cause the value to take it's default value of True.
This value cannot be false when trying to boot an instance from
a volume. See connected card for more details.

Connects https://github.com/rcbops/rpc-openstack/issues/2179