### PR TITLE
Ensure that the apt artifact repo is configured

### DIFF
--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -16,7 +16,7 @@
 - name: Configure the default apt sources for RPC-O
   hosts: "{{ apt_target_group | default('hosts') }}"
   user: root
-  tasks:
+  pre_tasks:
 
     - name: Determine the existing Ubuntu repo configuration
       shell: 'grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)" /etc/apt/sources.list'
@@ -51,3 +51,12 @@
       tags:
         - always
 
+  roles:
+    # We execute the pip_install role here to ensure that all
+    # hosts have the correct rpco repo configured now that
+    # /etc/apt/sources.list has been changed to no longer
+    # include the updates repo.
+    - role: "pip_install"
+      pip_lock_to_internal_repo: False
+      pip_upstream_url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ os_distro_version }}/get-pip.py"
+      pip_install_upper_constraints: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ os_distro_version }}/requirements_absolute_requirements.txt"


### PR DESCRIPTION
When using the apt artifacts, we currently remove
the updates source from /etc/apt/sources.list but
do not ensure that the rpco.list file is configured
prior to executing the openstack_hosts role. This
causes the build to fail because that role needs
packages not available in the base source.

This patch implements the execution of the
pip_install role which happens to also configure
the additional repo needed for everything to be
right with the world again.