### PR TITLE
[Backport - newton-14.0] UG-534 UG-544 Check if router moves agent during upgrade

### DIFF
--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -35,9 +35,3 @@ conf_directory_mode: 755
 holland_venv_enabled: True
 holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
 holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"
-
-date_stamp: "{{ ansible_date_time.date }}"
-time_stamp: "{{ ansible_date_time.time }}"
-datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
-local_home: "{{ lookup('env', 'HOME') }}"
-backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"

--- a/rpcd/playbooks/group_vars/all.yml
+++ b/rpcd/playbooks/group_vars/all.yml
@@ -35,3 +35,9 @@ conf_directory_mode: 755
 holland_venv_enabled: True
 holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
 holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"
+
+date_stamp: "{{ ansible_date_time.date }}"
+time_stamp: "{{ ansible_date_time.time }}"
+datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
+local_home: "{{ lookup('env', 'HOME') }}"
+backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/defaults/main.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+date_stamp: "{{ ansible_date_time.date }}"
+time_stamp: "{{ ansible_date_time.time }}"
+datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
+local_home: "{{ lookup('env', 'HOME') }}"
+backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"
 elasticsearch_http_port: 9200
 swift_venv_tag: "{{ openstack_release }}"
 swift_venv_bin: "/openstack/venvs/swift-{{ swift_venv_tag }}/bin"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -82,3 +82,57 @@
     msg: "One or more of the orchestration services are down. Check the output above for more detail."
   when: "'down' in '{{ item.split(' ')[-1] }}'"
   with_items: "{{ orchestration_output.stdout_lines | default([]) }}"
+
+- name: Obtain a list of neutron routers
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    neutron router-list -f value --column id
+  register: neutron_routers
+
+- name: Check agent assigned to each neutron router
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    neutron l3-agent-list-hosting-router -f value --column host {{ item }}
+  with_items: "{{ neutron_routers.stdout_lines|default([]) }}"
+  register: neutron_routers_agents
+
+- name: Write file containing agent for each router
+  copy:
+    content: "{{ item.stdout }}"
+    dest: "/tmp/{{ item.item }}.post-upgrade"
+  with_items: "{{ neutron_routers_agents.results|default([]) }}"
+  when: item.stdout != ""
+  delegate_to: localhost
+
+- name: Get stat of pre-upgrade files
+  stat:
+    path: "/tmp/{{ item }}.pre-upgrade"
+  register: neutron_routers_pre_stat
+  with_items: "{{ neutron_routers.stdout_lines|default([]) }}"
+  delegate_to: localhost
+
+- name: Get stat of post-upgrade files
+  stat:
+    path: "/tmp/{{ item }}.post-upgrade"
+  register: neutron_routers_post_stat
+  with_items: "{{ neutron_routers.stdout_lines|default([]) }}"
+  delegate_to: localhost
+
+- name: Print warning if neutron router has moved
+  debug:
+    msg: "*WARNING* Neutron router with ID {{ item.0.item }} appears to have moved agents during the upgrade. Please investigate."
+  when:
+    - item.0.stat.exists # skip check if router didn't exist when pre-upgrade check was run
+    - item.0.stat.md5 != item.1.stat.md5
+  with_together:
+    - "{{ neutron_routers_pre_stat.results }}"
+    - "{{ neutron_routers_post_stat.results }}"
+
+- name: Cleanup pre and post-upgrade router agent files
+  file:
+    path: "/tmp/{{ item.0 }}.{{ item.1 }}"
+    state: absent
+  with_nested:
+    - neutron_routers.stdout_lines
+    - [ 'pre-upgrade', 'post-upgrade' ]
+  delegate_to: localhost

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -99,40 +99,20 @@
 - name: Write file containing agent for each router
   copy:
     content: "{{ item.stdout }}"
-    dest: "/tmp/{{ item.item }}.post-upgrade"
+    dest: "{{ backup_dir }}/{{ item.item }}.post-upgrade"
   with_items: "{{ neutron_routers_agents.results|default([]) }}"
-  when: item.stdout != ""
   delegate_to: localhost
 
-- name: Get stat of pre-upgrade files
-  stat:
-    path: "/tmp/{{ item }}.pre-upgrade"
-  register: neutron_routers_pre_stat
+- name: Get content of pre-upgrade files
+  slurp:
+    src: "{{ backup_dir }}/{{ item }}.pre-upgrade"
+  register: neutron_routers_pre_slurp
   with_items: "{{ neutron_routers.stdout_lines|default([]) }}"
   delegate_to: localhost
+  failed_when: false
 
-- name: Get stat of post-upgrade files
-  stat:
-    path: "/tmp/{{ item }}.post-upgrade"
-  register: neutron_routers_post_stat
-  with_items: "{{ neutron_routers.stdout_lines|default([]) }}"
-  delegate_to: localhost
-
-- name: Print warning if neutron router has moved
-  debug:
-    msg: "*WARNING* Neutron router with ID {{ item.0.item }} appears to have moved agents during the upgrade. Please investigate."
-  when:
-    - item.0.stat.exists # skip check if router didn't exist when pre-upgrade check was run
-    - item.0.stat.md5 != item.1.stat.md5
-  with_together:
-    - "{{ neutron_routers_pre_stat.results }}"
-    - "{{ neutron_routers_post_stat.results }}"
-
-- name: Cleanup pre and post-upgrade router agent files
-  file:
-    path: "/tmp/{{ item.0 }}.{{ item.1 }}"
-    state: absent
-  with_nested:
-    - neutron_routers.stdout_lines
-    - [ 'pre-upgrade', 'post-upgrade' ]
+- name: Output into text file
+  template:
+    src: "neutron-router-status.txt.j2"
+    dest: "{{ backup_dir }}/neutron-router-status-{{ datetime_stamp }}.txt"
   delegate_to: localhost

--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -111,7 +111,7 @@
   delegate_to: localhost
   failed_when: false
 
-- name: Output into text file
+- name: Render router status template
   template:
     src: "neutron-router-status.txt.j2"
     dest: "{{ backup_dir }}/neutron-router-status-{{ datetime_stamp }}.txt"

--- a/rpcd/playbooks/roles/rpc_post_upgrade/templates/neutron-router-status.txt.j2
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/templates/neutron-router-status.txt.j2
@@ -4,7 +4,7 @@
     {% if post.item == pre.item %}
       {% if 'content' in pre %}
         {% if post.stdout == pre.content | b64decode %}
-  [OK] Router {{ post.item }} did not move agents during the migration
+  [OK] Router {{ post.item }} did not move agents during the migration and is assigned an agent
         {% else %}
           {% if post.stdout == "" %}
           {# if router post upgrade has no agent assigned but did prior to the upgrade #}

--- a/rpcd/playbooks/roles/rpc_post_upgrade/templates/neutron-router-status.txt.j2
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/templates/neutron-router-status.txt.j2
@@ -1,0 +1,19 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+{% for post in neutron_routers_agents.results %}
+  {% for pre in neutron_routers_pre_slurp.results %}
+    {% if post.item == pre.item %}
+      {% if 'content' in pre %}
+        {% if post.stdout == pre.content | b64decode %}
+  [OK] Router {{ post.item }} did not move agents during the migration
+        {% else %}
+          {% if post.stdout == "" %}
+          {# if router post upgrade has no agent assigned but did prior to the upgrade #}
+[WARN] Router {{ post.item }} is currently not assigned to an agent
+          {% else %}
+[WARN] Router {{ post.item }} appears to have moved agents during the migration
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -99,7 +99,6 @@
 - name: Write file containing agent for each router
   copy:
     content: "{{ item.stdout|replace('_','-') }}" # we replace here since containers will get renamed during upgrade
-    dest: "/tmp/{{ item.item }}.pre-upgrade"
+    dest: "{{ backup_dir }}/{{ item.item }}.pre-upgrade"
   with_items: "{{ neutron_routers_agents.results }}"
-  when: item.stdout != ""
   delegate_to: localhost

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -102,3 +102,4 @@
     dest: "/tmp/{{ item.item }}.pre-upgrade"
   with_items: "{{ neutron_routers_agents.results }}"
   when: item.stdout != ""
+  delegate_to: localhost

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -80,3 +80,25 @@
     - status
     - instance-volume-mappings
     - running-instances
+
+- name: Obtain a list of neutron routers
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    neutron router-list -f value --column id
+  register: neutron_routers
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Check agent assigned to each neutron router
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    neutron l3-agent-list-hosting-router -f value --column host {{ item }}
+  with_items: "{{ neutron_routers.stdout_lines }}"
+  register: neutron_routers_agents
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Write file containing agent for each router
+  copy:
+    content: "{{ item.stdout|replace('_','-') }}" # we replace here since containers will get renamed during upgrade
+    dest: "/tmp/{{ item.item }}.pre-upgrade"
+  with_items: "{{ neutron_routers_agents.results }}"
+  when: item.stdout != ""


### PR DESCRIPTION
This commit adds some tasks to the pre and post upgrade roles to check
if a neutron router has moved agents during the upgrade or if the
router is no longer assigned to an agent post upgrade. If either
condition is met we write a short message to a file in the upgrade
backup directory which can be inspected after the upgrade has been
completed.

Note that we have had to mirror some role variables defined in the pre
upgrade role specifically around the backup dir and duplicate those in
the post upgrade role.  When performing an upgrade, it would be
beneficial to add a _temporary_ override for backup_dir so that the
pre and post upgrade roles will use the same backup dir.  For example:

```
# BACKUP_DIR="{{ local_home }}/rpc13-upgrade-$(date '+%Y-%m-%d')"
# echo "backup_dir: \"${BACKUP_DIR}\"" \
    >> /etc/openstack_deploy/user_upgrade_variables.yml
```

In mitaka-13.1, this has been added to the scripts/test-upgrade.sh
file hower in newton-14.0 this file currently does not exist.

Lastly, the original commit was made to mitaka-13.1 so we could
exercise this commit in the gate (mitaka-13.1 being the only branch
that performs an upgrade test).