### PR TITLE
UG-641 Remove neutron agent iptables from deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -223,22 +223,6 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
   # setup the infrastructure
   run_ansible setup-infrastructure.yml
 
-  # This section is duplicated from OSA/run-playbooks as RPC doesn't currently
-  # make use of run-playbooks. (TODO: hughsaunders)
-  # Note that switching to run-playbooks may inadvertently convert to repo build from repo clone.
-  # When running in an AIO, we need to drop the following iptables rule in any neutron_agent containers
-  # to ensure that instances can communicate with the neutron metadata service.
-  # This is necessary because in an AIO environment there are no physical interfaces involved in
-  # instance -> metadata requests, and this results in the checksums being incorrect.
-  if [ "${DEPLOY_AIO}" == "yes" ]; then
-    ansible neutron_agent -m command \
-                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
-    ansible neutron_agent -m command \
-                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 8000 -j CHECKSUM --checksum-fill'
-    ansible neutron_agent -m shell \
-                          -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
-  fi
-
   # setup openstack
   run_ansible setup-openstack.yml
 


### PR DESCRIPTION
This commit updates deploy.sh by removing the iptables rules which get
dropped inside the neutron agents containers.  The os_neutron role in
stable/mitaka handles this when neutron_metadata_checksum_fix is set,
and this variable is automatically overriden by the AIO bootstrap.