### PR TITLE
[Backport - mitaka-13.1] Add run_tempest.yml playbook

### DIFF
--- a/releasenotes/notes/add-tempest-execution-playbook-efe64a286f255c34.yaml
+++ b/releasenotes/notes/add-tempest-execution-playbook-efe64a286f255c34.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    A new playbook has been introduced in the ``scripts/`` directory called
+    ``run_tempest.yml``. This playbook will install tempest using the upstream
+    OSA role, then execute the tempest tests defined in the sets enumerated
+    in the ``tempest_test_sets`` variable.
+  - |
+    A new variable, ``tempest_test_sets`` has been added to
+    group_vars/all/rpc-o.yml. This variable contains a space-delimited string
+    of tempest test sets to execute when running the ``scripts/run_tempest.yml``
+    playbook.

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -159,3 +159,11 @@ secure_cluster: true
 # List of secure flags to set on for a pool (options for the list are nodelete, nopgchange, nosizechange - prevents deletion, pg from changing and size from changing respectively).
 secure_cluster_flags:
   - nodelete
+
+# Tempest test execution options
+tempest_run_tempest_opts:
+  - "--serial"
+# Tempest testr options
+tempest_testr_opts: []
+# Tempest tests to run. A one-line, space-delimited string
+tempest_test_sets: "scenario defcore cinder_backup"

--- a/scripts/run_tempest.yml
+++ b/scripts/run_tempest.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Run the tempest playbook to install tempest
+- include: ../openstack-ansible/playbooks/os-tempest-install.yml
+  tags:
+    - tempest_install
+
+- name: Execute Tempest Tests
+  hosts: utility[0]
+  user: root
+  tasks:
+    - name: Execute tempest tests
+      shell: |
+        RUN_TEMPEST_OPTS={{ tempest_run_tempest_opts | join(' ') }}
+        TESTR_OPTS={{ tempest_testr_opts | join(' ') }}
+        bash /opt/openstack_tempest_gate.sh {{ tempest_test_sets }}
+      changed_when: false
+  tags:
+    - tempest_execute_tests
+
+


### PR DESCRIPTION
This playbook installs tempest and executes the tempest tests
defined in user_rpco_variables_defaults.yml in the variable
``tempest_test_sets``.

The goal for doing this is to eventually move out tempest test
execution from the rpc-gating repository, into the rpc-openstack
repository series branches. This is so, from the point of view
of the gating jobs, the tempest tests are consumed the same
way regardless of openstack version.

Connects https://github.com/rcbops/u-suk-dev/issues/1680

(cherry picked from commit 0e589df4fc7ce4327ea615c8ca28f72ee4920fce)