### PR TITLE
[backport] RE-133 Remove previously configured ansible

### DIFF
--- a/scripts/artifacts-building/apt/build-apt-artifacts.sh
+++ b/scripts/artifacts-building/apt/build-apt-artifacts.sh
@@ -63,7 +63,16 @@ fi
 
 # The derive-artifact-version.sh script expects the git clone to
 # be at /opt/rpc-openstack, so we link the current folder there.
-ln -sfn ${PWD} /opt/rpc-openstack
+if [[ "${PWD}" != "/opt/rpc-openstack" ]]; then
+  ln -sfn ${PWD} /opt/rpc-openstack
+fi
+
+# Remove any previous installed plugins, libraries,
+# facts and ansible/openstack-ansible refs. This
+# ensures that as we upgrade/downgrade on the long
+# running jenkins slave we do not get interference
+# from previously installed/configured items.
+rm -rf /etc/ansible /etc/openstack_deploy /usr/local/bin/ansible* /usr/local/bin/openstack-ansible*
 
 # Install Ansible
 ./scripts/bootstrap-ansible.sh


### PR DESCRIPTION
On the long running apt artifact builder we are
switching Ansible versions for each series, but
leaving behind parts of the installation which
cause the bootstrap to fail.
This is easily seen when doing the ansible
bootstrap using ocata, then trying to bootstrap
using newton. It fails if the role fetch method
is set to use git-clone.

This patch just ensures that we remove
everything related to the ansible execution so
that the new boostrap can do its thing without
worrying about previous installs.

(cherry picked from commit 71ff2d6dd90d890b1d452dd03635ad9e0456057b)