### PR TITLE
Use upstream RPC-MaaS (master)

### DIFF
--- a/group_vars/all/ceph.yml
+++ b/group_vars/all/ceph.yml
@@ -18,7 +18,7 @@ ceph_mons: >
   {% set _var = [] -%}
   {% if 'mons' in groups -%}
   {% for mon in groups.mons -%}
-  {% if _var.append(hostvars[mon]['ansible_ssh_host']) -%}{% endif -%}
+  {% if _var.append(hostvars[mon]['ansible_host']) -%}{% endif -%}
   {% endfor -%}
   {% endif -%}
   {{ _var }}

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -82,8 +82,6 @@ neutron_neutron_conf_overrides:
 #Set the default for Neutron-HA-tool to true
 neutron_legacy_ha_tool_enabled: true
 
-cinder_service_backup_program_enabled: false
-
 repo_build_upper_constraints_overrides:
   # Due to https://bugs.launchpad.net/ceilometer/+bug/1660800, gnocchiclient
   # must be pinned to < 3.0.0. This constraint matches what is defined in

--- a/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
@@ -14,48 +14,32 @@
 # limitations under the License.
 
 # MAAS
+# Set maas_auth_method to 'token' to use maas_auth_token/maas_api_url
+# instead of maas_username/maas_api_key
+maas_auth_method: password
+maas_tenant_id: "{{ rackspace_cloud_tenant_id | default('') }}"
+maas_username: "{{ rackspace_cloud_username | default('') }}"
+maas_api_key: "{{ rackspace_cloud_api_key | default('') }}"
+maas_auth_token: "{{ rackspace_cloud_auth_token | default('') }}"
+maas_notification_plan: npManaged
+
 # Set the maas_scheme
 # Note: (alextricity25) This has been changed to https because
 # SSL termination is done by default since Newton per https://review.openstack.org/#/c/277199/
 maas_scheme: https
 
-# Set the following to skip a specific check
-# horizon_local_check is disabled until https://github.com/rcbops/u-suk-dev/issues/781
-# is resolved
-maas_excluded_checks:
-  - 'horizon_local_check.*'
-  - 'cinder_backup_check.*'
+# Set whether checks should be enabled or disabled
+maas_ssl_check: false
+maas_host_check: false
+maas_remote_check: true
 
-# Disable the following MaaS alarms
-# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
-maas_excluded_alarms:
-  - '^idle_percent_average.*'
-  - '^memory_used.*'
-  - '^alarm-network-receive.*'
-  - '^alarm-network-transmit.*'
+# By default we will create an agent token for each entity, however if you'd
+# prefer to use the same agent token for all entities then specify it here
+#maas_agent_token: some_token
+maas_target_alias: public0_v4
 
-# Set overrides for check periods
-# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
-maas_check_period_override:
-  disk_utilisation: 900
-
-# overrides for the nova_cloud_stats  maas plugin
-maas_cloud_resource_cpu_allocation_ratio: "{{ nova_cpu_allocation_ratio | default(2.0) }}"
-maas_cloud_resource_mem_allocation_ratio: "{{ nova_ram_allocation_ratio | default(1.0) }}"
-
-#
-# maas_fqdn_extension: Sets the fully-qualified domain name (FQDN) extension that will be appended
-#                      to the short names for hosts that are specified in rpc_user_config. This
-#                      avoids the need to specify extremely long container names.
-#
-#   For example, if this variable was not set, a device called 12345-node1.mytestcluster.com would
-#   have to be named in openstack_user_config.yml as 12345-node1.mytestcluster.com for MaaS checks
-#   to be created correctly. However, if maas_fqdn_extension is set as .mytestcluster.com, the
-#   device can be named 12345-node1 in openstack_user_config.yml. This enables shorter container
-#   names while still enabling MaaS checks and alarms to be created properly.
-#
-# maas_fqdn_extension: .example.com
-maas_fqdn_extension: ""
+# Enable/Disable the cinder-backup monitor
+maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled | default(false) }}"
 
 # MaaS pathing and versions
 maas_release: master

--- a/rpcd/playbooks/maas-get.yml
+++ b/rpcd/playbooks/maas-get.yml
@@ -22,5 +22,13 @@
         repo: "https://github.com/rcbops/rpc-maas"
         dest: "/opt/rpc-maas"
         version: "{{ maas_release }}"
+    - name: Ensure openstack_deploy exists
+      file:
+        dest: "/etc/openstack_deploy"
+        state: directory
+    - name: Copy over base maas vars
+      copy:
+        src: "/opt/rpc-maas/tests/user_master_vars.yml"
+        dest: "/etc/openstack_deploy/user_rpcm_default_variables.yml"
   tags:
     - maas


### PR DESCRIPTION
This change simplifies our configs for the use of upstream maas and
brings forward a few of the improvements we're implementing in the
stable branches.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>