### PR TITLE
[Backport - newton-14.0] Add run_tempest.yml playbook

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -154,3 +154,11 @@ secure_cluster_flags:
 # this variable is required for ceph.ceph-common to function properly as our ceph playbooks
 # are not suppported by Ansible 2.1.5
 check_firewall: False
+
+# Tempest test execution options
+tempest_run_tempest_opts:
+  - "--serial"
+# Tempest testr options
+tempest_testr_opts: []
+# Tempest tests to run. A one-line, space-delimited string
+tempest_test_sets: "scenario defcore cinder_backup"

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -156,3 +156,9 @@ update-yaml.py
 
 This script takes in two arguments, a base file and an override file,
 then merges the two together and removes any duplicates.
+
+run_tempest.yml
+---------------
+
+This playbook includes the upstream os-tempest-install.yml playbook, then
+executes tempests tests.

--- a/scripts/run_tempest.yml
+++ b/scripts/run_tempest.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Run the tempest playbook to install tempest
+- include: ../openstack-ansible/playbooks/os-tempest-install.yml
+  tags:
+    - tempest_install
+
+- name: Execute Tempest Tests
+  hosts: utility[0]
+  user: root
+  tasks:
+    - name: Execute tempest tests
+      shell: |
+        RUN_TEMPEST_OPTS={{ tempest_run_tempest_opts | join(' ') }}
+        TESTR_OPTS={{ tempest_testr_opts | join(' ') }}
+        bash /opt/openstack_tempest_gate.sh {{ tempest_test_sets }}
+      changed_when: false
+  tags:
+    - tempest_execute_tests
+
+


### PR DESCRIPTION
This playbook installs tempest and executes the tempest tests
defined in group_vars/all/rpc_o.yml in the variable
``tempest_test_sets``.

The goal for doing this is to eventually move out tempest test
execution from the rpc-gating repository, into the rpc-openstack
repository series branches. This is so, from the point of view
of the gating jobs, the tempest tests are consumed the same
way regardless of openstack version.

Connects https://github.com/rcbops/u-suk-dev/issues/1680

(cherry picked from commit 0e589df4fc7ce4327ea615c8ca28f72ee4920fce)