### PR TITLE
Adapt AIO bootstrap when apt artifacts unavailable

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -81,7 +81,6 @@ fi
 ./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
-echo "rpc_release: ${RPC_RELEASE}" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 cd scripts/artifacts-building/
 cp user_*.yml /etc/openstack_deploy/
 

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -37,6 +37,18 @@ if [ -n "${DATA_DISK_DEVICE}" ]; then
   export BOOTSTRAP_OPTS="${BOOTSTRAP_OPTS} bootstrap_host_data_disk_device=${DATA_DISK_DEVICE}"
 fi
 
+# This toggles whether the AIO bootstrap will
+# clean out the apt sources or not. When there
+# are artifacts available, it should, because
+# the rpco sources file will be added. When
+# artifacts are not available then the updates
+# repo is needed.
+if apt_artifacts_available; then
+  export RPCO_APT_ARTIFACTS_AVAILABLE="yes"
+else
+  export RPCO_APT_ARTIFACTS_AVAILABLE="no"
+fi
+
 # Run AIO bootstrap playbook
 openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -36,7 +36,7 @@
 - name: Execute the OSA AIO bootstrap
   include: "{{ lookup('env', 'OA_DIR') }}/tests/bootstrap-aio.yml"
   vars:
-    bootstrap_host_apt_distribution_suffix_list: []
+    bootstrap_host_apt_distribution_suffix_list: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary([], ['updates', 'backports']) }}"
     scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -58,10 +58,6 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
   sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
 
-  # TODO(odyssey4me):
-  # Remove this once the rpc_release is statically defined.
-  echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
-
 fi
 
 # Now use GROUP_VARS of OSA and RPC


### PR DESCRIPTION
When the apt artifacts are not available (as they have
not yet been built for this release), the AIO bootstrap
must not clobber the updates/backports repository
configuration. This patch ensures that it adapts
accordingly.

A little bit of rpc_release override clean up has also
been removed as it is no longer necessary now that we
are setting the version statically.