### PR TITLE
Configure rabbitMQ HA policy

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -58,6 +58,19 @@ nova_console_type: novnc
 # RabbitMQ overrides
 rabbitmq_ulimit: 65535
 
+# Set RabbitMQ message replication count to 2
+# The desired setting would be {{ (groups.rabbitmq|length /2 +1)|round(0,'floor') |int }}
+# but can't be used due to https://github.com/ansible/ansible/issues/9362
+rabbitmq_policies:
+  - name: "HA"
+    pattern: '^(?!amq\.).*'
+    tags:
+      ha-mode: exactly
+      ha-params: 2
+      ha-sync-mode: automatic
+
+
+
 # Memcached overrides
 # https://github.com/rcbops/rpc-openstack/issues/1048
 # memcached_memory is calculated via https://github.com/openstack/openstack-ansible-memcached_server/blob/master/defaults/main.yml#L33

--- a/releasenotes/notes/rabbitmq-ha-configuration-c5062133932bd82b.yaml
+++ b/releasenotes/notes/rabbitmq-ha-configuration-c5062133932bd82b.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - The HA policy for RabbitMQ is changed to replicate to two nodes,
+    instead of three nodes, in order to increase performance and
+    scalability of the RabbitMQ service. The override `rabbitmq_policies`
+    set the new default value via the `group_vars/all/osa.yml`
+    configuration.
+    The replication count ideally resembles the number of RabbitMQ
+    nodes necessary to maintain quorum (2 for 3 nodes, 3 for 5 nodes).


### PR DESCRIPTION
The OSA policy replicated all queues to all nodes
ultimately leading to performance issues.
A new HA policy limits the queue mirroring to two
nodes allowing for much better scalability

Related-To: rcbops/u-suk-dev#461