### PR TITLE
Remove hard coded cinder backup enablement

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -90,8 +90,6 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
     sed -i "s/lb_name: .*/lb_name: '$(hostname)'/" $RPCD_VARS
     # set the notification_plan to the default for Rackspace Cloud Servers
     sed -i "s/maas_notification_plan: .*/maas_notification_plan: npTechnicalContactsEmail/" $RPCD_VARS
-    # the AIO needs this enabled to test the feature, but $RPCD_VARS defaults this to false
-    sed -i "s/cinder_service_backup_program_enabled: .*/cinder_service_backup_program_enabled: true/" /etc/openstack_deploy/user_variables.yml
     # set network speed for vms
     echo "net_max_speed: 1000" >>$RPCD_VARS
 


### PR DESCRIPTION
This is being removed because it has been determined by the gating team
to be broken. Sadly the gating team has hard coded an additional
override for this override, which disbales this feature, so this code
path is never exercised in or outside of the gate. This removal will
allow us use well defined, and known overrides within the project
giving developers a clear sense of what is being developed vs what
is being tested and will unblock work in master.

Related-Issue: rcbops/rpc-gating#224
Un-Blocks: #2296

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>