### PR TITLE
UG-621 Make staging work for multi-node builds

### DIFF
--- a/rpcd/playbooks/stage-apt-artifacts.yml
+++ b/rpcd/playbooks/stage-apt-artifacts.yml
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Identify the target host to stage to
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create the staging_hosts group with the appropriate member
+      add_host:
+        name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
+        groups: staging_hosts
+
 - name: Stage the apt artifacts
-  hosts: "{{ staging_host | default('localhost') }}"
+  hosts: staging_hosts
   user: root
   vars:
     rpco_mirror_base_url: "https://rpc-repo.rackspace.com"

--- a/rpcd/playbooks/stage-container-artifacts.yml
+++ b/rpcd/playbooks/stage-container-artifacts.yml
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Identify the target host to stage to
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create the staging_hosts group with the appropriate member
+      add_host:
+        name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
+        groups: staging_hosts
+
 - name: Stage the container artifacts
-  hosts: "{{ staging_host | default('localhost') }}"
+  hosts: staging_hosts
   user: root
   vars:
     aria_input_file: "/tmp/container_artifact_list.txt"

--- a/rpcd/playbooks/stage-python-artifacts.yml
+++ b/rpcd/playbooks/stage-python-artifacts.yml
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Identify the target host to stage to
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create the staging_hosts group with the appropriate member
+      add_host:
+        name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
+        groups: staging_hosts
+
 - name: Stage the git and python artifacts
-  hosts: "{{ staging_host | default('localhost') }}"
+  hosts: staging_hosts
   user: root
   vars:
     aria_input_file: "/tmp/python_artifact_list.txt"


### PR DESCRIPTION
Currently the staging process only works when the deploy
host and the first infrastructure host are the same.

This patch implements a change to the process to still
allow a staging host to be specific manually, but it will
automatically use the inventory to identify the host for
the first repo server which is where the staging should
be done to.