### PR TITLE
Remove run_plugin_in_venv.sh from plugin templates

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/templates/container_storage_checks.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/container_storage_checks.yaml.j2
@@ -6,8 +6,8 @@ period      : "{{ maas_check_period_override[label] | default(maas_check_period)
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
-    file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}container_storage_check.py", "--thresh", "{{ percent_used_critical_threshold }}"]
+    file    : container_storage_check.py
+    args    : ["--thresh", "{{ percent_used_critical_threshold }}"]
 alarms      :
     container_storage_percent_used_critical:
         label                   : container_storage_percent_used--{{ ansible_hostname }}

--- a/rpcd/playbooks/roles/rpc_maas/templates/hp-check.yaml.j2
+++ b/rpcd/playbooks/roles/rpc_maas/templates/hp-check.yaml.j2
@@ -6,8 +6,7 @@ period      : "{{ maas_check_period_override[label] | default(maas_check_period)
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
-    file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}hp_monitoring.py"]
+    file    : hp_monitoring.py
 alarms      :
     hp-controller_status :
         label                   : hp-controller--{{ inventory_hostname|quote }}


### PR DESCRIPTION
Two template files reference run_plugin_in_venv.sh, however this
wrapper was only introduced in rpco's mitaka branch.

Connects https://github.com/rcbops/u-suk-dev/issues/1654