### PR TITLE
LA-368 Remove lxc_container_cache_files from vars

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -105,12 +105,6 @@ repo_pkg_cache_enabled: no
 # all packages must come from our apt artifacts.
 lxc_package_repo_add: no
 
-# We need to ensure that the RPC-O repo containing apt
-# artifacts is included in the LXC container prep.
-lxc_container_cache_files:
-  - src: "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"
-    dest: "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"
-
 # For convenience
 rpco_apt_repo:
   repo: "{{ rpco_mirror_apt_deb_line }}"


### PR DESCRIPTION
`lxc_container_cache_files` is a list of files to copy from the
deployment host. The file, `"/etc/apt/sources.list.d/rcpo.list"`, is
created by the role `pip_install` on the required hosts and so there
should not be anything to copy. In general, having this variable set
does not cause an issue because the first infra node is used as the
deployment node. Where the deployment node is not itself part of the
deployment, e.g. on a multi-node AIO, the file is missing and causes a
failure in the `lxc_hosts` role when performing a leapfrog upgrade.