### PR TITLE
RI-38 - Create ansible role to configure and deploy ironic

### DIFF
--- a/rpcd/playbooks/roles/configure_ironic/CONTRIBUTING.md
+++ b/rpcd/playbooks/roles/configure_ironic/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../../../CONTRIBUTING.md

--- a/rpcd/playbooks/roles/configure_ironic/README.rst
+++ b/rpcd/playbooks/roles/configure_ironic/README.rst
@@ -1,0 +1,20 @@
+Configure Ironic
+========
+
+Configure deployment specific Ironic settings.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+.. code-block:: yaml
+
+    - hosts: servers
+      roles:
+         - { role: "filebeat" }
+
+License
+-------
+
+Apache 2.0

--- a/rpcd/playbooks/roles/configure_ironic/meta/main.yml
+++ b/rpcd/playbooks/roles/configure_ironic/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: rcbops
+  description: Role to configure Ironic
+  company: Rackspace
+  license: Apache 2
+
+  min_ansible_version: 1.9
+  platforms:
+  - name: Ubuntu
+    versions:
+    - trusty
+    - xenial
+
+  galaxy_tags: []
+
+dependencies: []

--- a/rpcd/playbooks/roles/configure_ironic/tasks/cleaning_network.yml
+++ b/rpcd/playbooks/roles/configure_ironic/tasks/cleaning_network.yml
@@ -13,8 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Configure and finish deploying Ironic
-  hosts: localhost
-  max_fail_percentage: 20
-  roles:
-    - "configure_ironic"
+
+- name: Get cleaning_network_uuid
+  pause:
+    prompt: "What is the ironic cleaning network uuid from neutron?"
+  register: cleaning_network_uuid
+
+- name: Register cleaning_network_uuid
+  config_template:
+    src: /etc/openstack_deploy/user_osa_variables_overrides.yml
+    dest: /etc/openstack_deploy/user_osa_variables_overrides.yml
+    config_type: yaml
+    config_overrides:
+      ironic_ironic_conf_overrides:
+        neutron:
+          cleaning_network_uuid: "{{ cleaning_network_uuid.user_input }}"

--- a/rpcd/playbooks/roles/configure_ironic/tasks/main.yml
+++ b/rpcd/playbooks/roles/configure_ironic/tasks/main.yml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Configure and finish deploying Ironic
-  hosts: localhost
-  max_fail_percentage: 20
-  roles:
-    - "configure_ironic"
+
+- include: cleaning_network.yml
+  when: ironic_ironic_conf_overrides.neutron.cleaning_network_uuid is not defined


### PR DESCRIPTION
Ironic requires some user action and values before it can finish
being deployed.  This new role will ask for these values then write
them to the correct overrides file.