### PR TITLE
Use CLI to create flavors

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/create_default_flavors.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/create_default_flavors.yml
@@ -13,33 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install shade and its dependencies
-  pip:
-    name: "{{ item.name }}"
-    version: "{{ item.version }}"
-    extra_args: "--isolated"
-  with_items:
-    - { name: "shade", version: "1.16.0"}
-
+# TODO(evrardjp): Move back to the previous commit with os_ module in
+# a more recent branch, with compatible requirements AND playbook
+# will be targetting to good hosts directly.
 - name: Add default flavors
-  os_nova_flavor:
-    name: "{{ item.name }}"
-    vcpus: "{{ item.vcpus }}"
-    state: present
-    endpoint_type: "internal"
-    disk: "{{ item.disk }}"
-    ram: "{{ item.ram }}"
-    auth:
-      auth_url: "{{ keystone_service_internalurl }}"
-      username: "admin"
-      password: "{{ keystone_auth_admin_password }}"
-      project_name: "admin"
-      domain_name: "Default"
-    validate_certs: false
+  shell: |
+    openstack --os-cloud default flavor create --ram {{ item.RAM }} --disk {{ item.Disk }} --vcpus {{ item.VCPUs }} --public {{ item.Name }}
+  register: flavor_create
+  failed_when:
+    - flavor_create.stderr.find('already exists') == -1
+    - flavor_create.rc != 0
+  changed_when:
+    - flavor_create.rc == 0
   with_items:
-    - { name: 'm1.tiny', vcpus: '1', disk: '1', ram: '512' }
-    - { name: 'm1.small', vcpus: '1', disk: 20, ram: '2048' }
-    - { name: 'm1.medium', vcpus: '2', disk: '40', ram: '4096' }
-    - { name: 'm1.large', vcpus: '4', disk: '80', ram: '8192' }
-    - { name: 'm1.xlarge', vcpus: '8', disk: '160', ram: '16384' }
-
+    - { Name: 'm1.tiny', VCPUs: '1', Disk: '1', RAM: '512' }
+    - { Name: 'm1.small', VCPUs: '1', Disk: 20, RAM: '2048' }
+    - { Name: 'm1.medium', VCPUs: '2', Disk: '40', RAM: '4096' }
+    - { Name: 'm1.large', VCPUs: '4', Disk: '80', RAM: '8192' }
+    - { Name: 'm1.xlarge', VCPUs: '8', Disk: '160', RAM: '16384' }

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -105,6 +105,9 @@
 
 - include: create_default_flavors.yml
   when:  inventory_hostname == groups['utility'][0]
+  tags:
+    - rpc_support-config
+    - rpc_support-flavors
 
 - include: sos.yml
   when:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -17,12 +17,12 @@
 import argparse
 import datetime
 import errno
+import logging
 import os
 import re
+import shutil
 import sys
 import yaml
-import logging
-import shutil
 
 import github3
 import sh
@@ -317,8 +317,7 @@ def chk_devel_version(repo, branch, expected_release):
 
 
 def update_repo_with_new_ver_number(repo, branch, new_version_number):
-    ''' Update the future_tag into repo, then git add, commit and push.
-    '''
+    """Update the future_tag into repo, then git add, commit and push."""
 
     repo.git.checkout(branch)
     repo.git.pull(repo.remote, branch)
@@ -525,8 +524,8 @@ def build_parser():
 
 
 def validate_args(args):
-    ''' Ensure the args are following expectations.
-    '''
+    """Ensure the args are following expectations."""
+
     # Store tag as a string on top of as a tag object
     args.tag_str = str(args.tag)
     # args.branch is always a string, discovered or not
@@ -613,6 +612,7 @@ def main():
                      .format(args.branch, release.next_release))
         update_repo_with_new_ver_number(rpco_repo, args.branch,
                                         str(release.next_release))
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
There is no good version (read: with compatible requirements)
for together shade, pbr, os client tools, and another conflicting
package.

This removes the dependency to shade and works out of the box.
Idempotency is ensured for existing/non existing flavors, without
checking their values.

This can be rolled back when the requirements will be bumped (i.e.
when we are in an upper branch, meant for the usage of shade and
these modules)

Connected https://github.com/rcbops/rpc-openstack/issues/2227