### PR TITLE
Restrict trusty-backports package imports

### DIFF
--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -112,6 +112,8 @@ aptly_mirrors:
       - main
       - universe
     create_flags:
+      - "-filter='apparmor | cgmanager | lxc'"
+      - "-filter-with-deps"
       - "-keyring='trustedkeys.gpg'"
     update_flags:
       - "-keyring='trustedkeys.gpg'"


### PR DESCRIPTION
We only want a very limited package set from
trusty backports. If we import too much, then
the backports packages get installed and may
interfere.

Connects https://github.com/rcbops/u-suk-dev/issues/1698