### PR TITLE
RE-171 Update newton-14.1 refs to newton/tags

### DIFF
--- a/releasenotes/notes/releasenotes-a800a042ad4e67cf.yaml
+++ b/releasenotes/notes/releasenotes-a800a042ad4e67cf.yaml
@@ -1,6 +1,6 @@
 ---
 prelude: >
-    Reno release notes will now be provided as of newton-14.1!
+    Reno release notes will now be provided as of r14.1.0!
 features:
   - |
-    Reno release notes will now be provided as of newton-14.1!
+    Reno release notes will now be provided as of r14.1.0!

--- a/releasenotes/source/index.rst
+++ b/releasenotes/source/index.rst
@@ -10,5 +10,5 @@ Series Release Notes
 
 .. toctree::
    :maxdepth: 1
-   
-   newton-14.0
+
+   newton

--- a/releasenotes/source/newton.rst
+++ b/releasenotes/source/newton.rst
@@ -3,4 +3,4 @@
 ==============================
 
 .. release-notes:: Release Notes
-    :branch: origin/newton-14.0
+    :branch: origin/newton

--- a/scripts/leapfrog/README.md
+++ b/scripts/leapfrog/README.md
@@ -2,14 +2,14 @@
 
 #### Overview
 A Leapfrog upgrade is a major upgrade that skips at least one release. Currently
-RPCO supports leapfrog upgrades from kilo to newton-14.1.
+RPCO supports leapfrog upgrades from kilo to r14.1.0 (newton).
 
 #### Terms
 * [RPCO](https://github.com/rcbops/rpc-openstack): Rackspace Private Cloud powered by OpenStack
 * [OSA](https://github.com/openstack/openstack-ansible):  OpenStack Ansible
 * [OSA-OPS](https://github.com/openstack/openstack-ansible-ops):  OpenStack Operations
 * [Kilo](https://github.com/rcbops/rpc-openstack/tree/kilo): The RPCO release of OpenStack Kilo
-* [Newton-14.1](https://github.com/rcbops/rpc-openstack/tree/newton-14.1): The second RPCO release of OpenStack Newton. This version includes Leapfrog upgrade tools.
+* [r14.1.0](https://github.com/rcbops/rpc-openstack/tree/r14.1.0): The second RPCO release of OpenStack Newton. This version includes Leapfrog upgrade tools.
 
 ## Pre Leapfrog Tasks
 * Verify that the kilo deployment is healthy.
@@ -17,7 +17,7 @@ RPCO supports leapfrog upgrades from kilo to newton-14.1.
 
 ## Executing a leapfrog upgrade
 
-The first step is to checkout the newton-14.1 branch of rpco. This will remove
+The first step is to checkout the RPC-O r14.1.0 tag. This will remove
 any uncommitted information from the rpco repo, so back that up if it is
 required.
 
@@ -29,15 +29,15 @@ git reset --hard
 git clean -df
 popd
 git fetch origin
-git checkout newton-14.1
+git checkout r14.1.0
 git submodule update
 git status
 ```
 
 It is crucial that the rpco repo and openstack-ansible submodule are both clean
-and at the appropriate SHAs for newton-14.1 at this stage. The [github
-newton-14.1 branch
-page](https://github.com/rcbops/rpc-openstack/tree/newton-14.1) shows both SHAs,
+and at the appropriate SHAs for r14.1.0 at this stage. The [github
+r14.1.0 tag
+page](https://github.com/rcbops/rpc-openstack/tree/r14.1.0) shows both SHAs,
 the RPCO SHA is the latest commit, and the OSA SHA is shown as an annotation
 after @ on the openstack-ansible submodule.
 


### PR DESCRIPTION
The release notes are now configured to use the branch
name and the documentation now refers to release tags
instead of the branch name.

Issue: [RE-171](https://rpc-openstack.atlassian.net/browse/RE-171)