### PR TITLE
Adapt based on artifact availability

### DIFF
--- a/scripts/artifacts-building/apt/build-apt-artifacts.sh
+++ b/scripts/artifacts-building/apt/build-apt-artifacts.sh
@@ -65,9 +65,6 @@ fi
 # be at /opt/rpc-openstack, so we link the current folder there.
 ln -sfn ${PWD} /opt/rpc-openstack
 
-# Figure out the release version
-export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
-
 # Install Ansible
 ./scripts/bootstrap-ansible.sh
 cp scripts/artifacts-building/apt/lookup/* /etc/ansible/roles/plugins/lookup/

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -65,15 +65,8 @@ cd /opt/rpc-openstack
 sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
 sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
 
-# Figure out the release version
-export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
-
-# Read the OS information
-source /etc/os-release
-source /etc/lsb-release
-
 # If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if curl http://rpc-repo.rackspace.com/meta/1.0/index-system | grep "^${ID};${DISTRIB_CODENAME};.*${RPC_RELEASE};"; then
+if container_artifacts_available; then
   export PUSH_TO_MIRROR="NO"
 fi
 
@@ -82,15 +75,10 @@ if [[ "$(echo ${REPLACE_ARTIFACTS} | tr [a-z] [A-Z])" == "YES" ]]; then
   export PUSH_TO_MIRROR="YES"
 fi
 
-# Remove the RPC-O default configurations that are necessary
-# for deployment, but cause the build to break due to the fact
-# that they require the container artifacts to be available,
-# but those are not yet built.
-sed -i.bak '/lxc_image_cache_server: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_cache_default_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_cache_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+# Remove the AIO configuration relating to the use
+# of container artifacts. This needs to be done
+# because the container artifacts do not exist yet.
+./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
 echo "rpc_release: ${RPC_RELEASE}" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml

--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -43,9 +43,6 @@ export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 # Bootstrap Ansible
 ./scripts/bootstrap-ansible.sh
 
-# Figure out the release version
-export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
-
 # Fetch all the git repositories and generate the git artifacts
 # The openstack-ansible CLI is used to ensure that the library path is set
 #
@@ -55,7 +52,7 @@ openstack-ansible -i /opt/inventory \
                   ${ANSIBLE_PARAMETERS}
 
 # If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if curl http://rpc-repo.rackspace.com/git-archives/${RPC_RELEASE}/requirements.checksum; then
+if git_artifacts_available; then
   export PUSH_TO_MIRROR="NO"
 fi
 

--- a/scripts/artifacts-building/remove-container-aio-config.sh
+++ b/scripts/artifacts-building/remove-container-aio-config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Main ----------------------------------------------------------------------
+
+# Remove the env.d configurations that set the build to use
+# container artifacts. We don't want this because container
+# artifacts do not currently exist when this script is used.
+sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/env.d/*.yml
+
+# Remove the RPC-O default configurations that are necessary
+# for deployment, but cause the build to break due to the fact
+# that they require the container artifacts to be available,
+# but those are not yet built.
+sed -i.bak '/lxc_image_cache_server: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_cache_default_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_cache_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -41,3 +41,11 @@ fi
 openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \
                   -e "${BOOTSTRAP_OPTS}"
+
+# If there are no container artifacts for this release, then remove the container artifact configuration
+if ! container_artifacts_available; then
+  # Remove the AIO configuration relating to the use
+  # of container artifacts. This needs to be done
+  # because the container artifacts do not exist yet.
+  ./scripts/artifacts-building/remove-container-aio-config.sh
+fi

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -42,9 +42,8 @@ check_submodule_status
 #
 # This has the ability to be disabled for the purpose of reusing the
 # bootstrap-ansible script for putting together the apt artifacts.
-if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]]; then
-  apt_sources_back_to_stock
-  apt_sources_use_rpc_apt_artifacts
+if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]] && apt_artifacts_available; then
+  configure_apt_sources
 fi
 
 # begin the bootstrap process


### PR DESCRIPTION
When rpc_release is changed, all PR's will fail
until the artifacts for that rpc_release are
generated (which takes ~8 hours).

This will stall development and cause a
chicken-and-egg problem where the PR to change
the release can't merge because the artifacts
the build will try to use do not exist, nor will
they until the patch to change the release
merges.

This patch solves that problem by making the AIO
configuration and deployment process use
artifacts if they're available, or not use them
if they are not available.

The artifact build scripts are adapted to re-use
the same functions to clean up a bit of code
duplication.

Connects https://github.com/rcbops/u-suk-dev/issues/1670