### PR TITLE
Remove MaaS role default vars

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -51,10 +51,9 @@ rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 #maas_agent_token: some_token
 maas_target_alias: public0_v4
 
-# Set whether checks should be enabled or disabled
+# TODO(evrardjp): Remove these vars when this PR is merged, and sha bumped
+# with the a-r-r: https://github.com/rcbops/rpc-maas/pull/232
 ssl_check: false
-host_check: false
-remote_check: true
 
 # Set the LB device name in CORE
 #lb_name: 'unspecified'


### PR DESCRIPTION
There is no need to override these vars, as there are already
the role defaults, and are not overriden anywhere else, including
test gates.