### PR TITLE
Move maas_rpc_scripts_dir and maas_venv_enabled

### DIFF
--- a/rpcd/playbooks/releasenotes/notes/remove-maas-venv_enabled-b88266875a95785c.yaml
+++ b/rpcd/playbooks/releasenotes/notes/remove-maas-venv_enabled-b88266875a95785c.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    The maas_venv_enabled variable has been removed from the verify-maas.yml
+    playbook. The rpc-maas-tool.py script will now always run from it's own
+    virtualenv.

--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -31,9 +31,7 @@
 
     - name: "Local MaaS Checks"
       shell: |
-        {% if maas_venv_enabled | bool %}
         . {{ maas_venv_bin }}/activate
-        {% endif %}
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-local
       register: verify_maas
       failed_when: verify_maas.rc != 0
@@ -44,9 +42,7 @@
 
     - name: "Verify Checks & Alarms are registered"
       shell: |
-        {% if maas_venv_enabled | bool %}
         . {{ maas_venv_bin }}/activate
-        {% endif %}
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-created \
         --entity {{ inventory_hostname }}{{ maas_fqdn_extension }} \
         {% for ec in maas_excluded_checks %} --excludedcheck {{ec}}
@@ -66,9 +62,7 @@
 
     - name: "Verify Check & Alarm Status"
       shell: |
-        {% if maas_venv_enabled | bool %}
         . {{ maas_venv_bin }}/activate
-        {% endif %}
         {{ maas_rpc_scripts_dir }}/rpc-maas-tool.py verify-status \
         --entity {{ inventory_hostname }}{{ maas_fqdn_extension }}
       register: verify_status
@@ -81,3 +75,5 @@
 
   vars_files:
     - [ "roles/rpc_maas/defaults/main.yml", "/etc/ansible/roles/rpc_maas/defaults/main.yml", "{{ ansible_env.HOME }}/.ansible/roles/rpc_maas/defaults/main.yml" ]
+  vars:
+    maas_rpc_scripts_dir: "/opt/rpc-openstack/scripts"


### PR DESCRIPTION
This commit moves the maas_rpc_scripts_dir variable definition to the
verify-maas.yml playbook. This variable is used no where else in the
rpc-maas role and has been taken out per
https://github.com/rcbops/rpc-maas/pull/239

This commit also removes the maas_venv_enabled variable. MaaS plugins
will now always run inside a python virtualenv.

Connects https://github.com/rcbops/u-suk-dev/issues/1601