### PR TITLE
RI-19 Bump OSA SHA to tip of stable/ocata

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -13,19 +13,15 @@
 - name: rcbops_openstack-ops
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
-  version: de006ade2f88790c43ec06a104abc895d98fe9b6
+  version: f87406880f67584b5fe562d2711734bbd63c0fdb
 - name: os_octavia
   scm: git
   src: https://github.com/openstack/openstack-ansible-os_octavia.git
   version: master
-#TODO(odyssey4me):
-# When the rpc_maas SHA is updated to include the below SHA,
-# remove the workaround from rpcd/playbooks/setup-maas.yml
-# https://github.com/rcbops/rpc-maas/commit/be5a9f82592e5dfd835aa76d8a6cff2d7ea53d3f
 - name: rpc_maas
   scm: git
   src: https://github.com/rcbops/rpc-maas
-  version: 1701d34fcb106cec11ba00284ac462e78bef14e0
+  version: 52d9084c8eca07c3bcb66bbb8d7f5ab93a300bc0
 # Override the current lxc_hosts role until
 # https://github.com/openstack/openstack-ansible-lxc_hosts/commit/df227381ff3d318fcb8d7ab925f1ee66ed161ec8
 # gets taken into a SHA bump in OSA and RPC.
@@ -36,4 +32,4 @@
 - name: rpc-role-logstash
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
-  version: e887f843b623c08ba5b0298df4df8ecd6b5303fc 
+  version: 3f5e7a6044629e76acb1933af19f09a89e55917b

--- a/group_vars/all/elasticsearch.yml
+++ b/group_vars/all/elasticsearch.yml
@@ -1,0 +1,10 @@
+# Elasticsearch versions
+# NOTE (alextricity25):
+# The elasticsearch version variables needs to be available to the repo_build role
+# due to the way it builds out the distro packages dataset. Distro packages within
+# a role are indexed using their raw form(jinja is not rendered). The repo_build
+# role then attempts to render these datasets, and will fail if it cannot resolve
+# a variable. Putting these variables in here ensures the repo_build
+# role can interpolate the variables correctly.
+elasticsearch_version: 2.4.1
+elasticsearch_reindex_version: 1.7.5

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -122,3 +122,9 @@ haproxy_extra_services:
       haproxy_balance_type: tcp
       haproxy_backend_options:
         - "ssl-hello-chk"
+
+# Do not run tempest as part of setup-openstack. Instead, tempest is run in deploy.sh
+# so we can control when to run it apart from setup-openstack.yml
+# See https://github.com/openstack/openstack-ansible/blob/485100fbd36adbacd6f300a34a6acd9df3fd5932/playbooks/setup-openstack.yml#L40
+tempest_install: no
+tempest_run: no

--- a/group_vars/all/release.yml
+++ b/group_vars/all/release.yml
@@ -16,5 +16,5 @@
 # The release tag to use
 # Note that this is set here so that the openstack_release override in osa_defaults
 # is able to use it.
-rpc_release: "r14.1.0rc1"
+rpc_release: "r15.0.0rc1"
 

--- a/group_vars/all/rpc-o.yml
+++ b/group_vars/all/rpc-o.yml
@@ -29,11 +29,3 @@ horizon_custom_uploads:
 # Use RPC python package index
 repo_build_pip_extra_indexes:
   - "https://rpc-repo.rackspace.com/pools"
-
-# Tempest test execution options
-tempest_run_tempest_opts:
-  - "--serial"
-# Tempest testr options
-tempest_testr_opts: []
-# Tempest tests to run. A one-line, space-delimited string
-tempest_test_sets: "scenario defcore cinder_backup"

--- a/releasenotes/notes/add-upper-constraints-to-es-c2eb0b51c83e30e2.yaml
+++ b/releasenotes/notes/add-upper-constraints-to-es-c2eb0b51c83e30e2.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The elasticsearch role now respects upper constraints when installing
+    pip packages.

--- a/releasenotes/notes/move-es-version-vars-17c22cfd558a68d5.yaml
+++ b/releasenotes/notes/move-es-version-vars-17c22cfd558a68d5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``elasticsearch_version`` and ``elasticsearch_reindex_version``
+    variables have been moved to ``group_vars/all/rpc-o.yml``
+    so that all OSA roles can have access to the variables.

--- a/releasenotes/notes/remove-elasticsearch-constraint-9dae50a1b4aeb7e6.yaml
+++ b/releasenotes/notes/remove-elasticsearch-constraint-9dae50a1b4aeb7e6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``elasticsearch>=2.0.0,<3.0.0`` constraint has been removed from the
+    ElasticSearch role, and is now controlled via OpenStack upper-constraints
+    placed here:
+    https://github.com/openstack/requirements/blob/b6c588574ed23e7e5b8c1b788c7117f7c3aa4cff/upper-constraints.txt#L124

--- a/releasenotes/notes/rename-ansible-ssh-host-7332cc551f494495.yaml
+++ b/releasenotes/notes/rename-ansible-ssh-host-7332cc551f494495.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    ``ansible_ssh_host`` has been removed from Ansible 2.2 and renamed to
+    ``ansible_host``. All references of ``ansible_ssh_host`` in RPCO have
+    been renamed to ``ansible_host``.

--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -42,7 +42,7 @@ elasticsearch_version: 2.4.1
 elasticsearch_reindex_version: 1.7.5
 
 elasticsearch_pip_packages:
-  - elasticsearch>=2.0.0,<3.0.0
+  - elasticsearch
   - elasticsearch-curator==4.0.4
   - httplib2
 

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -31,7 +31,9 @@
   pip:
     name: "{{ item }}"
     state: latest
-    extra_args: "{{ pip_install_options | default('') }}"
+    extra_args: >-
+      {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
+      {{ pip_install_options | default('') }}
   register: install_pip_packages
   until: install_pip_packages | success
   retries: 5

--- a/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
@@ -44,7 +44,7 @@
 
 - name: Wait for ElasticSearch port
   wait_for:
-    host: "{{ ansible_ssh_host }}"
+    host: "{{ ansible_host }}"
     port: "9200"
 
 - name: Setup the ElasticSearch Curator cron job

--- a/rpcd/playbooks/roles/filebeat/defaults/main.yml
+++ b/rpcd/playbooks/roles/filebeat/defaults/main.yml
@@ -31,7 +31,7 @@ filebeat_logstash_port: "{{ logstash_beats_port |default(5044) }}"
 # NOTE(sigmavirus24): Once we upgrade to Ansible 2.1, we can use the extract
 # filter
 #"{{ groups['logstash_all'] | map('extract', hostvars, ['container_address']) | list }}"
-filebeat_logstash_hosts: "{% for host in groups['logstash_all'] %}{{ hostvars[host]['ansible_ssh_host'] }}:{{ filebeat_logstash_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+filebeat_logstash_hosts: "{% for host in groups['logstash_all'] %}{{ hostvars[host]['ansible_host'] }}:{{ filebeat_logstash_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 # NOTE(sigmavirus24): Explanation of the regular expression:
 # - The Date is formatted by oslo.log as YYYY-MM-DD

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
@@ -39,4 +39,3 @@
   with_items: "{{ kibana_pip_packages }}"
   tags:
     - kibana-pip-packages
-

--- a/rpcd/playbooks/setup-maas.yml
+++ b/rpcd/playbooks/setup-maas.yml
@@ -24,11 +24,5 @@
   gather_facts: true
   roles:
     - role: "rpc_maas"
-      #TODO(odyssey4me):
-      # This is a workaround until the below commit is included in the
-      # rpc-maas SHA we consume.
-      # https://github.com/rcbops/rpc-maas/commit/be5a9f82592e5dfd835aa76d8a6cff2d7ea53d3f
-      holland_venv_enabled: true
-      holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
   tags:
     - maas-setup

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -21,6 +21,9 @@
       set_fact:
         user_variables_overrides:
           apply_security_hardening: "{{ rpco_deploy_hardening }}"
+          # Tempest is turned off to prevent the tests from running by default
+          tempest_run: no
+          tempest_install: no
       when: "{{ not rpco_deploy_ceph | bool }}"
     - name: Set ceph user_variables override
       set_fact:
@@ -28,6 +31,9 @@
           apply_security_hardening: "{{ rpco_deploy_hardening }}"
           glance_default_store: rbd
           nova_libvirt_images_rbd_pool: vms
+          # Tempest is turned off to prevent the tests from running by default
+          tempest_run: no
+          tempest_install: no
       when: "{{ rpco_deploy_ceph | bool }}"
   vars:
     rpco_deploy_ceph: "{{ lookup('env', 'DEPLOY_CEPH') }}"
@@ -38,6 +44,8 @@
   vars:
     bootstrap_host_apt_distribution_suffix_list: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary([], ['updates', 'backports']) }}"
     scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
+    bootstrap_host_scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
+    bootstrap_user_variables_template: "user_variables.aio.yml.j2"
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"
     uca_enable: no

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -171,7 +171,7 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
 
   if [[ "${DEPLOY_TEMPEST}" == "yes" ]]; then
     # Deploy tempest
-    run_ansible os-tempest-install.yml
+    run_ansible ${BASE_DIR}/scripts/run_tempest.yml
   fi
 
   if [[ "${DEPLOY_RALLY}" == "yes" ]]; then

--- a/scripts/run_tempest.yml
+++ b/scripts/run_tempest.yml
@@ -13,23 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Get defcore tests and set tempest_test_whitelist fact
+- name: Get defcore tests and set tempest_test_whitelist fact
+  hosts: utility_all[0]
+  gather_facts: no
+  user: root
+  tasks:
+    - name: Get defcore test list from defcore repo
+      get_url:
+        url: "{{ defcore_url }}"
+        dest: "/opt/defcore_tempest_list_{{ version_number }}"
+      delegate_to: localhost
+
+    - name: Set fact for defcore json file
+      set_fact:
+        defcore_json_file: "{{ lookup('file', '/opt/defcore_tempest_list_'~version_number) | from_json }}"
+
+    - name: Set fact for defcore tests
+      set_fact:
+        defcore_tests: "{{ defcore_tests|default([]) + item.tests.keys() }}"
+      with_items: "{{ defcore_json_file['capabilities'].values() }}"
+
+    - name: Set tempest_test_whitelist fact
+      set_fact:
+        tempest_test_whitelist: "{{ tempest_test_whitelist|default([]) + defcore_tests }}"
+  tags:
+    - tempest_install
+  vars:
+    # 2017.01 corresponds to Ocata
+    version_number: "2017.01"
+    defcore_url: "https://raw.githubusercontent.com/openstack/defcore/master/{{ version_number }}.json"
 
 # Run the tempest playbook to install tempest
 - include: ../openstack-ansible/playbooks/os-tempest-install.yml
   tags:
     - tempest_install
+  vars:
+    tempest_run: no
 
-- name: Execute Tempest Tests
-  hosts: utility[0]
+# Run the tempest tests from the os_tempest role
+- name: Run tempest tests from the os_tempest role
+  hosts: utility_all[0]
+  gather_facts: no
   user: root
-  tasks:
-    - name: Execute tempest tests
-      shell: |
-        export RUN_TEMPEST_OPTS='{{ tempest_run_tempest_opts | join(' ') }}'
-        export TESTR_OPTS='{{ tempest_testr_opts | join(' ') }}'
-        bash /opt/openstack_tempest_gate.sh {{ tempest_test_sets }}
-      changed_when: false
   tags:
     - tempest_execute_tests
-
-
+  tasks:
+    - name: Run Tempest Tests
+      include_role:
+        name: os_tempest
+        tasks_from: tempest_run

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ whitelist_externals =
     sed
 deps =
     -rtest-requirements.txt
-    ansible{env:ANSIBLE_VERSION:==2.1.0}
+    ansible{env:ANSIBLE_VERSION:==2.2.2}
     -e./hacking
 setenv =
     ANSIBLE_ACTION_PLUGINS = {homedir}/.ansible/roles/plugins/action


### PR DESCRIPTION
OpenStack-Ansible Ocata Release Notes:
https://docs.openstack.org/releasenotes/openstack-ansible/ocata.html

The following changes have been made to comply with upstream
changes:

* The bootstrap scenario variable ``scenario`` has been changed per
  openstack/openstack-ansible@cd8f931
  (release note provided)

* OSA no longer supports the use of custom scenarios due to the way
  it builds out the user_variables template filename. An upstream
  patch has been submitted to change this: https://review.openstack.org/#/c/459329/1
  (release note provided)

* Move elasticsearch version variables to user_variable files.
  The elasticsearch version variables needs to be available to
  the repo_build role due to the way it builds out the distro
  packages dataset. Distro packages within
  a role are indexed using their raw form(jinja is not rendered).
  The repo_build role then attempts to render these datasets,
  and will fail if it cannot resolve a variable. Putting these
  variables in user_variables ensures the repo_build
  role can interpolate the variables correctly.
  (release note provided)

* Change references of `ansible_ssh_host` to `ansible_host`
  (release note provided)

* Remove elasticsearch constraints in role's ``defaults/main.yml``
  The constraint is now respected in OpenStack's upper-constraints.
  Additionally, the elasticsearch role has been modified to respect
  these upper-constraints when install pip packages.
  (release note provided)

* Put quotes and brakets around the "logstash_apt_packages" variable

* Bump the rpc-maas role SHA to fix some issues with python module
  versions: rcbops/rpc-maas#246

* Bump the openstack-ops role SHA to bring in some fixes for ansible 2.2.2

* The ansible version in tox.ini has been changed to ansible 2.2.2

* Removed a work-around in rpcd/playbooks/setup-maas.yml that is no longer
  required as a result of the rpc-maas role SHA bump.

* Changed tempest execution so that the tasks in the os_tempest role are used