### PR TITLE
Move GROUP_VARS and HOST_VARS_PATH

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -60,10 +60,6 @@ source scripts/bootstrap-ansible.sh
 # that no containers are created in the inventory.
 rm -f /etc/openstack_deploy/conf.d/*
 
-# Now use GROUP_VARS of OSA and RPC
-sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-
 # If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
 if container_artifacts_available; then
   export PUSH_TO_MIRROR="NO"

--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -45,10 +45,6 @@ export ANSIBLE_ROLE_FETCH_MODE="git-clone"
 # functions and vars are available.
 source scripts/bootstrap-ansible.sh
 
-# Now use GROUP_VARS of OSA and RPC
-sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${OA_DIR}/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${OA_DIR}/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-
 # Fetch all the git repositories and generate the git artifacts
 # The openstack-ansible CLI is used to ensure that the library path is set
 #

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -53,10 +53,6 @@ source scripts/bootstrap-ansible.sh
 # Bootstrap the AIO configuration
 ./scripts/bootstrap-aio.sh
 
-# Now use GROUP_VARS of OSA and RPC
-sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${BASE_DIR}/openstack-ansible/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-
 # Remove the AIO configuration relating to the use
 # of container artifacts. This needs to be done
 # because the container artifacts do not exist yet.

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -50,9 +50,20 @@ else
 fi
 
 # Run AIO bootstrap playbook
+# Setting GROUP_VARS and HOST_VARS to their original
+# values here so that the OSA bootstrap playbooks
+# can run with the correct variables.
+export GROUP_VARS_PATH="/etc/openstack_deploy/group_vars/"
+export HOST_VARS_PATH="/etc/openstack_deploy/host_vars/"
 openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \
                   -e "${BOOTSTRAP_OPTS}"
+# Unset GROUP_VARS_PATH and HOST_VARS_PATH so that the
+# defaults are taken in openstack-ansible.rc
+unset GROUP_VARS_PATH
+unset HOST_VARS_PATH
+
+
 
 if ! apt_artifacts_available; then
   # Remove the AIO configuration relating to the use

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -75,4 +75,8 @@ pushd ${OA_DIR}
   # path for Ansible to search.
   sed -i "s|/etc/ansible/roles:|/etc/ansible/roles:${RPCD_DIR}/playbooks/roles:|" /usr/local/bin/openstack-ansible.rc
 
+  # Now use GROUP_VARS of OSA and RPC
+  sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${OA_DIR}/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
+  sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${OA_DIR}/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
+
 popd

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -60,10 +60,6 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
 
 fi
 
-# Now use GROUP_VARS of OSA and RPC
-sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${OA_DIR}/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${OA_DIR}/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-
 # move OSA secrets to correct locations
 if [[ ! -f /etc/openstack_deploy/user_osa_secrets.yml ]] && [[ -f /etc/openstack_deploy/user_secrets.yml ]]; then
   mv /etc/openstack_deploy/user_secrets.yml /etc/openstack_deploy/user_osa_secrets.yml


### PR DESCRIPTION
These variables are now set in the bootstrap-ansible script. This is to prevent
situations where the deploy re-runs bootstrap-ansible.sh as a stand-alone script,
which would overwrite the variables causing out of scope issues.

In addition, some logic has been added so that the variables are set to their
original value before running the OSA bootstrap playbook. This is so there
are no extra settings when the bootstrap playbook runs.

(cherry picked from commit ce2b72aabc1ab95ebbc9be499973200b633c0841)