### PR TITLE
[backport - newton-14.0] IT-3581 Add export to RUN_TEMPEST_OPTS and TESTR_OPTS

### DIFF
--- a/scripts/run_tempest.yml
+++ b/scripts/run_tempest.yml
@@ -25,8 +25,8 @@
   tasks:
     - name: Execute tempest tests
       shell: |
-        RUN_TEMPEST_OPTS={{ tempest_run_tempest_opts | join(' ') }}
-        TESTR_OPTS={{ tempest_testr_opts | join(' ') }}
+        export RUN_TEMPEST_OPTS={{ tempest_run_tempest_opts | join(' ') }}
+        export TESTR_OPTS={{ tempest_testr_opts | join(' ') }}
         bash /opt/openstack_tempest_gate.sh {{ tempest_test_sets }}
       changed_when: false
   tags:


### PR DESCRIPTION
This is so the openstack_tempest_gate.sh script picks up
these variables when invoked.

Connects https://github.com/rcbops/u-suk-dev/issues/1680

(cherry picked from commit 6591baef015d6be5d541d92b2a1acb39b67161e7)