### PR TITLE
Adding config.yaml to 14.0 branch

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,3 @@
+---
+release_tag_re: '^r\d+\.\d+\.\d+(rc\d+)?'
+pre_release_tag_re: '(?P<pre_release>rc\d+$)'


### PR DESCRIPTION
The 14.0 branch did not include a config.yaml file for the reno release notes build. This issue was solved in the 14.1 branch, but still requires one to build the release notes documentation for Newton.