### PR TITLE
Add default value for maas_use_api

### DIFF
--- a/rpcd/playbooks/verify-maas.yml
+++ b/rpcd/playbooks/verify-maas.yml
@@ -52,3 +52,6 @@
       delay: "5"
       when:
         - maas_use_api | bool
+
+  vars:
+    maas_use_api: true


### PR DESCRIPTION
Add default value for maas_use_api as not all scenarios define it.
This playbook will probably removed in a future refactor, but for
now we need to unblock the gate.

Connects: rcbops/rpc-openstack#2377.