### PR TITLE
LA-271 Remove liberasurecode-dev requirement

### DIFF
--- a/scripts/leapfrog/ubuntu14-leapfrog.sh
+++ b/scripts/leapfrog/ubuntu14-leapfrog.sh
@@ -47,7 +47,7 @@ export OA_OPS_REPO=${OA_OPS_REPO:-'https://github.com/openstack/openstack-ansibl
 # Please bump the following when a patch for leapfrog is merged into osa-ops
 # If you are developping, just clone your ops repo into (by default)
 # /opc/rpc-leapfrog/openstack-ansible-ops
-export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'c1a4219a5ac9f634afae695be8d6dea0e1e31059'}
+export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'da7cc439f7701dc6e42cccbf870e97ab1aae7542'}
 # Instead of storing the debug's log of run in /tmp, we store it in an
 # folder that will get archived for gating logs
 export DEBUG_PATH="/var/log/osa-leapfrog-debug.log"


### PR DESCRIPTION
If the leapfrog venv is published we don't need to install
liberasurecode-dev on the deploy node, and therefore no
requirements on the repos used for the deploy node.

This bumps openstack-ansible-ops sha to include the
patch that removes the installation of liberasurecode-dev on
the deploy node (while keeping it on the venv build node)

