### PR TITLE
Add overides for ironic endpoints

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_overrides.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_overrides.yml
@@ -20,3 +20,7 @@
 
 # this variable is here because vars files need to have at least ONE variable defined.
 this_file_is_reserved_for_support: True
+extra_lb_vip_addresses:
+  - 172.18.40.227
+ironic_openstack_api_url: "http://172.18.40.227:{{ ironic_service_port }}"
+ironic_swift_endpoint: "http://172.18.40.227:8080"


### PR DESCRIPTION
This change adds overrides to setup the ironic endpoints to enable the
swift/ironic health checks.

Connects RI-34