### PR TITLE
UG-664 Remove nova-spicehtml5proxy MaaS config

### DIFF
--- a/rpcd/playbooks/rpc-pre-upgrades.yml
+++ b/rpcd/playbooks/rpc-pre-upgrades.yml
@@ -86,3 +86,17 @@
         path: "/etc/rackspace-monitoring-agent.conf.d/beaver_process_check-{{ inventory_hostname }}.yaml"
         state: absent
       delegate_to: "{{ physical_host }}"
+
+- name: Remove legacy nova-spicehtml5proxy MaaS checks/alarms
+  hosts: nova_console
+  user: root
+  tags:
+    - rpc-pre-upgrades
+    - remove-nova-spice-console-maas-config
+  tasks:
+    - file:
+        path: "/etc/rackspace-monitoring-agent.conf.d/nova_spice_console_check--{{ inventory_hostname }}.yaml"
+        state: absent
+      delegate_to: "{{ physical_host }}"
+      when:
+        - nova_console_type == "novnc"


### PR DESCRIPTION
As we upgrade from liberty->mitaka, we change console type from "spice"
to "novnc".  At present, we do not remove the old spice MaaS configs
which causes Verify MaaS to fail.

This commit simply updates rpc-per-upgrades.yml to remove these
configs when nova_console_type is in fact "novnc".

Issue: [UG-664](https://rpc-openstack.atlassian.net/browse/UG-664)