### PR TITLE
Add playbooks and roles to deploy log aggregation container

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -22,3 +22,12 @@
   scm: git
   src: https://github.com/rcbops/rpc-maas
   version: 1701d34fcb106cec11ba00284ac462e78bef14e0
+- name: rpc-role-aggie
+  src: https://github.com/rcbops/rpc-role-aggie.git
+  scm: git
+  version: f169496d4d04ddac17b2fb4823d6a36f8bf6826f
+- name: rpc-role-aggie-build
+  src: https://github.com/rcbops/rpc-role-aggie-build.git
+  scm: git
+  version: 21f2fb66102200959298c3510804ed8a68b50965
+

--- a/releasenotes/notes/issue-942-additions-f1837f281ce51522.yaml
+++ b/releasenotes/notes/issue-942-additions-f1837f281ce51522.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    This change is to address issue-942 to allow for pulling and filtering logs
+    from the local elks stack and forward them to a global elk cluster for 
+    support.

--- a/rpcd/playbooks/aggie-build.yml
+++ b/rpcd/playbooks/aggie-build.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Build Aggie Package
+  hosts: 'localhost:repo_all'
+  roles:
+    - "rpc-role-aggie-build"
+  vars:
+    is_metal: "{{ properties.is_metal | default(False) }}"
+

--- a/rpcd/playbooks/aggie.yml
+++ b/rpcd/playbooks/aggie.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Setup Aggie host
+  hosts: 'aggie_all'
+  roles:
+    - "rpc-role-aggie"
+  vars:
+    is_metal: "{{ properties.is_metal | default(False) }}"

--- a/scripts/linting-ansible.sh
+++ b/scripts/linting-ansible.sh
@@ -30,8 +30,11 @@ pushd rpcd/playbooks/
   echo "Running ansible-lint"
   # Lint playbooks and roles while skipping the ceph-* roles. They are not
   # ours and so we do not wish to lint them and receive errors about code we
-  # do not maintain.
+  # do not maintain. Removing aggie roles as lint checks happen on repo PRs.
   ansible-lint -v *.yml --exclude ~/.ansible/roles/ceph.ceph-common \
                         --exclude ~/.ansible/roles/ceph.ceph-mon \
-                        --exclude ~/.ansible/roles/ceph.ceph-osd
+                        --exclude ~/.ansible/roles/ceph.ceph-osd \
+                        --exclude ~/.ansible/roles/rpc-role-aggie \
+                        --exclude ~/.ansible/roles/rpc-role-aggie-build
+
 popd


### PR DESCRIPTION
This change is for issue/942 with the overall goal of filtering
and pushing customer logs from the local elk stack to a shared
global elk cluster.  This should give support easier access to
search customer logs for a quicker resolution with customer issues.
This is done in two roles with a playbook for each.  One takes
the elixir based aggie code, builds it in a local lxc continer,
packages it up and copies it to the local repo servers. The second
playbook will set up an lxc container created through openstack-ansible's
setup-hosts playbook and deploy the aggie code to it.  Where
the roles are in their own repo's, future changes should only
require a version update in the ansible-role-requirements.yml file
for anxible-galaxy.

Connects https://github.com/rcbops/u-suk-dev/issues/942