### PR TITLE
Add internal endpoint type to flavor create

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/create_default_flavors.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/create_default_flavors.yml
@@ -26,6 +26,7 @@
     name: "{{ item.name }}"
     vcpus: "{{ item.vcpus }}"
     state: present
+    endpoint_type: "internal"
     disk: "{{ item.disk }}"
     ram: "{{ item.ram }}"
     auth:


### PR DESCRIPTION
This change defines the endpoint type when creating a flavor. This is
being done to resolve issue #2060.

Closes-Bug: #2060
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>