### PR TITLE
Bump OSA-OPS repo

### DIFF
--- a/scripts/leapfrog/ubuntu14-leapfrog.sh
+++ b/scripts/leapfrog/ubuntu14-leapfrog.sh
@@ -47,7 +47,7 @@ export OA_OPS_REPO=${OA_OPS_REPO:-'https://github.com/openstack/openstack-ansibl
 # Please bump the following when a patch for leapfrog is merged into osa-ops
 # If you are developping, just clone your ops repo into (by default)
 # /opc/rpc-leapfrog/openstack-ansible-ops
-export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'c441ba44103a20f9a0e58c70f3ce785f0d7206fc'}
+export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'1116df75287201a7a269b94cc0448127b5908daa'}
 # Instead of storing the debug's log of run in /tmp, we store it in an
 # folder that will get archived for gating logs
 export DEBUG_PATH="/var/log/osa-leapfrog-debug.log"


### PR DESCRIPTION
This includes, for the leapfrog:
- A fix to the openstack-release discovery
- A change to the mirror used by default
- A fix to mysql-python/pip requirements dependencies

Partial-issue: LA-322