### PR TITLE
[master-backport] UG-547 Verify Neutron Ports

### DIFF
--- a/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -50,6 +50,24 @@
   when: "'xxx' in '{{ item.split(' ')[-1] }}'"
   with_items: "{{ neutron_output.stdout_lines | default([]) }}"
 
+- name: Grab relevant output of neutron port-list
+  shell: |
+    . ~/openrc && neutron port-list -c id -c binding:host_id -c device_owner -c status -f value
+  register: neutron_port_output
+
+- name: Warn if any neutron ports are in the build state
+  fail:
+    msg: "One or more of the neutron ports are in the build state"
+  when: "'build' in (item.split(' ')[-1]|lower)"
+  with_items: "{{ neutron_port_output.stdout|default([]) }}"
+  ignore_errors: yes
+
+- name: Write file listing ports in build status
+  template:
+    src: "neutron-port-status.txt.j2"
+    dest: "{{ backup_dir }}/neutron_ports_in_build_status-{{ datetime_stamp }}.post-upgrade"
+  delegate_to: localhost
+
 # Note: As part of https://github.com/rcbops/u-suk-dev/issues/348,
 # it has been realized that cinder services with the old hostname
 # cannot be deleted. Because of this, any services

--- a/rpcd/playbooks/roles/rpc_post_upgrade/templates/neutron-port-status.txt.j2
+++ b/rpcd/playbooks/roles/rpc_post_upgrade/templates/neutron-port-status.txt.j2
@@ -1,0 +1,6 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+{% for port in neutron_port_output.stdout.split('\n')|default([]) %}
+  {% if 'build' in port|lower  %}
+    [WARN] neutron-port {{ port.split(' ')[0] }} on {{ port.split(' ')[1] }} in 'build' status
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Adds post-upgrade task verifying neutron ports not in build
state. Ports in build state results in a warning on post upgrade
tasks, and these ports are written to a post-upgrade file for
easy review.

Rather than exactly matching existing similar tests, this uses a
couple minor ansible syntax changes which match functionality
and are still similar in appearance for a logical grouping of tests.

Created and gated on  Mitaka-13.1, this is backport to master.

(cherry picked from commit 95760ff059cbf2999f1b47ec833d3baa50b8e6d1)