### PR TITLE
UG-617 Limit the number of Ansible forks used to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,10 @@ DEPLOY_SWIFT       | yes                                | Deploy swift          
 DEPLOY_HARDENING   | yes                                | Deploy openstack-ansible-security role               |
 DEPLOY_RPC         | yes                                | Deploy the RPCO specific variables                   |
 BOOTSTRAP_OPTS     |                                    | Any options used for the bootstrap process           | Only used if DEPLOY_AIO=yes
-FORKS              | `grep -c ^processor /proc/cpuinfo` | Number of forks Ansible may use                      | May have issues if FORKS > SSHD's MaxSessions. Adjust accordingly
 ANSIBLE_PARAMETERS |                                    | Additional paramters passed to Ansible               |
 
 All of the variables for deploy.sh are made available by sourcing the [functions.sh](https://github.com/rcbops/rpc-openstack/blob/master/scripts/functions.sh) script
 
-For instance to adjust the number of forks Ansible is able to use:
-
-```
-export FORKS=10
-./scripts/deploy.sh
-```
 # Linting
 
 If you would like to lint against a version of ansible that is not the


### PR DESCRIPTION
The default MaxSessions setting for SSHD is 10.
Each Ansible fork makes use of a Session, so
this patch still uses the CPU number to set the
number of forks used but limits it to 10 forks
when the number of CPU's is larger.

Bug Reference:
https://bugs.launchpad.net/openstack-ansible/+bug/1479812

The 'FORKS' environment variable is still
catered for in case it is used, but this
changes the implementation of fork setting
from using the CLI parameter to the standard
Ansible environment variable. As such, there
is no need to document the environment variable
in the way that FORKS required it.