### PR TITLE
Bring the ability to use influxdb (#2388)

### DIFF
--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -e -u -x
+set -o pipefail
+
+## Functions -----------------------------------------------------------------
+
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
+## Main ----------------------------------------------------------------------
+
+# begin the RPC installation
+cd ${RPCD_DIR}/playbooks/
+
+# configure everything for RPC support access
+if [[ "${DEPLOY_SUPPORT_ROLE}" == "yes" ]]; then
+    run_ansible rpc-support.yml
+fi
+
+# deploy and configure the ELK stack
+if [[ "${DEPLOY_ELK}" == "yes" ]]; then
+    run_ansible setup-logging.yml
+fi
+
+# Download the latest release of rpc-maas
+# TODO(odyssey4me):
+# Remove this once rpc-gating no longer tries
+# to run rpc-maas as its own thing and instead
+# just uses deploy.sh end-to-end. This line
+# should not be necessary as setup-maas.yml
+# below includes maas-get.yml
+run_ansible maas-get.yml
+
+# Deploy and configure RAX MaaS
+if [[ "${DEPLOY_MAAS}" == "yes" ]]; then
+    # Run the rpc-maas setup process
+    run_ansible setup-maas.yml
+
+    # verify RAX MaaS is running after all necessary
+    # playbooks have been run
+    run_ansible verify-maas.yml
+fi
+
+# To send data to the influxdb server, we need to deploy and
+# configure telegraf.
+# By default, telegraf will use log_hosts (rsyslog hosts)
+# to define its influxdb servers.
+# These playbooks need maas-get to have run previously.
+if [[ "${DEPLOY_TELEGRAF}" == "yes" ]]; then
+    # BUILD_TAG is used as reference for gating, to allow
+    if [[ -z "${BUILD_TAG}" ]]; then
+        # user_zzz_variables are generated at every build, so
+        # we are fine to just echo it.
+        echo 'maas_job_reference: "${BUILD_TAG}"' >> /etc/openstack_deploy/user_zzz_gating_metrics_variables.yml
+        # Telegraph shipping is done to influx nodes belonging to
+        # influx_telegraf_targets | union(influx_all)
+        if [[ -z "${INFLUX_IP}" ]]; then
+            cat >> /etc/openstack_deploy/user_zzz_gating_metrics_variables.yml << EOF
+influx_telegraf_targets:
+  - 'http://$INFLUX_IP:$INFLUX_PORT'
+EOF
+        fi
+    fi
+    run_ansible /opt/rpc-maas/playbooks/maas-tigkstack-telegraf.yml
+fi
+
+# Deploy Influx
+if [[ "${DEPLOY_INFLUX}" == "yes" ]]; then
+    # We'll assume the deployer has configured his environment
+    # to define the influx_all servers.
+    run_ansible /opt/rpc-maas/playbooks/maas-tigkstack-influxdb.yml
+fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2014-2017 , Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Vars ----------------------------------------------------------------------
+
+# Gating
+export BUILD_TAG=${BUILD_TAG:-}
+export INFLUX_IP=${INFLUX_IP:-}
+export INFLUX_PORT=${INFLUX_IP:-"8086"}
+
+# Other
+export DEPLOY_SUPPORT_ROLE=${DEPLOY_SUPPORT_ROLE:-"no"}
+export DEPLOY_ELK=${DEPLOY_ELK:-"yes"}
+export DEPLOY_MAAS=${DEPLOY_MAAS:-"no"}
+export DEPLOY_TELEGRAF=${DEPLOY_TELEGRAF:-"no"}
+export DEPLOY_INFLUX=${DEPLOY_INFLUX:-"no"}
+
+export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-''}
+export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+export RPCD_DIR="${BASE_DIR}/rpcd"
+
+
+function run_ansible {
+  openstack-ansible ${ANSIBLE_PARAMETERS} --forks ${FORKS} $@
+}


### PR DESCRIPTION
RPC-Maas is able to push metrics to influx, we should expose
this facility to our users, which includes our gates.

On top of it, we should bring the facility to deploy influx, if
need be.

RPC-Maas is able to push metrics to influx, we should expose
this facility to our users, which includes our gates.

Note: To include this in a more standardized way, I had to
create scripts/(functions|deploy-rpc-playbooks).sh, and use these
from deploy.sh. Further work can be done to simplify deploy.sh
script to look more like the one on upper branches.

Issue: [LA-314](https://rpc-openstack.atlassian.net/browse/LA-314)
Manual cherry pick from 45046ee09887b4eb3e91e10de9707c9634011b23