### PR TITLE
LA-356 Do not take the BUILD_TAG literally

### DIFF
--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -67,7 +67,7 @@ if [[ "${DEPLOY_TELEGRAF}" == "yes" ]]; then
     if [[ -n "${BUILD_TAG}" ]]; then
         # user_rpco_variables_overrides are generated at every build, so
         # we are fine to just echo it.
-        echo 'maas_job_reference: "${BUILD_TAG}"' >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
+        echo "maas_job_reference: '${BUILD_TAG}'" >> /etc/openstack_deploy/user_rpco_variables_overrides.yml
         # Telegraph shipping is done to influx nodes belonging to
         # influx_telegraf_targets | union(influx_all)
         cat >> /etc/openstack_deploy/user_rpco_variables_overrides.yml << EOF


### PR DESCRIPTION
We should interpret BUILD_TAG and set that as a var, instead of
setting ${BUILD_TAG} as a var. Else we won't have he proper info.

Issue: [LA-356](https://rpc-openstack.atlassian.net/browse/LA-356)