### PR TITLE
Remove old beaver checks/alarms

### DIFF
--- a/rpcd/playbooks/rpc-pre-upgrades.yml
+++ b/rpcd/playbooks/rpc-pre-upgrades.yml
@@ -80,3 +80,9 @@
       group:
         name: beaver
         state: absent
+
+    - name: Remove legacy beaver MaaS checks/alarms
+      file:
+        path: "/etc/rackspace-monitoring-agent.conf.d/beaver_process_check-{{ inventory_hostname }}.yaml"
+        state: absent
+      delegate_to: "{{ physical_host }}"


### PR DESCRIPTION
Our gate job RPC-AIO_mitaka-upgrade-periodic, which does a more
extensive maas test, is failing verify-maas.yml after doing the mitaka
upgrade.  This is because on mitaka we remove beaver in favour of
filebeat but nothing cleans up the old beaver MaaS checks.

This commit simply removes those old checks as part of the beaver
cleanup.