### PR TITLE
LA-381 Fix removal of old MaaS config files

### DIFF
--- a/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml
+++ b/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml
@@ -2,8 +2,13 @@
 - hosts: hosts
   gather_facts: no
   tasks:
-    - shell: "rm -f {% raw %}/etc/rackspace-monitoring-agent.conf.d/*${{% endraw %}{{ item }}{% raw %}}*{% endraw %}"
-      args:
-        executable: /bin/bash
-      with_file:
-        - "/etc/openstack_deploy/leapfrog_remove_remaining_old_containers"
+    - name: Get list of old containers
+      command: "cat /etc/openstack_deploy/leapfrog_remove_remaining_old_containers"
+      run_once: true
+      delegate_to: localhost
+      register: old_containers
+
+    - name: Remove old MaaS neutron container config files
+      shell: "rm /etc/rackspace-monitoring-agent.conf.d/*{{ item }}*"
+      with_items: old_containers.stdout_lines
+      ignore_errors: true


### PR DESCRIPTION
Leapfrog upgrades requires the removal of MaaS configuration files for
neutron containers that are destroyed. This changes updates the playbook
to ensure that the removal works on a multi-node build.