### PR TITLE
[Backport - newton-14.0] Fix holland backup monitor for greenfield

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/holland_create_backupset.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/holland_create_backupset.yml
@@ -1,0 +1,48 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: List holland backups
+  find:
+    path: "/var/backup/holland_backups/rpc_support"
+    file_type: directory
+    age_stamp: ctime
+    age: -1d
+    size: 4m
+    use_regex: true
+    patterns: '\d+_\d+'
+  register: found_holland_backups
+  tags:
+    - holland_create_backup
+    - holland_all
+
+- name: Create holland backup (venv)
+  shell: |
+    {{ holland_venv_bin + '/' }}holland bk
+  when:
+    - holland_venv_enabled | bool
+    - found_holland_backups.matched < 1
+  tags:
+    - holland_create_backup
+    - holland_all
+
+- name: Create holland backup (no venv)
+  shell: |
+    /usr/local/bin/holland bk
+  when:
+    - not holland_venv_enabled | bool
+    - found_holland_backups.matched < 1
+  tags:
+    - holland_create_backup
+    - holland_all

--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -87,6 +87,10 @@
   when: >
     inventory_hostname in groups['galera']
 
+- include: holland_create_backupset.yml
+  when: >
+    inventory_hostname in groups['galera']
+
 - include: neutron_debug.yml
   when: >
     inventory_hostname in groups['neutron_agent']


### PR DESCRIPTION
This fix will create a holland backup when not present.
In addition, the holland backup monitor is checking for one
successful backup within 48 hours in order to go into an
OK state. This fixes specifically the greenfield
installation where no backup is present from 'yesterday'

Connects #2048
(cherry picked from commit 1fd7d2f032d8a82a2db0d18ab8b9d4ec6e708885)