### PR TITLE
RI-44: Add post deployment Ironic instructions

### DIFF
--- a/IRONIC.md
+++ b/IRONIC.md
@@ -3,7 +3,7 @@
 This document will guide you through the necessary steps to properly configure
 and setup Ironic in RPC-O.
 
-## openstack_user_config
+## openstack\_user\_config
 
 ### New networks
 
@@ -89,10 +89,10 @@ ironic-api and Swift.
 The following variables need to be inserted and upated with the correct values
 inside of `` user_osa_variables_overrides.yml ``.
 
-	extra_lb_vip_addresses: 
+	extra_lb_vip_addresses:
 	  - <IP address>
 	ironic_openstack_api_url: "<IP address>:{{ ironic_service_port }}"
-	ironic_swift_endpoint: "<IP address>:8080" 
+	ironic_swift_endpoint: "<IP address>:8080"
 
 The IP addresses referenced should be the same one referenced in
 `` extra_lb_vip_addresses `` that have been setup during installation.
@@ -122,7 +122,7 @@ of Ironic.  Once the initial deployment is done, you can proceed.
 	  --allocation-pool start=<NON_ALLOCATED_TFTP_RANGE_START>,end=<NON_ALLOCATED_TFTP_RANGE_END> \
 	  --dns-nameserver=4.4.4.4 tftp <TFTP_NETWORK>/<TFTP_NETMASK>
 
-Once the network is created, take the output of 
+Once the network is created, take the output of
 `` neutron net-list | grep tftp | awk '{print $2}' `` and add the following
 section to your `` user_osa_variables_overrides.yml ``.
 
@@ -139,4 +139,176 @@ to Ironic.
 
 Rerun the `` os-ironic-install.yml `` play to get the new settings in place.
 
-## todo: Post deployment image registration and node enrollment
+# Post deployment image registration and node enrollment
+
+## Creating and registering images
+
+The standard way of creating images for Ironic is to use diskimage-builder.
+Follow the documentation to install diskimage-builder located:
+https://docs.openstack.org/diskimage-builder/latest/ .  After that is done,
+clone https://github.com/osic/osic-elements to `` /opt/osic-elements ``.
+
+Next we will create and upload the deploy image, this is the initial image used
+to lay down he final image.  It needs raid tools, in this case for HP gear.
+
+	export DIB_HPSSACLI_URL="http://downloads.hpe.com/pub/softlib2/software1/pubsw-linux/p1857046646/v109216/hpssacli-2.30-6.0.x86_64.rpm"
+	export IRONIC_AGENT_VERSION="stable/ocata"
+	disk-image-create --install-type source -o ironic-deploy ironic-agent fedora devuser proliant-tools
+
+	glance image-create --name ironic-deploy.kernel \
+	                    --visibility public \
+	                    --disk-format aki \
+	                    --property hypervisor_type=baremetal \
+	                    --protected=True \
+	                    --container-format aki < ironic-deploy.kernel
+	glance image-create --name ironic-deploy.initramfs \
+	                    --visibility public \
+	                    --disk-format ari \
+	                    --property hypervisor_type=baremetal \
+	                    --protected=True \
+	                    --container-format ari < ironic-deploy.initramfs
+
+Now we create the final deploy images, these images are what are delivered to
+the end user.  The steps below create images for Ubuntu Xenial, Trusty and
+CentOS 7.
+
+	export ELEMENTS_PATH="/opt/osic-elements"
+	export DIB_CLOUD_INIT_DATASOURCES="Ec2, ConfigDrive, OpenStack"
+	export DIB_RELEASE=xenial
+	export DISTRO_NAME=ubuntu
+
+	disk-image-create -o baremetal-$DISTRO_NAME-$DIB_RELEASE $DISTRO_NAME baremetal bootloader osic-dfw
+
+	VMLINUZ_UUID="$(glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE.vmlinuz \
+	                                    --visibility public \
+	                                    --disk-format aki \
+	                                    --property hypervisor_type=baremetal \
+	                                    --protected=True \
+	                                    --container-format aki < baremetal-$DISTRO_NAME-$DIB_RELEASE.vmlinuz | awk '/\| id/ {print $4}')"
+	INITRD_UUID="$(glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE.initrd \
+	                                   --visibility public \
+	                                   --disk-format ari \
+	                                   --property hypervisor_type=baremetal \
+	                                   --protected=True \
+	                                   --container-format ari < baremetal-$DISTRO_NAME-$DIB_RELEASE.initrd | awk '/\| id/ {print $4}')"
+	glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE \
+	                    --visibility public \
+	                    --disk-format qcow2 \
+	                    --container-format bare \
+	                    --property hypervisor_type=baremetal \
+	                    --property kernel_id=${VMLINUZ_UUID} \
+	                    --protected=True \
+	                    --property ramdisk_id=${INITRD_UUID} < baremetal-$DISTRO_NAME-$DIB_RELEASE.qcow2
+
+	export DIB_RELEASE=trusty
+	export DISTRO_NAME=ubuntu
+
+	disk-image-create -o baremetal-$DISTRO_NAME-$DIB_RELEASE $DISTRO_NAME baremetal bootloader osic-dfw
+
+	VMLINUZ_UUID="$(glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE.vmlinuz \
+	                                    --visibility public \
+	                                    --disk-format aki \
+	                                    --property hypervisor_type=baremetal \
+	                                    --protected=True \
+	                                    --container-format aki < baremetal-$DISTRO_NAME-$DIB_RELEASE.vmlinuz | awk '/\| id/ {print $4}')"
+	INITRD_UUID="$(glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE.initrd \
+	                                   --visibility public \
+	                                   --disk-format ari \
+	                                   --property hypervisor_type=baremetal \
+	                                   --protected=True \
+	                                   --container-format ari < baremetal-$DISTRO_NAME-$DIB_RELEASE.initrd | awk '/\| id/ {print $4}')"
+	glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE \
+	                    --visibility public \
+	                    --disk-format qcow2 \
+	                    --container-format bare \
+	                    --property hypervisor_type=baremetal \
+	                    --property kernel_id=${VMLINUZ_UUID} \
+	                    --protected=True \
+	                    --property ramdisk_id=${INITRD_UUID} < baremetal-$DISTRO_NAME-$DIB_RELEASE.qcow2
+
+	export DIB_RELEASE=7
+	export DISTRO_NAME=centos
+
+	disk-image-create -o baremetal-$DISTRO_NAME-$DIB_RELEASE $DISTRO_NAME baremetal bootloader osic-dfw
+
+	VMLINUZ_UUID="$(glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE.vmlinuz \
+	                                    --visibility public \
+	                                    --disk-format aki \
+	                                    --property hypervisor_type=baremetal \
+	                                    --protected=True \
+	                                    --container-format aki < baremetal-$DISTRO_NAME-$DIB_RELEASE.vmlinuz | awk '/\| id/ {print $4}')"
+	INITRD_UUID="$(glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE.initrd \
+	                                   --visibility public \
+	                                   --disk-format ari \
+	                                   --property hypervisor_type=baremetal \
+	                                   --protected=True \
+	                                   --container-format ari < baremetal-$DISTRO_NAME-$DIB_RELEASE.initrd | awk '/\| id/ {print $4}')"
+	glance image-create --name baremetal-$DISTRO_NAME-$DIB_RELEASE \
+	                    --visibility public \
+	                    --disk-format qcow2 \
+	                    --container-format bare \
+	                    --property hypervisor_type=baremetal \
+	                    --property kernel_id=${VMLINUZ_UUID} \
+	                    --protected=True \
+	                    --property ramdisk_id=${INITRD_UUID} < baremetal-$DISTRO_NAME-$DIB_RELEASE.qcow2
+
+## Registering the nodes
+
+This section relies on information that makes it highly dependant on the
+specific hardware you deploy, the code examples below may not work for you.
+
+	# Node details
+	inventory_hostname=node-hostname
+	Port1NIC_MACAddress="aa:bb:cc:dd:ee:ff"
+
+	# IPMI details
+	ipmi_address="127.1.1.1"
+	ipmi_password="secrete"
+	ipmi_user="root"
+
+	# Image details belonging to a particular node
+	image_vcpu=48
+	image_ram=254802
+	image_disk=80
+	image_total_disk_size=3600
+	image_cpu_arch="x86_64"
+
+	KERNEL_IMAGE=$(glance image-list | awk '/ubuntu-user-image.vmlinuz/ {print $2}')
+	INITRAMFS_IMAGE=$(glance image-list | awk '/ubuntu-user-image.initrd/ {print $2}')
+	DEPLOY_RAMDISK=$(glance image-list | awk '/ironic-deploy.initramfs/ {print $2}')
+	DEPLOY_KERNEL=$(glance image-list | awk '/ironic-deploy.kernel/ {print $2}')
+
+	if ironic node-list | grep "$inventory_hostname"; then
+	    NODE_UUID=$(ironic node-list | awk "/$inventory_hostname/ {print \$2}")
+	else
+	    NODE_UUID=$(ironic node-create \
+	      -d agent_ipmitool \
+	      -i ipmi_address="$ipmi_address" \
+	      -i ipmi_password="$ipmi_password" \
+	      -i ipmi_username="$ipmi_user" \
+	      -i deploy_ramdisk="${DEPLOY_RAMDISK}" \
+	      -i deploy_kernel="${DEPLOY_KERNEL}" \
+	      -n $inventory_hostname | awk '/ uuid / {print $4}')
+	    ironic port-create -n "$NODE_UUID" \
+	                       -a $Port1NIC_MACAddress
+	fi
+	ironic node-update "$NODE_UUID" add \
+	          driver_info/deploy_kernel=$DEPLOY_KERNEL \
+	          driver_info/deploy_ramdisk=$DEPLOY_RAMDISK \
+	          instance_info/deploy_kernel=$KERNEL_IMAGE \
+	          instance_info/deploy_ramdisk=$INITRAMFS_IMAGE \
+	          instance_info/root_gb=40 \
+	          properties/cpus=$image_vcpu \
+	          properties/memory_mb=$image_ram \
+	          properties/local_gb=$image_disk \
+	          properties/size=$image_total_disk_size \
+	          properties/cpu_arch=$image_cpu_arch
+	          properties/capabilities=memory_mb:$image_ram,local_gb:$image_disk,cpu_arch:$image_cpu_arch,cpus:$image_vcpu,boot_option:local,disk_label:gpt
+
+	ironic --ironic-api-version 1.15 node-set-provision-state $NODE_UUID provide
+
+The above needs to be done for every Ironic node, there exists an ansible docs
+to do this on a large amount of nodes at a time from osic.  For refrence they
+are located https://github.com/osic/osic-clouds/blob/master/nextgen/admin-node-enrollment.md
+It uses Ironic's ability to alter the raid configuration, the docs are located
+https://docs.openstack.org/ironic/latest/admin/raid.html

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ and ignore remote API checks by specifing ``maas_use_api: False`` in the
 * `ceph-osd.yml` - Runs the `ceph.ceph-osd` Ansible role, which is an external role
   located at https://github.com/ceph/ansible-ceph-osd to deploy the ceph OSD bits
 
+# Ironic suplimental guide
+
+Ironic has it's own set of configuration and post-deployment instructions.  If
+you wish to deploy Ironic please view [IRONIC.md](https://github.com/rcbops/rpc-openstack/blob/master/IRONIC.md).
 
 # Quick Start with an RPCO All-In-One(AIO)
 


### PR DESCRIPTION
This documentation goes over how to create images for the deployed ironic
environment along with registering those images for CentOS 7, Ubuntu Xenial and
Ubuntu Trusty.  It also goes over how to register nodes to Ironic.

Signed-off-by: Matthew Thode <mthode@mthode.org>