### PR TITLE
[backport-14.1] UG-543 Verify Orchestration

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -70,3 +70,20 @@
     msg: "One or more of the cinder services are in the down state. Check the output above for more detail."
   when: "'down' in '{{ item.split(' ')[-1] }}'"
   with_items: "{{ cinder_output.stdout_lines | default([]) }}"
+
+- name: Grab relevant output of orchestration service list
+  shell: |
+    . ~/openrc
+    openstack orchestration service list -c Binary -c host -c status -f value
+  register: orchestration_output
+  failed_when: "orchestration_output.rc != 0"
+
+- name: Display output of orchestration service list
+  debug:
+    var: orchestration_output
+
+- name: Fail if any of the orchestration services are down
+  fail:
+    msg: "One or more of the orchestration services are down. Check the output above for more detail."
+  when: "'down' in '{{ item.split(' ')[-1] }}'"
+  with_items: "{{ orchestration_output.stdout_lines | default([]) }}"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -44,6 +44,13 @@
   register: neutron_agentlist_result
   delegate_to: "{{ groups['utility_all'][0] }}"
 
+- name: Gather orchestration service list
+  shell: "source ~/openrc; openstack orchestration service list --insecure"
+  args:
+    executable: /bin/bash
+  register: orchestration_servicelist_result
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
 - name: Gather openstack endpoint list
   shell: "source ~/openrc; openstack --insecure endpoint list"
   args:

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/templates/status.txt.j2
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/templates/status.txt.j2
@@ -25,6 +25,11 @@ cinder service-list output as at {{ ansible_date_time.date }}-{{ ansible_date_ti
 {{ line }}
 {% endfor %}
 
+orchestration service list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for line in orchestration_servicelist_result.stdout_lines %}
+{{ line }}
+{% endfor %}
 
 neutron agent-list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
 


### PR DESCRIPTION
Adds verification Orchestration service post upgrade which matches
existing test style. Also includes Orchestration in pre-upgrade
check.

(cherry picked from commit 69269b40cd47e48d89d5938f3be5ab9989aaaf47)