### PR TITLE
[LA-365] Force yaprt to build setuptools 24

### DIFF
--- a/rpcd/playbooks/roles/beaver/defaults/main.yml
+++ b/rpcd/playbooks/roles/beaver/defaults/main.yml
@@ -14,8 +14,20 @@
 # limitations under the License.
 
 # the pip packages to install
+# Only beaver is required, the rest are there to constrain the version of deps.
 beaver_pip_packages:
   - "beaver==33.3.0"
+  - "boto==2.48.0"
+  - "conf-d==0.0.4"
+  - "glob2==0.3"
+  - "kafka-python==1.3.3"
+  - "lockfile==0.12.2"
+  - "mosquitto==1.2.3"
+  - "msgpack-pure==0.1.3"
+  - "pika==0.10.0"
+  - "python-daemon==1.6.1"
+  - "redis==2.10.5"
+  - "setuptools==24.0.2"
 
 # the beaver daemon settings
 beaver_daemon_log: "/var/log/beaver/beaver.log"

--- a/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/rpcd/playbooks/roles/elasticsearch/defaults/main.yml
@@ -25,8 +25,14 @@ elasticsearch_apt_packages:
   - elasticsearch
   - openjdk-7-jre-headless
 
+# Elasticsearch dependencies added to package list so their versions
+# can be constrained.
 elasticsearch_pip_packages:
-  - elasticsearch-curator
+  - elasticsearch-curator<3.5.0
+  - elasticsearch<2.1.0
+  - setuptools==24.0.2
+  - click==6.7
+  - urllib3==1.21.1
 
 # This sets the cluster name
 elasticsearch_cluster: openstack


### PR DESCRIPTION
There is no constraint at all for setuptools in the rpc builds.
So we can install any version of these software, and yaprt
is building latest wheels.

We need to not use latest wheels for setuptools, therefore
I list it as a pip_package. It will therefore be listed in the
deps, and will be used in the yaprt process. No new setuptools
will be used, as the dependency will be met.

On top of it, it was free for all for elasticsearch, so I took
the liberty (pun intended) to strengthen the elasticsearch and
elastisearch-curator constraints, with a value coming from
Liberty-12.2 branch.

Issue: [LA-365](https://rpc-openstack.atlassian.net/browse/LA-365)