### PR TITLE
[WIP] Newton backport check nova services

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/main.yml
@@ -32,7 +32,7 @@
 
 # Run openstack services verification tasks
 - include: post-upgrade-utility.yml
-  when: inventory_hostname in groups['utility'][0]
+  when: inventory_hostname == groups['utility'][0]
   tags:
     - openstack_services
 
@@ -53,3 +53,9 @@
   when: inventory_hostname in groups['neutron_all']
   tags:
     - neutron
+
+# Run nova verification tasks
+- include: post-upgrade-nova-venv.yml
+  when: inventory_hostname in groups['nova_all']
+  tags:
+    - nova

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-nova-venv.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-nova-venv.yml
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-elasticsearch_http_port: 9200
-swift_venv_tag: "{{ openstack_release }}"
-swift_venv_bin: "/openstack/venvs/swift-{{ swift_venv_tag }}/bin"
-neutron_venv_tag: "{{ openstack_release }}"
-neutron_venv_bin: "/openstack/venvs/neutron-{{ neutron_venv_tag }}/bin"
-nova_venv_tag: "{{ openstack_release }}"
-nova_venv_bin: "/openstack/venvs/nova-{{ nova_venv_tag }}/bin"
+# Extra `when` required to ensure this is only on Nova Service nodes which should
+# be running in a venv, as otherwise this could catch a valid nova service outside
+# of a venv
+- name: Find running nova services not in venv
+  shell: |
+    pgrep -a "nova" | awk '{print $2,$3}' | grep -vP "{{ nova_venv_bin }}/\w+[\d\.\d]?\s{1}{{ nova_venv_bin }}/\w+"
+  register: nova_output
+  when: '"nova" in hostvars["{{ inventory_hostname }}"].properties.service_name'
+  failed_when: "nova_output.stdout_lines|length != 0"
+
+- name: Display output of nova_output
+  debug: var=nova_output

--- a/rpcd/playbooks/rpc-post-upgrades.yml
+++ b/rpcd/playbooks/rpc-post-upgrades.yml
@@ -16,6 +16,7 @@
 - name: Run post-upgrade tasks
   hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container:neutron_all
   user: root
+  hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container:neutron_all
   any_errors_fatal: true
   roles:
     - rpc_post_upgrade

--- a/rpcd/playbooks/rpc-post-upgrades.yml
+++ b/rpcd/playbooks/rpc-post-upgrades.yml
@@ -16,7 +16,6 @@
 - name: Run post-upgrade tasks
   hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container:neutron_all
   user: root
-  hosts: galera_all:rabbitmq:utility:swift_proxy:elasticsearch_container:neutron_all
   any_errors_fatal: true
   roles:
     - rpc_post_upgrade


### PR DESCRIPTION
Adds post-upgrade task to check running nova services to ensure
all are running in the correct venv.

Includes commit fc40fa1 which is awaiting backport in #2209

Connects rcbops/u-suk-dev#856

(cherry picked from commit d6236c3)