### PR TITLE
Adapt apt repo use based on artifact availability

### DIFF
--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -42,6 +42,13 @@ openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \
                   -e "${BOOTSTRAP_OPTS}"
 
+if ! apt_artifacts_available; then
+  # Remove the AIO configuration relating to the use
+  # of apt artifacts. This needs to be done because
+  # the apt artifacts do not exist yet.
+  sed -i '/^rpco_mirror_base_url/,$d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+fi
+
 # If there are no container artifacts for this release, then remove the container artifact configuration
 if ! container_artifacts_available; then
   # Remove the AIO configuration relating to the use


### PR DESCRIPTION
In 698390d69b9398d631275ee57aec6cdecbe4b00e the
process was made to be more adaptable, but the
default config to setup the repo was missed.

This patch closes the gap.

Note that this will destroy every line in the
defaults file to the end of the file, so that
further patches which implement configuration
that matters must be above the line starting
with 'rpco_mirror_base_url'.