### PR TITLE
AR-191 Make artifact jobs all work for Ocata

### DIFF
--- a/scripts/artifacts-building/apt/build-apt-artifacts.sh
+++ b/scripts/artifacts-building/apt/build-apt-artifacts.sh
@@ -87,14 +87,15 @@ set -x
 # Ensure that the repo server public key is a known host
 grep "${REPO_HOST}" ~/.ssh/known_hosts || echo "${REPO_HOST} $(cat $REPO_HOST_PUBKEY)" >> ~/.ssh/known_hosts
 
-#Append host to [mirrors] group
+# Create an inventory to use
 echo '[mirrors]' > /opt/inventory
 echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='${REPO_KEYFILE}' " >> /opt/inventory
+echo "localhost ansible_python_interpreter='/usr/bin/python2'" >> /opt/inventory
 
 # Execute the playbooks
 cd ${BASE_DIR}/scripts/artifacts-building/apt
-ansible-playbook aptly-pre-install.yml ${ANSIBLE_PARAMETERS}
+ansible-playbook aptly-pre-install.yml -i /opt/inventory ${ANSIBLE_PARAMETERS}
 ansible-playbook aptly-all.yml -i /opt/inventory ${ANSIBLE_PARAMETERS}
 
 source /opt/rpc-openstack/openstack-ansible/scripts/openstack-ansible.rc
-ansible-playbook apt-artifacts-testing.yml ${ANSIBLE_PARAMETERS}
+ansible-playbook apt-artifacts-testing.yml -i /opt/inventory ${ANSIBLE_PARAMETERS}

--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -74,7 +74,7 @@
     skip_tags:
       - config
     skip_handlers: True
-    image_name: "{{ role_name | replace('os_', '') }}"
+    image_name: "{{ role_name | replace('os_', '') | replace('rpc-role-', '') }}"
   vars_files:
     - container-vars.yml
   pre_tasks:
@@ -107,7 +107,7 @@
   vars_files:
     - container-vars.yml
   vars:
-    image_name: "{{ role_name | replace('os_', '') }}"
+    image_name: "{{ role_name | replace('os_', '') | replace('rpc-role-', '') }}"
   tasks:
     - name: Set artifact facts
       set_fact:
@@ -168,7 +168,7 @@
   vars_files:
     - container-vars.yml
   vars:
-    image_name: "{{ role_name | replace('os_', '') }}"
+    image_name: "{{ role_name | replace('os_', '') | replace('rpc-role-', '') }}"
   tasks:
     - name: Check if the list exist to avoid re-hitting the server
       stat:

--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -62,6 +62,14 @@
         test -e /usr/bin/python || (apt-get -y update && apt-get install -y python-minimal)
       tags:
         - always
+    # TODO(odyssey4me):
+    # Remove this once all roles have developer mode package
+    # install tasks which include git.
+    - name: When using developer_mode install git
+      apt:
+        name: "git-core"
+        state: present
+      when: "developer_mode | bool"
   tags:
     - always
 

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -157,7 +157,7 @@ openstack-ansible containers/artifact-build-chroot.yml \
 
 # Build the list of roles to build containers for
 role_list=""
-role_list="${role_list} elasticsearch kibana logstash memcached_server"
+role_list="${role_list} elasticsearch kibana rpc-role-logstash memcached_server"
 role_list="${role_list} os_cinder os_glance os_heat os_horizon os_ironic"
 role_list="${role_list} os_keystone os_neutron os_nova os_swift os_tempest"
 role_list="${role_list} rabbitmq_server repo_server rsyslog_server"

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -93,6 +93,11 @@ git config --global user.email "rcbops@rackspace.com"
 git config --global user.name "RCBOPS gating"
 
 # Patch the roles
+# TODO(odyssey4me):
+# Remove the patcher process once the following have merged
+# and are available to RPC-O:
+# https://review.openstack.org/474734
+# https://review.openstack.org/474730
 cd containers/patches/
 patch_all_roles
 

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -169,9 +169,13 @@ for cnt in ${role_list}; do
                     ${ANSIBLE_PARAMETERS}
 done
 
-# test one container build contents
-openstack-ansible containers/test-built-container.yml
-openstack-ansible containers/test-built-container-idempotency-test.yml | tee /tmp/output.txt; grep -q 'changed=0.*failed=0' /tmp/output.txt && { echo 'Idempotence test: pass';  } || { echo 'Idempotence test: fail' && exit 1; }
+# If there are no python artifacts, then the containers built are unlikely
+# to be idempotent, so skip this test.
+if python_artifacts_available; then
+    # test one container build contents
+    openstack-ansible containers/test-built-container.yml
+    openstack-ansible containers/test-built-container-idempotency-test.yml | tee /tmp/output.txt; grep -q 'changed=0.*failed=0' /tmp/output.txt && { echo 'Idempotence test: pass';  } || { echo 'Idempotence test: fail' && exit 1; }
+fi
 
 if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
   if [ -z ${REPO_USER_KEY+x} ] || [ -z ${REPO_USER+x} ] || [ -z ${REPO_HOST+x} ] || [ -z ${REPO_HOST_PUBKEY+x} ]; then

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -56,9 +56,13 @@ rm -f /opt/list
 # be at /opt/rpc-openstack, so we link the current folder there.
 ln -sfn ${PWD} /opt/rpc-openstack
 
-# Bootstrap Ansible and the AIO config
+# Bootstrap Ansible
+# This script is sourced to ensure that the common
+# functions and vars are available.
 cd /opt/rpc-openstack
-./scripts/bootstrap-ansible.sh
+source scripts/bootstrap-ansible.sh
+
+# Bootstrap the AIO configuration
 ./scripts/bootstrap-aio.sh
 
 # Now use GROUP_VARS of OSA and RPC

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -99,14 +99,20 @@ patch_all_roles
 # Run playbooks
 cd /opt/rpc-openstack/openstack-ansible/playbooks
 
-# The host must only have the base Ubuntu repository configured.
-# All updates (security and otherwise) must come from the RPC-O apt artifacting.
-# The host sources are modified to ensure that when the containers are prepared
-# they have our mirror included as the default. This happens because in the
-# lxc_hosts role the host apt sources are copied into the container cache.
-openstack-ansible /opt/rpc-openstack/rpcd/playbooks/configure-apt-sources.yml \
-                  -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu" \
-                  ${ANSIBLE_PARAMETERS}
+# If the apt artifacts are not available, then this is likely
+# a PR test which is not going to upload anything, so the
+# artifacts we build do not need to be strictly set to use
+# the RPC-O apt repo.
+if apt_artifacts_available; then
+    # The host must only have the base Ubuntu repository configured.
+    # All updates (security and otherwise) must come from the RPC-O apt artifacting.
+    # The host sources are modified to ensure that when the containers are prepared
+    # they have our mirror included as the default. This happens because in the
+    # lxc_hosts role the host apt sources are copied into the container cache.
+    openstack-ansible /opt/rpc-openstack/rpcd/playbooks/configure-apt-sources.yml \
+                      -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu" \
+                      ${ANSIBLE_PARAMETERS}
+fi
 
 # Setup the host
 openstack-ansible setup-hosts.yml --limit lxc_hosts,hosts

--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -40,3 +40,10 @@ rpco_mirror_apt_deb_line: "deb {{ rpco_mirror_apt_url }} {{ rpc_release }}-{{ an
 rpc_mirror_container_images_list: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/meta/1.0/index-system"
 rpc_mirror_container_relative_image_location: "{{ webserver_container_artifacts_uri }}/{{ lxc_index_path }}/{{ image_name }}-{{ rpc_release }}/{{ build_id }}"
 rpc_mirror_container_full_image_location: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/{{ rpc_mirror_container_relative_image_location }}"
+
+#
+# TODO(odyssey4me):
+# Remove this once https://review.openstack.org/474720 has merged
+# and is available in RPC-O.
+#
+keystone_developer_mode: "{{ developer_mode | default('no') }}"

--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -30,11 +30,13 @@ architecture_mapping:
 os_distro_version: "{{ ansible_distribution | lower }}-{{ ansible_distribution_version.split('.')[:2] | join('.') }}-{{ ansible_architecture | lower }}"
 role_vars:
   # We can't use the group vars, we need to override ourselves.
-  venv_download_url: "{{ rpco_mirror_base_url }}/venvs/{{ rpc_release }}/{{ os_distro_version }}/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
+  venv_download_url: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/venvs/{{ rpc_release }}/{{ os_distro_version }}/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
   venv_tag: "{{ rpc_release }}"
   developer_mode: False
 webserver_owner: "nginx"
 webserver_group: "www-data"
-rpc_mirror_container_images_list: "{{ rpco_mirror_base_url }}/meta/1.0/index-system"
+rpco_mirror_apt_url: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/apt-mirror/integrated/"
+rpco_mirror_apt_deb_line: "deb {{ rpco_mirror_apt_url }} {{ rpc_release }}-{{ ansible_distribution_release }} main"
+rpc_mirror_container_images_list: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/meta/1.0/index-system"
 rpc_mirror_container_relative_image_location: "{{ webserver_container_artifacts_uri }}/{{ lxc_index_path }}/{{ image_name }}-{{ rpc_release }}/{{ build_id }}"
-rpc_mirror_container_full_image_location: "{{ rpco_mirror_base_url }}/{{ rpc_mirror_container_relative_image_location }}"
+rpc_mirror_container_full_image_location: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/{{ rpc_mirror_container_relative_image_location }}"

--- a/scripts/artifacts-building/containers/container-vars.yml
+++ b/scripts/artifacts-building/containers/container-vars.yml
@@ -32,7 +32,7 @@ role_vars:
   # We can't use the group vars, we need to override ourselves.
   venv_download_url: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/venvs/{{ rpc_release }}/{{ os_distro_version }}/{{ image_name }}-{{ rpc_release }}-{{ ansible_architecture }}.tgz"
   venv_tag: "{{ rpc_release }}"
-  developer_mode: False
+  developer_mode: "{{ developer_mode | default('no') }}"
 webserver_owner: "nginx"
 webserver_group: "www-data"
 rpco_mirror_apt_url: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/apt-mirror/integrated/"

--- a/scripts/artifacts-building/containers/patches/os_keystone
+++ b/scripts/artifacts-building/containers/patches/os_keystone
@@ -1,30 +1,15 @@
-From 4c7deb6c18dc265a8b4b15b35968ebe60c7f543a Mon Sep 17 00:00:00 2001
-From: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>
-Date: Fri, 3 Feb 2017 08:15:57 +0000
-Subject: [PATCH] Cleanup artifact building
+From d4ff51bc332f4954c0d64be1347e2815dd3a78f4 Mon Sep 17 00:00:00 2001
+From: Jesse Pretorius <jesse.pretorius@rackspace.co.uk>
+Date: Wed, 14 Jun 2017 15:41:39 +0100
+Subject: [PATCH] Remove ssh key generation
 
 Some tasks can't be changed upstream and have to be fixed here.
 ---
- tasks/keystone_install.yml     | 3 ---
  tasks/keystone_pre_install.yml | 1 -
- 2 files changed, 4 deletions(-)
+ 1 file changed, 1 deletion(-)
 
-diff --git a/tasks/keystone_install.yml b/tasks/keystone_install.yml
-index 34dbb78..533d7b3 100644
---- a/tasks/keystone_install.yml
-+++ b/tasks/keystone_install.yml
-@@ -83,9 +83,6 @@
-   when:
-     - not keystone_developer_mode | bool
-     - keystone_get_venv | changed or keystone_venv_dir | changed
--  notify:
--    - Restart Keystone APIs
--    - Restart service
- 
- - name: Install pip packages
-   pip:
 diff --git a/tasks/keystone_pre_install.yml b/tasks/keystone_pre_install.yml
-index fbc668b..553c004 100644
+index 8a8a85c..c348d46 100644
 --- a/tasks/keystone_pre_install.yml
 +++ b/tasks/keystone_pre_install.yml
 @@ -46,7 +46,6 @@
@@ -36,5 +21,5 @@ index fbc668b..553c004 100644
  - name: Create keystone dir
    file:
 -- 
-1.9.1
+2.11.0 (Apple Git-81)
 

--- a/scripts/artifacts-building/containers/patches/repo_server
+++ b/scripts/artifacts-building/containers/patches/repo_server
@@ -1,7 +1,7 @@
-From c8c1d0cd310563b4cec0bfae23791ee4c74f2f57 Mon Sep 17 00:00:00 2001
-From: RCBOPS gating <rcbops@rackspace.com>
-Date: Wed, 1 Mar 2017 11:58:22 +0000
-Subject: [PATCH] Cleanup artifact building
+From 902979d2d1978945994aeccc6b81f670cf3729b6 Mon Sep 17 00:00:00 2001
+From: Jesse Pretorius <jesse.pretorius@rackspace.co.uk>
+Date: Wed, 14 Jun 2017 15:58:17 +0100
+Subject: [PATCH] Remove ssh key generation
 
 Some tasks can't be changed upstream and have to be fixed here.
 ---
@@ -9,7 +9,7 @@ Some tasks can't be changed upstream and have to be fixed here.
  1 file changed, 1 deletion(-)
 
 diff --git a/tasks/repo_post_install.yml b/tasks/repo_post_install.yml
-index 7fb1949..34cb748 100644
+index d51f85d..8d5154f 100644
 --- a/tasks/repo_post_install.yml
 +++ b/tasks/repo_post_install.yml
 @@ -45,7 +45,6 @@
@@ -20,3 +20,6 @@ index 7fb1949..34cb748 100644
    tags:
      - pkg-repo-user
      - repo-key
+-- 
+2.11.0 (Apple Git-81)
+

--- a/scripts/artifacts-building/containers/test-built-container-idempotency-test.yml
+++ b/scripts/artifacts-building/containers/test-built-container-idempotency-test.yml
@@ -19,18 +19,18 @@
 - name: Check integrity
   hosts: lxc_container_artifact
   connection: chroot
-  # Gether facts is necessary
+  # Gather facts is necessary
   vars_files:
     - container-vars.yml
   vars:
     image_name: "{{ lookup('env', 'CONTAINER_TYPE') | default('keystone', True) }}"
     official_repos:
-      - "deb http://mirror.rackspace.com/ubuntu trusty main universe"
+      - "deb http://mirror.rackspace.com/ubuntu {{ ansible_distribution_release }} main universe"
       - "{{ rpco_mirror_apt_deb_line }}"
   tasks:
     - name: Fetch get-pip for comparison
       get_url:
-        url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/get-pip.py"
+        url: "{{ rpco_mirror_base_url | default(openstack_repo_url) }}/os-releases/{{ rpc_release }}/get-pip.py"
         dest: /opt/get-pip.py
         force: yes #Ensure it's redownloaded for testing purposes, not directly ok.
     - name: List all the active apt sources

--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -41,7 +41,13 @@ export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 ## Main ----------------------------------------------------------------------
 
 # Bootstrap Ansible
-./scripts/bootstrap-ansible.sh
+# This script is sourced to ensure that the common
+# functions and vars are available.
+source scripts/bootstrap-ansible.sh
+
+# Now use GROUP_VARS of OSA and RPC
+sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${OA_DIR}/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
+sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${OA_DIR}/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
 
 # Fetch all the git repositories and generate the git artifacts
 # The openstack-ansible CLI is used to ensure that the library path is set

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -63,7 +63,6 @@ sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${BASE_DIR}/open
 ./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
-echo "rpc_release: ${RPC_RELEASE}" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 echo "repo_build_venv_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
 cp scripts/artifacts-building/user_rcbops_artifacts_building.yml /etc/openstack_deploy/

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -44,9 +44,13 @@ export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 # be at /opt/rpc-openstack, so we link the current folder there.
 ln -sfn ${PWD} /opt/rpc-openstack
 
-# bootstrap Ansible and the AIO config
+# Bootstrap Ansible
+# This script is sourced to ensure that the common
+# functions and vars are available.
 cd /opt/rpc-openstack
-./scripts/bootstrap-ansible.sh
+source scripts/bootstrap-ansible.sh
+
+# Bootstrap the AIO configuration
 ./scripts/bootstrap-aio.sh
 
 # Now use GROUP_VARS of OSA and RPC

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -70,13 +70,19 @@ cp scripts/artifacts-building/user_rcbops_artifacts_building.yml /etc/openstack_
 # Prepare to run the playbooks
 cd /opt/rpc-openstack/openstack-ansible/playbooks
 
-# The host must only have the base Ubuntu repository configured.
-# All updates (security and otherwise) must come from the RPC-O apt artifacting.
-# This is also being done to ensure that the python artifacts are built using
-# the same sources as the container artifacts will use.
-openstack-ansible /opt/rpc-openstack/rpcd/playbooks/configure-apt-sources.yml \
-                  -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu" \
-                  ${ANSIBLE_PARAMETERS}
+# If the apt artifacts are not available, then this is likely
+# a PR test which is not going to upload anything, so the
+# artifacts we build do not need to be strictly set to use
+# the RPC-O apt repo.
+if apt_artifacts_available; then
+    # The host must only have the base Ubuntu repository configured.
+    # All updates (security and otherwise) must come from the RPC-O apt artifacting.
+    # This is also being done to ensure that the python artifacts are built using
+    # the same sources as the container artifacts will use.
+    openstack-ansible /opt/rpc-openstack/rpcd/playbooks/configure-apt-sources.yml \
+                      -e "host_ubuntu_repo=http://mirror.rackspace.com/ubuntu" \
+                      ${ANSIBLE_PARAMETERS}
+fi
 
 # Setup the repo container and build the artifacts
 openstack-ansible setup-hosts.yml \

--- a/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+++ b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
@@ -23,7 +23,7 @@ apply_security_hardening: False
 # of the repo server. When we build artifacts we don't build
 # a repo container so we override the default group_var to
 # ensure that we re-use the python artifacts in rpc-repo.
-openstack_repo_url: "{{ rpco_mirror_base_url }}"
+openstack_repo_url: "{{ rpco_mirror_base_url | default('https://rpc-repo.rackspace.com') }}"
 
 # When building container artifacts we need to ensure that
 # the lxc_hosts role prepares the default container based


### PR DESCRIPTION
Unfortunately all the artifact jobs were giving a false pass due to a mistake in the job config. This has now been resolved so they're testing properly now, but all the artifact builds are broken. This PR will be a series of patches to fix them again.