### PR TITLE
UG-534 Correctly set backup_dir for pre/post upgrades

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -28,9 +28,3 @@ migrations_dir: /etc/openstack_deploy/migrations
 
 # Ceph Conf Directory Mode
 conf_directory_mode: 755
-
-date_stamp: "{{ ansible_date_time.date }}"
-time_stamp: "{{ ansible_date_time.time }}"
-datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
-local_home: "{{ lookup('env', 'HOME') }}"
-backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -72,6 +72,8 @@ ansible-galaxy install --role-file=${BASE_DIR}/ansible-role-requirements.yml --f
 # Issue: We need to analyze support's maintenance plan to determine which
 # pieces we can orchestrate with ansible. This should be added to a
 # pre-upgrade task list.
+touch ${UPGRADE_VARIABLES_FILE}
+grep -q 'backup_dir' ${UPGRADE_VARIABLES_FILE} || echo "backup_dir: \"{{ local_home }}/rpc13-upgrade-$(date '+%Y-%m-%d')\"" >> ${UPGRADE_VARIABLES_FILE}
 cd ${RPCD_DIR}/playbooks
 openstack-ansible rpc-pre-upgrades.yml
 
@@ -147,7 +149,6 @@ popd
 # Set upgrade variables for the RPCO playbooks
 # The variables are put into a temporary user_variables file, then deleted
 # at the end of this script.
-touch ${UPGRADE_VARIABLES_FILE}
 if grep -q 'logging_upgrade' ${UPGRADE_VARIABLES_FILE}; then
   sed -i "s/logging_upgrade:.*$/logging_upgrade: true/" ${UPGRADE_VARIABLES_FILE}
 else


### PR DESCRIPTION
In order for the post upgrade neutron router tests to inspect state
prior to upgrade, we had to add number of backup_dir-related vars to
the post upgrade role.  Additionally, we added those vars to
group_vars/all.yml so that the pre and post upgrade roles would share
those vars.  What we missed unfortunately is that those vars reference
additional vars, which are evaluated at run-time.  This means if
someone runs an upgrade at 11 PM at night, the backup_dir would be (for
example) /root/rpc13-upgrade-2017-06-16.  By the time the post upgrade
runs, it'll be past midnight, and now backup_dir will be
/root/rpc13-upgrade-2017-06-17.  While this won't cause the post
upgrade role to fail, it won't see the router data from pre upgrade and
not provide any meaningful data to the deployer.

In a nutshell, this commit simply adds an override for backup_dir to
/etc/openstack_deploy/user_upgrade_variables.yml (created temporarily by
test-upgrade.sh) and removes all the unnecessary overrides added to
group_vars/all.yml.  A doc change and note for support will follow.