### PR TITLE
Add pre-upgrade nova db Hygiene tasks

### DIFF
--- a/rpcd/playbooks/rpc-pre-upgrades.yml
+++ b/rpcd/playbooks/rpc-pre-upgrades.yml
@@ -19,3 +19,41 @@
     - role: "rpc_pre_upgrade"
   tags:
     - rpc-pre-upgrades
+
+- name: Run nova DB hygiene on shadow_instance tables
+  hosts: galera_all[0]
+  gather_facts: false
+  user: root
+  tasks:
+    - name: Prune the shadow instance tables
+      shell: |
+        mysql -sNL \
+              --unbuffered \
+              -e "delete from {{ item }} where deleted>0;" {{ nova_galera_database | default('nova') }}
+      with_items:
+        - shadow_instance_actions
+        - shadow_instance_actions_events
+        - shadow_instance_extra
+        - shadow_instance_faults
+        - shadow_instance_group_member
+        - shadow_instance_group_policy
+        - shadow_instance_groups
+        - shadow_instance_id_mappings
+        - shadow_instance_info_caches
+        - shadow_instance_metadata
+        - shadow_instance_system_metadata
+        - shadow_instance_type_extra_specs
+        - shadow_instance_type_projects
+        - shadow_instance_types
+        - shadow_instances
+
+- name: Run nova DB hygiene on instance tables
+  hosts: nova_api_os_compute[0]
+  gather_facts: false
+  user: root
+  tasks:
+    - name: Archive all nova deleted instances
+      command: "{{ nova_bin }}/nova-manage db archive_deleted_rows --until-complete"
+  vars:
+    nova_venv_tag: "{{ venv_tag }}"
+    nova_bin: "/openstack/venvs/nova-{{ nova_venv_tag }}/bin"


### PR DESCRIPTION
This change adds two tasks to run a Database deleted instances archive
and then to prune the shadow tables in preparation for upgrade. This
change will ensure that all deleted instances are cleanup which speeds
up nova migrations as well as ensures migrations are not impeded due
to legacy data being stuck in a deleted VM record.

Closes-Bug: #1608
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [UG-651](https://rpc-openstack.atlassian.net/browse/UG-651)