### PR TITLE
maas_target_alias is already the default

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -49,7 +49,6 @@ rpc_repo_path: /opt/rpc-openstack/openstack-ansible
 # By default we will create an agent token for each entity, however if you'd
 # prefer to use the same agent token for all entities then specify it here
 #maas_agent_token: some_token
-maas_target_alias: public0_v4
 
 # Set whether checks should be enabled or disabled
 ssl_check: false


### PR DESCRIPTION
This override don't need to exist:
- Its value is already the group default
- It's not overriden by any other mechanism
- It's not re-use outside the role scope.

Connected https://github.com/rcbops/u-suk-dev/issues/1620