### PR TITLE
[kilo] Allow builds to be executed on new kernels

### DIFF
--- a/rpcd/patches/openstack-hosts-u-suk-dev-issues-1629.patch
+++ b/rpcd/patches/openstack-hosts-u-suk-dev-issues-1629.patch
@@ -1,0 +1,13 @@
+diff --git a/playbooks/roles/openstack_hosts/defaults/main.yml b/playbooks/roles/openstack_hosts/defaults/main.yml
+index 2c305552..30d6a238 100644
+--- a/playbooks/roles/openstack_hosts/defaults/main.yml
++++ b/playbooks/roles/openstack_hosts/defaults/main.yml
+@@ -45,7 +45,7 @@ openstack_host_kernel_modules:
+   - nf_defrag_ipv4
+   - nf_nat
+   - nf_nat_ipv4
+-  - scsi_dh
++  - "{% if ansible_kernel | version_compare('4.4.0-0-generic', '<') %}scsi_dh{% endif %}"
+   - vhost_net
+   - x_tables
+ 

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -24,3 +24,6 @@
   user: root
   roles:
     - { role: "patcher", tags: [ "patcher" ] }
+  vars:
+    patcher_files:
+      - openstack-hosts-u-suk-dev-issues-1629.patch


### PR DESCRIPTION
This change conditionally includes the "scsi_dh" module which
is no longer available when using the 4.4 kernel.

This is a patcher role implementation of:
https://github.com/openstack/openstack-ansible/commit/8d40626145c566f9e5c1a0ca40f4121b78e1b18f

Connects https://github.com/rcbops/u-suk-dev/issues/1629