### PR TITLE
Adds check for neutron service venv

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
@@ -47,3 +47,9 @@
   when: inventory_hostname in groups['elasticsearch_container']
   tags:
     - elasticsearch
+
+# Run neutron verifciation tasks
+- include: post-upgrade-neutron-venv.yml
+  when: inventory_hostname in groups['neutron_all']
+  tags:
+    - neutron

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-neutron-venv.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-neutron-venv.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-elasticsearch_http_port: 9200
-swift_venv_tag: "{{ openstack_release }}"
-swift_venv_bin: "/openstack/venvs/swift-{{ swift_venv_tag }}/bin"
-neutron_venv_tag: "{{ openstack_release }}"
-neutron_venv_bin: "/openstack/venvs/neutron-{{ neutron_venv_tag }}/bin"
+- name: Find running neutron services not in venv
+  shell: |
+    pgrep -a "neutron" | awk '{print $2,$3}' | grep -vP "{{ neutron_venv_bin }}/\w+(\d\.\d)?\s{1}{{ neutron_venv_bin }}/\w+"
+  register: neutron_output
+  failed_when: "neutron_output.stdout_lines|length != 0"
+
+- name: Display output of neutron_output
+  debug: var=neutron_output

--- a/rpcd/playbooks/rpc-post-upgrades.yml
+++ b/rpcd/playbooks/rpc-post-upgrades.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Run post-upgrade tasks
-  hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container
+  hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container:neutron_all
   user: root
   any_errors_fatal: true
   roles:


### PR DESCRIPTION
This checks all neutron services to ensure using the proper
virtual environment for the openstack release. Reports fail
on any neutron service not running via correct venv.

Includes update to variable in use for neutron_venv_bin which
due to bad copy/paste uses swift variable name.

Connects rcbops/u-suk-dev#857

(cherry picked from commit fc40fa13146d4e685e97733bcd495dd38a61eac0)