### PR TITLE
[Backport - mitaka-13.1] Tighten Sphinx constraint

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,8 +7,8 @@ mccabe==0.2.1 # capped for flake8
 bashate>=0.2 # Apache-2.0
 
 
-# this is required for the docs build jobs
-sphinx>=1.3.4
+# This is required for the docs build jobs
+sphinx>=1.3.4,<1.6.0
 oslosphinx>=2.5.0 # Apache-2.0
 # TODO (alextricity25)
 # We need to investigate reno > 2.0.0


### PR DESCRIPTION
The latest version of Sphinx(1.6) introduced some problems with our
current tox tests for release notes. This commit tightens the constraint
so that version 1.6 is not installed.

(cherry picked from commit 9aeb628208387299cdd1c6ed618e6371ba4367dc)