### PR TITLE
LA-369 Remove old maas checks from maas agent

### DIFF
--- a/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml
+++ b/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml
@@ -1,0 +1,9 @@
+---
+- hosts: hosts
+  gather_facts: no
+  tasks:
+    - shell: "rm -f {% raw %}/etc/rackspace-monitoring-agent.conf.d/*${{% endraw %}{{ item }}{% raw %}}*{% endraw %}"
+      args:
+        executable: /bin/bash
+      with_file:
+        - "/etc/openstack_deploy/leapfrog_remove_remaining_old_containers"

--- a/scripts/leapfrog/post_leap.sh
+++ b/scripts/leapfrog/post_leap.sh
@@ -33,6 +33,7 @@ if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/deploy-rpc.complete" ]]; then
     sed -i 's#export ANSIBLE_INVENTORY=.*#export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/opt/rpc-openstack/openstack-ansible/playbooks/inventory}"#g' /usr/local/bin/openstack-ansible.rc
     # TODO(remove the following hack to restart the neutron agents, when fixed upstream)
     ansible -m shell -a "restart neutron-linuxbridge-agent" nova_compute -i /opt/rpc-openstack/openstack-ansible/playbooks/inventory/dynamic_inventory.py
+    openstack-ansible ${RPCO_DEFAULT_FOLDER}/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml
     openstack-ansible setup-logging.yml
     openstack-ansible maas-get.yml
     openstack-ansible setup-maas.yml


### PR DESCRIPTION
After leapfrog, the neutron agent container that was destroyed
during the leap will still be in the hosts' appropriate maas
agent config folder.

We have to clean this up for the verify maas to not fail.

Issue: [LA-369](https://rpc-openstack.atlassian.net/browse/LA-369)