### PR TITLE
Ignore whitespaces when checking repo configuration

### DIFF
--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -19,7 +19,7 @@
   tasks:
 
     - name: Determine the existing Ubuntu repo configuration
-      shell: 'grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)" /etc/apt/sources.list'
+      shell: 'sed "s/^[ \t]*//" /etc/apt/sources.list | grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)"'
       register: _ubuntu_repo
       when:
         - host_ubuntu_repo is not defined


### PR DESCRIPTION
Removes any leading whitespaces in sources.list
before checking for the existing repo configuration.

This resolves issues when building using the
multi-node AIO.