### PR TITLE
UG-641 Backport metadata checksum fix to liberty

### DIFF
--- a/rpcd/patches/neutron-metadata-checksum-fix.patch
+++ b/rpcd/patches/neutron-metadata-checksum-fix.patch
@@ -1,0 +1,92 @@
+diff --git a/playbooks/roles/os_neutron/defaults/main.yml b/playbooks/roles/os_neutron/defaults/main.yml
+index e86b2e9..01e5b79 100644
+--- a/playbooks/roles/os_neutron/defaults/main.yml
++++ b/playbooks/roles/os_neutron/defaults/main.yml
+@@ -355,6 +355,13 @@ neutron_lbaas_apt_packages:
+ neutron_apt_remove_packages:
+   - conntrackd
+
++# When running in an AIO, we need to implement an iptables rule in any
++# neutron_agent containers to that ensure instances can communicate with
++# the neutron metadata service. This is necessary because in an AIO
++# environment there are no physical interfaces involved in instance ->
++# metadata requests, and this results in the checksums being incorrect.
++neutron_metadata_checksum_fix: False
++
+ # neutron packages that must be installed before anything else
+ neutron_requires_pip_packages:
+   - virtualenv
+diff --git a/playbooks/roles/os_neutron/files/post-up-metadata-checksum b/playbooks/roles/os_neutron/files/post-up-metadata-checksum
+new file mode 100644
+index 0000000..0e3705a
+--- /dev/null
++++ b/playbooks/roles/os_neutron/files/post-up-metadata-checksum
+@@ -0,0 +1,37 @@
++#!/usr/bin/env bash
++# Copyright 2016, Rackspace US, Inc.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# NOTICE:
++# When running in an AIO, we need to drop the following iptables rule in any
++# neutron_agent containers to that ensure instances can communicate with the
++# neutron metadata service. This is necessary because in an AIO environment
++# there are no physical interfaces involved in instance -> metadata requests,
++# and this results in the checksums being incorrect.
++
++# Iptables path, used for ipv4 firewall.
++IPTABLES=$(which iptables)
++if [ ! -z "${IPTABLES}" ]; then
++    if ! ${IPTABLES} -C POSTROUTING -t mangle -p tcp --sport 80 -j CHECKSUM --checksum-fill 2> /dev/null; then
++        ${IPTABLES} -A POSTROUTING -t mangle -p tcp --sport 80 -j CHECKSUM --checksum-fill
++    fi
++fi
++
++# Ip6tables path, used for ipv6 firewall.
++IP6TABLES=$(which ip6tables)
++if [ ! -z "${IP6TABLES}" ]; then
++    if ! ${IP6TABLES} -C POSTROUTING -t mangle -p udp --sport 80 -j CHECKSUM --checksum-fill 2> /dev/null; then
++        ${IP6TABLES} -A POSTROUTING -t mangle -p udp --sport 80 -j CHECKSUM --checksum-fill
++    fi
++fi
+diff --git a/playbooks/roles/os_neutron/tasks/neutron_post_install.yml b/playbooks/roles/os_neutron/tasks/neutron_post_install.yml
+index 2e5830b..a7cb55f 100644
+--- a/playbooks/roles/os_neutron/tasks/neutron_post_install.yml
++++ b/playbooks/roles/os_neutron/tasks/neutron_post_install.yml
+@@ -160,3 +160,26 @@
+     - not neutron_venv_enabled | bool
+   tags:
+     - neutron-command-bin
++
++- name: Drop metadata iptables checksum fix
++  copy:
++    src: "post-up-metadata-checksum"
++    dest: "/etc/network/if-up.d/post-up-metadata-checksum"
++    owner: "root"
++    group: "root"
++    mode: "0755"
++  when:
++    - neutron_metadata_checksum_fix | bool
++    - inventory_hostname in groups[neutron_services['neutron-linuxbridge-agent']['group']]
++  tags:
++    - neutron-config
++    - neutron-checksum-fix
++
++- name: Run metadata iptables checksum fix
++  command: /etc/network/if-up.d/post-up-metadata-checksum
++  when:
++    - neutron_metadata_checksum_fix | bool
++    - inventory_hostname in groups[neutron_services['neutron-linuxbridge-agent']['group']]
++  tags:
++    - neutron-config
++    - neutron-checksum-fix

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -24,3 +24,6 @@
   user: root
   roles:
     - { role: "patcher", tags: [ "patcher" ] }
+  vars:
+    patcher_files:
+      - neutron-metadata-checksum-fix.patch


### PR DESCRIPTION
This commit backports [1] to liberty-12.2, which gets applied via the
patcher role.

We also update scripts/deploy.sh to remove adding iptables rules, and
add write `neutron_metadata_checksum_fix: true` to user_variables.yml
when DEPLOY_AIO=yes.

[1] https://review.openstack.org/#/c/330405/

Issue: [UG-641](https://rpc-openstack.atlassian.net/browse/UG-641)