### PR TITLE
UG-632 Exclude Nova Agent in nova verify

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-nova-venv.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-nova-venv.yml
@@ -18,7 +18,7 @@
 # of a venv
 - name: Find running nova services not in venv
   shell: |
-    pgrep -a "nova" | awk '{print $2,$3}' | grep -vP "{{ nova_venv_bin }}/\w+[\d\.\d]?\s{1}{{ nova_venv_bin }}/\w+"
+    pgrep -a "nova" | grep -v "nova-agent"| awk '{print $2,$3}' | grep -vP "{{ nova_venv_bin }}/\w+[\d\.\d]?\s{1}{{ nova_venv_bin }}/\w+"
   register: nova_output
   when: '"nova" in hostvars["{{ inventory_hostname }}"].properties.service_name'
   failed_when: "nova_output.stdout_lines|length != 0"


### PR DESCRIPTION
Explicitely excludes nova-agent when verifying nova processes are
running in the correct virtualenv check. Currently gating running
on pubcloud resources can fail the nova-venv check by nova-agent
on the host causing this to fail.