### PR TITLE
AR-204 Remove maas-get from bootstrap-ansible

### DIFF
--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -71,11 +71,6 @@ pushd ${OA_DIR}
     exit 99
   fi
 
-  # Run the RPC-MaaS "GET" playbook to clone RPC-MaaS into place.
-  ansible-playbook -i 'localhost 127.0.0.1,' \
-                   -e @"${RPCD_DIR}/etc/openstack_deploy/user_rpcm_variables.yml" \
-                   "${RPCD_DIR}/playbooks/maas-get.yml"
-
   # RPC-O has roles in its own git tree, so we need to add it to the
   # path for Ansible to search.
   sed -i "s|/etc/ansible/roles:roles|/etc/ansible/roles:roles:${RPCD_DIR}/playbooks/roles|" /usr/local/bin/openstack-ansible.rc

--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -39,6 +39,12 @@ if [[ "${DEPLOY_ELK}" == "yes" ]]; then
 fi
 
 # Download the latest release of rpc-maas
+# TODO(odyssey4me):
+# Remove this once rpc-gating no longer tries
+# to run rpc-maas as its own thing and instead
+# just uses deploy.sh end-to-end. This line
+# should not be necessary as setup-maas.yml
+# below includes maas-get.yml
 run_ansible maas-get.yml
 
 # deploy and configure RAX MaaS


### PR DESCRIPTION
As maas-get implements some configuration in
/etc/openstack_deploy which breaks the apt
artifact building, and maas-get is effectively
run in three different places, it is removed
from the Ansible bootstrap.

Issue: [AR-204](https://rpc-openstack.atlassian.net/browse/AR-204)