### PR TITLE
RE-97 Add support to configure multi-node AIO

### DIFF
--- a/gating/capabilities/mnaio_config
+++ b/gating/capabilities/mnaio_config
@@ -1,0 +1,6 @@
+This file exists as a marker to let Jenkins/rpc-gating know that adding config overrides for gating and
+scenarios will be handled in repo and doesn't need to be touched by gating scripts.
+
+
+Once this has been backported to all branches, the functionality will be removed from rpc-gating, then these
+files won't be needed.

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -151,12 +151,15 @@
     rpco_deploy_hardening: "{{ lookup('env', 'DEPLOY_HARDENING') }}"
     TRIGGER: "{{ lookup('env', 'TRIGGER')}}"
     SCENARIO: "{{ lookup('env', 'SCENARIO')}}"
-    TARGET: "{{ lookup('env', 'TARGET')}}"
+    TARGET: "{{ lookup('env', 'TARGET') | default('aio', true) }}"
 
 
 - name: Execute the OSA AIO bootstrap
   include: "{{ lookup('env', 'OA_DIR') }}/tests/bootstrap-aio.yml"
+  when:
+    - TARGET == "aio"
   vars:
+    TARGET: "{{ lookup('env', 'TARGET') | default('aio', true) }}"
     bootstrap_host_apt_distribution_suffix_list: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary([], ['updates', 'backports']) }}"
     bootstrap_host_scenario: "{{ (lookup('env', 'DEPLOY_CEPH') | bool) | ternary('ceph','swift') }}"
     bootstrap_user_variables_template: "user_variables.aio.yml.j2"

--- a/scripts/configure-multi-node-aio.sh
+++ b/scripts/configure-multi-node-aio.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -e -u -x
+
+## Functions -----------------------------------------------------------------
+
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
+## Main ----------------------------------------------------------------------
+
+# Check the openstack-ansible submodule status
+check_submodule_status
+
+# Run multi-node AIO config setup playbook
+export TARGET=${TARGET:-"mnaio"}
+openstack-ansible -vvv ${BASE_DIR}/scripts/configure-multi-node-aio.yml \
+                  -i "localhost," -c local
+
+if ! apt_artifacts_available; then
+  # Remove the AIO configuration relating to the use
+  # of apt artifacts. This needs to be done because
+  # the apt artifacts do not exist yet.
+  sed -i '/^rpco_mirror_base_url/,$d' /etc/openstack_deploy/user_osa_variables_defaults.yml
+fi
+
+# If there are no container artifacts for this release, then remove the container artifact configuration
+if ! container_artifacts_available; then
+  # Remove the AIO configuration relating to the use
+  # of container artifacts. This needs to be done
+  # because the container artifacts do not exist yet.
+  ./scripts/artifacts-building/remove-container-aio-config.sh
+fi

--- a/scripts/configure-multi-node-aio.yml
+++ b/scripts/configure-multi-node-aio.yml
@@ -1,0 +1,34 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Execute the OSA AIO bootstrap to set user_variables_overrides
+  include: "{{ rpco_base_dir }}/scripts/bootstrap-aio.yml"
+  vars:
+    rpco_base_dir: "{{ lookup('env', 'BASE_DIR') }}"
+
+- name: Create file for user variables
+  hosts: localhost
+  user: root
+  tasks:
+    # The overrides file for AIO is created in the bootstrap-host role
+    # that is not run for multi-node AIO, so the file is created here.
+    - name: Create user variables override file
+      file:
+        path: "/etc/openstack_deploy/user_osa_variables_overrides.yml"
+        state: touch
+    - name: Write to user variables overrides file
+      lineinfile:
+        dest: "/etc/openstack_deploy/user_osa_variables_overrides.yml"
+        line:  "{{ user_variables_overrides|to_nice_yaml }}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -60,6 +60,11 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
 
 fi
 
+# Configure for multi-node AIO
+if [[ "${CONFIGURE_MNAIO}" == "yes" ]]; then
+  source "$(dirname "${0}")/configure-multi-node-aio.sh"
+fi
+
 # move OSA secrets to correct locations
 if [[ ! -f /etc/openstack_deploy/user_osa_secrets.yml ]] && [[ -f /etc/openstack_deploy/user_secrets.yml ]]; then
   mv /etc/openstack_deploy/user_secrets.yml /etc/openstack_deploy/user_osa_secrets.yml

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -38,6 +38,7 @@ export DEPLOY_ARA=${DEPLOY_ARA:-"no"}
 export DEPLOY_SUPPORT_ROLE=${DEPLOY_SUPPORT_ROLE:-"no"}
 export BOOTSTRAP_OPTS=${BOOTSTRAP_OPTS:-""}
 export UNAUTHENTICATED_APT=${UNAUTHENTICATED_APT:-no}
+export CONFIGURE_MNAIO=${CONFIGURE_MNAIO:-"no"}
 
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export OA_DIR="${BASE_DIR}/openstack-ansible"


### PR DESCRIPTION
Adds a configure_multi_node_aio script and playbook
that runs if CONFIGURE_MNAIO is set to "yes". This
prepares the configuration that was previously done in
rpc-gating by reusing bootstrap-aio.

Issue: [RE-97](https://rpc-openstack.atlassian.net/browse/RE-97)