### PR TITLE
[kilo] Correct ansible-role-requirements

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,9 +1,5 @@
-- name: ceph-common
-  src: https://github.com/ceph/ansible-ceph-common.git
-  version: 1c623611a1d43b4c9116d1a0c21f0bdbdd87a0e7
-- name: ceph-mon
-  src: https://github.com/ceph/ansible-ceph-mon.git
-  version: 01d3d6f0b06125b33b1e25745c06fa1d7137f7e9
-- name: ceph-osd
-  src: https://github.com/ceph/ansible-ceph-osd.git
-  version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
+---
+- name: sshd
+  scm: git
+  src: https://github.com/willshersystems/ansible-sshd
+  version: "0.4.4"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,6 +16,7 @@ export DEPLOY_SWIFT=${DEPLOY_SWIFT:-"yes"}
 export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-""}
 export BOOTSTRAP_OPTS=${BOOTSTRAP_OPTS:-""}
+export ANSIBLE_ROLE_FILE="/opt/rpc-openstack/ansible-role-requirements.yml"
 
 OA_DIR='/opt/rpc-openstack/openstack-ansible'
 RPCD_DIR='/opt/rpc-openstack/rpcd'


### PR DESCRIPTION
The openstack-ansible ansible-role-requirements.yml file
is specified in galaxy format and no longer works. In this
patch we ensure that the same role is specified using the
git format so that it's always retrievable. This ensures
that the ansible bootstrap works properly.

Also, the ceph roles which were specified in this file are
removed as this file is never used. The ceph roles are
instead included using submodules.

Connects https://github.com/rcbops/u-suk-dev/issues/1515