### PR TITLE
UG-641 Remove neutron checksum workaround

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -225,22 +225,6 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   # setup the infrastructure
   run_ansible setup-infrastructure.yml
 
-  # This section is duplicated from OSA/run-playbooks as RPC doesn't currently
-  # make use of run-playbooks. (TODO: hughsaunders)
-  # Note that switching to run-playbooks may inadvertently convert to repo build from repo clone.
-  # When running in an AIO, we need to drop the following iptables rule in any neutron_agent containers
-  # to ensure that instances can communicate with the neutron metadata service.
-  # This is necessary because in an AIO environment there are no physical interfaces involved in
-  # instance -> metadata requests, and this results in the checksums being incorrect.
-  if [ "${DEPLOY_AIO}" == "yes" ]; then
-    ansible neutron_agent -m command \
-                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
-    ansible neutron_agent -m command \
-                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 8000 -j CHECKSUM --checksum-fill'
-    ansible neutron_agent -m shell \
-                          -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
-  fi
-
   # setup openstack
   run_ansible setup-openstack.yml
 


### PR DESCRIPTION
The checksum addition using this method was very
unreliable, so in OSA it was added [1] in a more
robust way to the neutron role and removed from
run-playbooks [2].

RPC-O therefore inherits it and does not need
to do this any more. In fact it may interfere
with it so it's better not to use this hack.

[1] https://review.openstack.org/330405
[2] https://review.openstack.org/330389