### PR TITLE
UG-651 IT-16525 Re-disable nova_cross_az_attach

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -52,7 +52,7 @@ nova_ram_allocation_ratio: 1.0
 # if the environment needs to be able to boot an instance from
 # a volume
 # https://bugs.launchpad.net/nova/+bug/1648324
-#nova_cross_az_attach: False
+nova_cross_az_attach: False
 nova_console_type: novnc
 
 # RabbitMQ overrides


### PR DESCRIPTION
This override was disabled in newton due to [1], however this issue has
been resolved in stable/ocata so we can now disable this option in
rcp-openstack's master (ocata).

[1] https://review.openstack.org/#/c/468147/

Issue: [UG-651](https://rpc-openstack.atlassian.net/browse/UG-651)