### PR TITLE
[LA-314] Bring the ability to use influxdb

### DIFF
--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -30,23 +30,53 @@ cd ${RPCD_DIR}/playbooks/
 
 # configure everything for RPC support access
 if [[ "${DEPLOY_SUPPORT_ROLE}" == "yes" ]]; then
-  run_ansible rpc-support.yml
+    run_ansible rpc-support.yml
 fi
 
 # deploy and configure the ELK stack
 if [[ "${DEPLOY_ELK}" == "yes" ]]; then
-  run_ansible setup-logging.yml
+    run_ansible setup-logging.yml
 fi
 
 # Download the latest release of rpc-maas
 run_ansible maas-get.yml
 
-# deploy and configure RAX MaaS
+# Deploy and configure RAX MaaS
 if [[ "${DEPLOY_MAAS}" == "yes" ]]; then
-  # Run the rpc-maas setup process
-  run_ansible setup-maas.yml
+    # Run the rpc-maas setup process
+    run_ansible setup-maas.yml
 
-  # verify RAX MaaS is running after all necessary
-  # playbooks have been run
-  run_ansible verify-maas.yml
+    # verify RAX MaaS is running after all necessary
+    # playbooks have been run
+    run_ansible verify-maas.yml
+fi
+
+# To send data to the influxdb server, we need to deploy and
+# configure telegraf.
+# By default, telegraf will use log_hosts (rsyslog hosts)
+# to define its influxdb servers.
+# These playbooks need maas-get to have run previously.
+if [[ "${DEPLOY_TELEGRAF}" == "yes" ]]; then
+    # BUILD_TAG is used as reference for gating, to allow
+    if [[ -z "${BUILD_TAG}" ]]; then
+        # user_zzz_variables are generated at every build, so
+        # we are fine to just echo it.
+        echo 'maas_job_reference: "${BUILD_TAG}"' >> /etc/openstack_deploy/user_zzz_gating_metrics_variables.yml
+        # Telegraph shipping is done to influx nodes belonging to
+        # influx_telegraf_targets | union(influx_all)
+        if [[ -z "${INFLUX_IP}" ]]; then
+            cat >> /etc/openstack_deploy/user_zzz_gating_metrics_variables.yml << EOF
+influx_telegraf_targets:
+  - 'http://$INFLUX_IP:$INFLUX_PORT'
+EOF
+        fi
+    fi
+    run_ansible /opt/rpc-maas/playbooks/maas-tigkstack-telegraf.yml
+fi
+
+# Deploy Influx
+if [[ "${DEPLOY_INFLUX}" == "yes" ]]; then
+    # We'll assume the deployer has configured his environment
+    # to define the influx_all servers.
+    run_ansible /opt/rpc-maas/playbooks/maas-tigkstack-influxdb.yml
 fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -15,11 +15,19 @@
 
 ## Vars ----------------------------------------------------------------------
 
+# Gating
+export BUILD_TAG=${BUILD_TAG:-}
+export INFLUX_IP=${INFLUX_IP:-}
+export INFLUX_PORT=${INFLUX_IP:-"8086"}
+
+# Other
 export ADMIN_PASSWORD=${ADMIN_PASSWORD:-"secrete"}
 export DEPLOY_AIO=${DEPLOY_AIO:-"no"}
 export DEPLOY_OA=${DEPLOY_OA:-"yes"}
 export DEPLOY_ELK=${DEPLOY_ELK:-"yes"}
 export DEPLOY_MAAS=${DEPLOY_MAAS:-"no"}
+export DEPLOY_TELEGRAF=${DEPLOY_TELEGRAF:-"no"}
+export DEPLOY_INFLUX=${DEPLOY_INFLUX:-"no"}
 export DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"no"}
 export DEPLOY_RALLY=${DEPLOY_RALLY:-"no"}
 export DEPLOY_CEPH=${DEPLOY_CEPH:-"no"}


### PR DESCRIPTION
RPC-Maas is able to push metrics to influx, we should expose
this facility to our users, which includes our gates.

Issue: [LA-314](https://rpc-openstack.atlassian.net/browse/LA-314)