### PR TITLE
RI-33 Make neutron DHCP non-authoritative - doc

### DIFF
--- a/IRONIC.md
+++ b/IRONIC.md
@@ -11,7 +11,7 @@ The ironic agent needs to be on the ironic-tftp network in order to access
 ironic-api and Swift.
 
 The following variables need to be inserted and upated with the correct values
-inside of `` user_osa_variables_overrides ``.
+inside of `` user_osa_variables_overrides.yml ``.
 
 	extra_lb_vip_addresses: 
 	  - <IP address>
@@ -20,3 +20,16 @@ inside of `` user_osa_variables_overrides ``.
 
 The IP addresses referenced should be the same one referenced in
 `` extra_lb_vip_addresses `` that have been setup during installation.
+
+### Configure neutron DHCP to be non-authoritative
+
+To prevent us from having conflicts with an existing authoritative DHCP server,
+neutron needs to be set to non-authoritative.
+
+In order to do this, a few variables need to be set, so we need to include the
+following variables in `` user_osa_variables_overrides.yml ``:
+
+        neutron_dhcp_config:
+          dhcp-option-force: "26,1500"
+          dhcp-ignore: "tag:!known"
+          log-facility: "/var/log/neutron/dnsmasq.log"


### PR DESCRIPTION
This commit describes the steps needed to make neutron DHCP
non-authoritative to work with Ironic.

Issue: [RI-33](https://rpc-openstack.atlassian.net/browse/RI-33)