### PR TITLE
LA-370 Use proper default influx port

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -18,7 +18,7 @@
 # Gating
 export BUILD_TAG=${BUILD_TAG:-}
 export INFLUX_IP=${INFLUX_IP:-}
-export INFLUX_PORT=${INFLUX_IP:-"8086"}
+export INFLUX_PORT=${INFLUX_PORT:-"8086"}
 
 # Other
 export ADMIN_PASSWORD=${ADMIN_PASSWORD:-"secrete"}


### PR DESCRIPTION
Typo made influx port the same as the IP. This should fix it.

Issue: [LA-370](https://rpc-openstack.atlassian.net/browse/LA-370)