### PR TITLE
[WIP] UG-653 Move test_holland.yml from rpc-gating

### DIFF
--- a/scripts/test_holland.yml
+++ b/scripts/test_holland.yml
@@ -1,0 +1,21 @@
+---
+
+- hosts: galera
+  user: root
+  vars:
+    # This fallback for when rpc_release is not defined is to cater for older releases
+    # where rpc_release is not available as a variable, but is instead derived by the
+    # execution of a module. If we are no longer testing branches older than Newton,
+    # the fallback mechanism can be removed.
+    latest_tag: "{{ lookup('pipe', 'cd /opt/rpc-openstack && git describe --tags --abbrev=0') }}"
+    holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release | default(latest_tag) }}/bin"
+  tasks:
+    - name: Test for holland venv
+      stat:
+        path: "{{ holland_venv_bin }}"
+      register: holland_venv
+
+    - name: Test the functionality of the holland bk command
+      register: command_result
+      failed_when: "command_result.rc > 0"
+      command: "{{ holland_venv.stat.exists | bool | ternary(holland_venv_bin + '/python2.7', '') }} {{ holland_venv.stat.exists | bool | ternary(holland_venv_bin + '/', '') }}holland bk"


### PR DESCRIPTION
This commit moves rpc-gating's test_holland.yml into rpc-openstack.
This change is part of a wider effort to reduce the logic and files
that exist within rpc-gating and making them widely available to the
repos beings tested.

Issue: [UG-653](https://rpc-openstack.atlassian.net/browse/UG-653)