### PR TITLE
RE-171 Update newton-14.1 refs to newton/tags

### DIFF
--- a/releasenotes/notes/releasenotes-a800a042ad4e67cf.yaml
+++ b/releasenotes/notes/releasenotes-a800a042ad4e67cf.yaml
@@ -1,6 +1,6 @@
 ---
 prelude: >
-    Reno release notes will now be provided as of newton-14.1!
+    Reno release notes will now be provided as of r14.1.0!
 features:
   - |
-    Reno release notes will now be provided as of newton-14.1!
+    Reno release notes will now be provided as of r14.1.0!

--- a/releasenotes/source/index.rst
+++ b/releasenotes/source/index.rst
@@ -10,5 +10,5 @@ Series Release Notes
 
 .. toctree::
    :maxdepth: 1
-   
-   newton-14.0
+
+   newton

--- a/releasenotes/source/newton.rst
+++ b/releasenotes/source/newton.rst
@@ -3,4 +3,4 @@
 ==============================
 
 .. release-notes:: Release Notes
-    :branch: origin/newton-14.0
+    :branch: origin/newton


### PR DESCRIPTION
The release notes are now configured to use the branch
name and the documentation now refers to release tags
instead of the branch name.

Conflicts:
scripts/leapfrog/README.md

(cherry picked from commit fcf7ff69a817d2fb7bba1b6d82e46852e0adc713)

Issue: [RE-171](https://rpc-openstack.atlassian.net/browse/RE-171)