### PR TITLE
Remove the ansible.cfg file

### DIFF
--- a/rpcd/playbooks/ansible.cfg
+++ b/rpcd/playbooks/ansible.cfg
@@ -1,4 +1,0 @@
-[defaults]
-# NOTE: The ssh timeout is increased here to 120 (OSA's default is 5) to
-#       avoid transient ssh errors in some environments.
-timeout = 120

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,7 +19,7 @@ set -e -u -x
 set -o pipefail
 
 ## Functions -----------------------------------------------------------------
-
+export ANSIBLE_TIMEOUT=120
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 source ${BASE_DIR}/scripts/functions.sh
 


### PR DESCRIPTION
This file creates a global override when playbooks are executed within
this path. Within upstream OSA we use an rc file to control pathing and
options within the ansible stack. This change simply exports our needed
option within deploy.sh instead of carrying the more heavy handed
ansible.cfg file.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>