### PR TITLE
UG-629 Add quotes around tempest variables

### DIFF
--- a/scripts/run_tempest.yml
+++ b/scripts/run_tempest.yml
@@ -25,8 +25,8 @@
   tasks:
     - name: Execute tempest tests
       shell: |
-        export RUN_TEMPEST_OPTS={{ tempest_run_tempest_opts | join(' ') }}
-        export TESTR_OPTS={{ tempest_testr_opts | join(' ') }}
+        export RUN_TEMPEST_OPTS='{{ tempest_run_tempest_opts | join(' ') }}'
+        export TESTR_OPTS='{{ tempest_testr_opts | join(' ') }}'
         bash /opt/openstack_tempest_gate.sh {{ tempest_test_sets }}
       changed_when: false
   tags:


### PR DESCRIPTION
If tempest_run_tempest_opts or tempest_testr_opts are
empty lists, have spaces in values, or have mulitple
values, the exports fail without these quotes.