### PR TITLE
[LA-350] Ensure ansible_host doesn't exist in vars

### DIFF
--- a/scripts/leapfrog/pre_leap.sh
+++ b/scripts/leapfrog/pre_leap.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# (c) 2017, Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>
+
+## Shell Opts ----------------------------------------------------------------
+set -e -u -x
+set -o pipefail
+
+# Branches lower than Newton may have ansible_host: ansible_ssh_host mapping
+# that will fail because ansible_ssh_host is undefined on ansible 2.1
+# Strip it.
+if [[ -f /etc/openstack_deploy/user_rpcm_variables.yml ]]; then
+    sed -i '/ansible_host/d' /etc/openstack_deploy/user_rpcm_variables.yml
+fi

--- a/scripts/leapfrog/pre_leap.sh
+++ b/scripts/leapfrog/pre_leap.sh
@@ -22,6 +22,6 @@ set -o pipefail
 # Branches lower than Newton may have ansible_host: ansible_ssh_host mapping
 # that will fail because ansible_ssh_host is undefined on ansible 2.1
 # Strip it.
-if [[ -f /etc/openstack_deploy/user_rpcm_variables.yml ]]; then
-    sed -i '/ansible_host/d' /etc/openstack_deploy/user_rpcm_variables.yml
+if [[ -f /etc/openstack_deploy/user_rpcm_default_variables.yml ]]; then
+    sed -i '/ansible_host/d' /etc/openstack_deploy/user_rpcm_default_variables.yml
 fi


### PR DESCRIPTION
If the new RPC-Maas is deployed on K,L,M, ansible_host will be
defined to ansible_ssh_host and will break the leapfrog.

Issue: [LA-350](https://rpc-openstack.atlassian.net/browse/LA-350)