### PR TITLE
[Backport - newton-14.1] Implement fixes for artifacting code

### DIFF
--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -19,7 +19,7 @@
   pre_tasks:
 
     - name: Determine the existing Ubuntu repo configuration
-      shell: 'grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)" /etc/apt/sources.list'
+      shell: 'sed "s/^[ \t]*//" /etc/apt/sources.list | grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)"'
       register: _ubuntu_repo
       when:
         - host_ubuntu_repo is not defined

--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -16,7 +16,7 @@
 - name: Configure the default apt sources for RPC-O
   hosts: "{{ apt_target_group | default('hosts') }}"
   user: root
-  tasks:
+  pre_tasks:
 
     - name: Determine the existing Ubuntu repo configuration
       shell: 'grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)" /etc/apt/sources.list'
@@ -51,3 +51,12 @@
       tags:
         - always
 
+  roles:
+    # We execute the pip_install role here to ensure that all
+    # hosts have the correct rpco repo configured now that
+    # /etc/apt/sources.list has been changed to no longer
+    # include the updates repo.
+    - role: "pip_install"
+      pip_lock_to_internal_repo: False
+      pip_upstream_url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ os_distro_version }}/get-pip.py"
+      pip_install_upper_constraints: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ os_distro_version }}/requirements_absolute_requirements.txt"

--- a/rpcd/playbooks/stage-apt-artifacts.yml
+++ b/rpcd/playbooks/stage-apt-artifacts.yml
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Identify the target host to stage to
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create the staging_hosts group with the appropriate member
+      add_host:
+        name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
+        groups: staging_hosts
+
 - name: Stage the apt artifacts
-  hosts: "{{ staging_host | default('localhost') }}"
+  hosts: staging_hosts
   user: root
   vars:
     rpco_mirror_base_url: "https://rpc-repo.rackspace.com"

--- a/rpcd/playbooks/stage-container-artifacts.yml
+++ b/rpcd/playbooks/stage-container-artifacts.yml
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Identify the target host to stage to
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create the staging_hosts group with the appropriate member
+      add_host:
+        name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
+        groups: staging_hosts
+
 - name: Stage the container artifacts
-  hosts: "{{ staging_host | default('localhost') }}"
+  hosts: staging_hosts
   user: root
   vars:
     aria_input_file: "/tmp/container_artifact_list.txt"

--- a/rpcd/playbooks/stage-python-artifacts.yml
+++ b/rpcd/playbooks/stage-python-artifacts.yml
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Identify the target host to stage to
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create the staging_hosts group with the appropriate member
+      add_host:
+        name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
+        groups: staging_hosts
+
 - name: Stage the git and python artifacts
-  hosts: "{{ staging_host | default('localhost') }}"
+  hosts: staging_hosts
   user: root
   vars:
     aria_input_file: "/tmp/python_artifact_list.txt"

--- a/scripts/artifacts-building/apt/build-apt-artifacts.sh
+++ b/scripts/artifacts-building/apt/build-apt-artifacts.sh
@@ -65,9 +65,6 @@ fi
 # be at /opt/rpc-openstack, so we link the current folder there.
 ln -sfn ${PWD} /opt/rpc-openstack
 
-# Figure out the release version
-export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
-
 # Install Ansible
 ./scripts/bootstrap-ansible.sh
 cp scripts/artifacts-building/apt/lookup/* /etc/ansible/roles/plugins/lookup/

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -81,7 +81,6 @@ fi
 ./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
-echo "rpc_release: ${RPC_RELEASE}" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 cd scripts/artifacts-building/
 cp user_*.yml /etc/openstack_deploy/
 

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -65,15 +65,8 @@ cd /opt/rpc-openstack
 sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
 sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
 
-# Figure out the release version
-export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
-
-# Read the OS information
-source /etc/os-release
-source /etc/lsb-release
-
 # If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if curl http://rpc-repo.rackspace.com/meta/1.0/index-system | grep "^${ID};${DISTRIB_CODENAME};.*${RPC_RELEASE};"; then
+if container_artifacts_available; then
   export PUSH_TO_MIRROR="NO"
 fi
 
@@ -82,15 +75,10 @@ if [[ "$(echo ${REPLACE_ARTIFACTS} | tr [a-z] [A-Z])" == "YES" ]]; then
   export PUSH_TO_MIRROR="YES"
 fi
 
-# Remove the RPC-O default configurations that are necessary
-# for deployment, but cause the build to break due to the fact
-# that they require the container artifacts to be available,
-# but those are not yet built.
-sed -i.bak '/lxc_image_cache_server: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_cache_default_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_cache_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
-sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+# Remove the AIO configuration relating to the use
+# of container artifacts. This needs to be done
+# because the container artifacts do not exist yet.
+./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
 echo "rpc_release: ${RPC_RELEASE}" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml

--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -43,9 +43,6 @@ export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 # Bootstrap Ansible
 ./scripts/bootstrap-ansible.sh
 
-# Figure out the release version
-export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
-
 # Fetch all the git repositories and generate the git artifacts
 # The openstack-ansible CLI is used to ensure that the library path is set
 #
@@ -55,7 +52,7 @@ openstack-ansible -i /opt/inventory \
                   ${ANSIBLE_PARAMETERS}
 
 # If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if curl http://rpc-repo.rackspace.com/git-archives/${RPC_RELEASE}/requirements.checksum; then
+if git_artifacts_available; then
   export PUSH_TO_MIRROR="NO"
 fi
 

--- a/scripts/artifacts-building/remove-container-aio-config.sh
+++ b/scripts/artifacts-building/remove-container-aio-config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Main ----------------------------------------------------------------------
+
+# Remove the env.d configurations that set the build to use
+# container artifacts. We don't want this because container
+# artifacts do not currently exist when this script is used.
+sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/env.d/*.yml
+
+# Remove the RPC-O default configurations that are necessary
+# for deployment, but cause the build to break due to the fact
+# that they require the container artifacts to be available,
+# but those are not yet built.
+sed -i.bak '/lxc_image_cache_server: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_cache_default_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_cache_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_container_variant: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+sed -i.bak '/lxc_container_download_template_extra_options: /d' /etc/openstack_deploy/user_osa_variables_defaults.yml

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -42,6 +42,13 @@ openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \
                   -e "${BOOTSTRAP_OPTS}"
 
+if ! apt_artifacts_available; then
+  # Remove the AIO configuration relating to the use
+  # of apt artifacts. This needs to be done because
+  # the apt artifacts do not exist yet.
+  sed -i '/^rpco_mirror_base_url/,$d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+fi
+
 # If there are no container artifacts for this release, then remove the container artifact configuration
 if ! container_artifacts_available; then
   # Remove the AIO configuration relating to the use

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -37,6 +37,18 @@ if [ -n "${DATA_DISK_DEVICE}" ]; then
   export BOOTSTRAP_OPTS="${BOOTSTRAP_OPTS} bootstrap_host_data_disk_device=${DATA_DISK_DEVICE}"
 fi
 
+# This toggles whether the AIO bootstrap will
+# clean out the apt sources or not. When there
+# are artifacts available, it should, because
+# the rpco sources file will be added. When
+# artifacts are not available then the updates
+# repo is needed.
+if apt_artifacts_available; then
+  export RPCO_APT_ARTIFACTS_AVAILABLE="yes"
+else
+  export RPCO_APT_ARTIFACTS_AVAILABLE="no"
+fi
+
 # Run AIO bootstrap playbook
 openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -41,3 +41,11 @@ fi
 openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \
                   -e "${BOOTSTRAP_OPTS}"
+
+# If there are no container artifacts for this release, then remove the container artifact configuration
+if ! container_artifacts_available; then
+  # Remove the AIO configuration relating to the use
+  # of container artifacts. This needs to be done
+  # because the container artifacts do not exist yet.
+  ./scripts/artifacts-building/remove-container-aio-config.sh
+fi

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -36,7 +36,7 @@
 - name: Execute the OSA AIO bootstrap
   include: "{{ lookup('env', 'OA_DIR') }}/tests/bootstrap-aio.yml"
   vars:
-    bootstrap_host_apt_distribution_suffix_list: []
+    bootstrap_host_apt_distribution_suffix_list: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary([], ['updates', 'backports']) }}"
     scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -42,9 +42,8 @@ check_submodule_status
 #
 # This has the ability to be disabled for the purpose of reusing the
 # bootstrap-ansible script for putting together the apt artifacts.
-if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]]; then
-  apt_sources_back_to_stock
-  apt_sources_use_rpc_apt_artifacts
+if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]] && apt_artifacts_available; then
+  configure_apt_sources
 fi
 
 # begin the bootstrap process

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -58,10 +58,6 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
   sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
   sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
 
-  # TODO(odyssey4me):
-  # Remove this once the rpc_release is statically defined.
-  echo "rpc_release: $(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
-
 fi
 
 # Now use GROUP_VARS of OSA and RPC


### PR DESCRIPTION
When the apt artifacts are not available (as they have
not yet been built for this release), the AIO bootstrap
must not clobber the updates/backports repository
configuration. This patch ensures that it adapts
accordingly.

A little bit of rpc_release override clean up has also
been removed as it is no longer necessary now that we
are setting the version statically.

(cherry picked from commit 71d8774fc5c518d5bfbce1c49ccb64cc204a76fe)