### PR TITLE
Tighten Sphinx constraints

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ bashate>=0.2 # Apache-2.0
 
 
 # This is required for the docs build jobs
-sphinx>=1.3.4
+sphinx>=1.3.4,<1.6.0
 oslosphinx>=2.5.0 # Apache-2.0
 reno==2.2.0 # Apache-2.0. Latest version as of 03-20-2017
 sphinx_rtd_theme>=0.1.9


### PR DESCRIPTION
The latest version of Sphinx(1.6) introduced some problems with our
current tox tests for release notes. This commit tigtens the constraint
so that version 1.6 is not installed.