### PR TITLE
UG-641 Backport metadata checksum fix to kilo

### DIFF
--- a/rpcd/patches/neutron-metadata-checksum-fix.patch
+++ b/rpcd/patches/neutron-metadata-checksum-fix.patch
@@ -1,0 +1,92 @@
+diff --git a/playbooks/roles/os_neutron/defaults/main.yml b/playbooks/roles/os_neutron/defaults/main.yml
+index fdf15dd..c88c441 100644
+--- a/playbooks/roles/os_neutron/defaults/main.yml
++++ b/playbooks/roles/os_neutron/defaults/main.yml
+@@ -288,6 +288,13 @@ neutron_apt_packages:
+ neutron_apt_remove_packages:
+   - conntrackd
+
++# When running in an AIO, we need to implement an iptables rule in any
++# neutron_agent containers to that ensure instances can communicate with
++# the neutron metadata service. This is necessary because in an AIO
++# environment there are no physical interfaces involved in instance ->
++# metadata requests, and this results in the checksums being incorrect.
++neutron_metadata_checksum_fix: False
++
+ neutron_pip_packages:
+   - configobj
+   - cliff
+diff --git a/playbooks/roles/os_neutron/files/post-up-metadata-checksum b/playbooks/roles/os_neutron/files/post-up-metadata-checksum
+new file mode 100644
+index 0000000..0e3705a
+--- /dev/null
++++ b/playbooks/roles/os_neutron/files/post-up-metadata-checksum
+@@ -0,0 +1,37 @@
++#!/usr/bin/env bash
++# Copyright 2016, Rackspace US, Inc.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# NOTICE:
++# When running in an AIO, we need to drop the following iptables rule in any
++# neutron_agent containers to that ensure instances can communicate with the
++# neutron metadata service. This is necessary because in an AIO environment
++# there are no physical interfaces involved in instance -> metadata requests,
++# and this results in the checksums being incorrect.
++
++# Iptables path, used for ipv4 firewall.
++IPTABLES=$(which iptables)
++if [ ! -z "${IPTABLES}" ]; then
++    if ! ${IPTABLES} -C POSTROUTING -t mangle -p tcp --sport 80 -j CHECKSUM --checksum-fill 2> /dev/null; then
++        ${IPTABLES} -A POSTROUTING -t mangle -p tcp --sport 80 -j CHECKSUM --checksum-fill
++    fi
++fi
++
++# Ip6tables path, used for ipv6 firewall.
++IP6TABLES=$(which ip6tables)
++if [ ! -z "${IP6TABLES}" ]; then
++    if ! ${IP6TABLES} -C POSTROUTING -t mangle -p udp --sport 80 -j CHECKSUM --checksum-fill 2> /dev/null; then
++        ${IP6TABLES} -A POSTROUTING -t mangle -p udp --sport 80 -j CHECKSUM --checksum-fill
++    fi
++fi
+diff --git a/playbooks/roles/os_neutron/tasks/neutron_post_install.yml b/playbooks/roles/os_neutron/tasks/neutron_post_install.yml
+index 52e388f..c125bd0 100644
+--- a/playbooks/roles/os_neutron/tasks/neutron_post_install.yml
++++ b/playbooks/roles/os_neutron/tasks/neutron_post_install.yml
+@@ -146,3 +146,26 @@
+ - name: Setup PLUMgrid config
+   include: plumgrid_config.yml
+   when: neutron_plugin_type == 'plumgrid'
++
++- name: Drop metadata iptables checksum fix
++  copy:
++    src: "post-up-metadata-checksum"
++    dest: "/etc/network/if-up.d/post-up-metadata-checksum"
++    owner: "root"
++    group: "root"
++    mode: "0755"
++  when:
++    - neutron_metadata_checksum_fix | bool
++    - inventory_hostname in groups['neutron_linuxbridge_agent']
++  tags:
++    - neutron-config
++    - neutron-checksum-fix
++
++- name: Run metadata iptables checksum fix
++  command: /etc/network/if-up.d/post-up-metadata-checksum
++  when:
++    - neutron_metadata_checksum_fix | bool
++    - inventory_hostname in groups['neutron_linuxbridge_agent']
++  tags:
++    - neutron-config
++    - neutron-checksum-fix

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -27,3 +27,4 @@
   vars:
     patcher_files:
       - openstack-hosts-u-suk-dev-issues-1629.patch
+      - neutron-metadata-checksum-fix.patch

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -66,6 +66,7 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
     sed -i "s/cinder_service_backup_program_enabled: .*/cinder_service_backup_program_enabled: true/" /etc/openstack_deploy/user_variables.yml
     # set network speed for vms
     echo "net_max_speed: 1000" >>$RPCD_VARS
+    echo "neutron_metadata_checksum_fix: yes" >> /etc/openstack_deploy/user_variables.yml
 
     # set the necessary bits for ceph
     if [[ "$DEPLOY_CEPH" == "yes" ]]; then
@@ -138,20 +139,6 @@ if [[ "${DEPLOY_OA}" == "yes" ]]; then
 
   # setup the infrastructure
   run_ansible setup-infrastructure.yml
-
-  # This section is duplicated from OSA/run-playbooks as RPC doesn't currently
-  # make use of run-playbooks. (TODO: hughsaunders)
-  # Note that switching to run-playbooks may inadvertently convert to repo build from repo clone.
-  # When running in an AIO, we need to drop the following iptables rule in any neutron_agent containers
-  # to ensure that instances can communicate with the neutron metadata service.
-  # This is necessary because in an AIO environment there are no physical interfaces involved in
-  # instance -> metadata requests, and this results in the checksums being incorrect.
-  if [ "${DEPLOY_AIO}" == "yes" ]; then
-    ansible neutron_agent -m command \
-                          -a '/sbin/iptables -t mangle -A POSTROUTING -p tcp --sport 80 -j CHECKSUM --checksum-fill'
-    ansible neutron_agent -m shell \
-                          -a 'DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent'
-  fi
 
   # setup openstack
   run_ansible setup-openstack.yml


### PR DESCRIPTION
This commit backports [1] to kilo, which gets applied via the patcher
role.

We also update scripts/deploy.sh to remove adding iptables rules, and
add write neutron_metadata_checksum_fix: true to user_variables.yml
when DEPLOY_AIO=yes.

[1] https://review.openstack.org/#/c/330405/