### PR TITLE
RE-155 Add rpco apt source to lxc base cache

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -30,3 +30,9 @@
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
   version: fdd159a0238cede501e91a9850c47b4692d334c9
+# TODO(odyssey4me)
+# Remove this once this SHA is included in our OSA SHA
+- name: rabbitmq_server
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-rabbitmq_server
+  version: e944366f98f358d600f79062465a31ee11cecf4b

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -24,3 +24,9 @@
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
   version: 3f5e7a6044629e76acb1933af19f09a89e55917b
+# TODO(odyssey4me)
+# Remove this once this SHA is included in our OSA SHA
+- name: lxc_hosts
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
+  version: fdd159a0238cede501e91a9850c47b4692d334c9

--- a/group_vars/lxc_hosts.yml
+++ b/group_vars/lxc_hosts.yml
@@ -1,0 +1,17 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+lxc_container_cache_files_from_host:
+  - "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -121,6 +121,7 @@ haproxy_gpg_keys: "{{ rpco_apt_gpg_keys }}"
 # RabbitMQ
 rabbitmq_install_method: "external_repo"
 rabbitmq_repo: "{{ rpco_apt_repo }}"
+rabbitmq_erlang_repo: "{{ rpco_apt_repo }}"
 rabbitmq_gpg_keys: "{{ rpco_apt_gpg_keys }}"
 
 # ceph_client wiring

--- a/rpcd/playbooks/roles/kibana/defaults/main.yml
+++ b/rpcd/playbooks/roles/kibana/defaults/main.yml
@@ -25,7 +25,7 @@ kibana_pip_packages:
   - httplib2  # NOTE(sigmavirus24): Need this for the uri module
 
 kibana_apt_packages:
-  - kibana
+  - kibana=4.5.4
   - apache2
   - python-passlib
 

--- a/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
+++ b/rpcd/playbooks/roles/kibana/tasks/kibana_install.yml
@@ -16,7 +16,7 @@
 - name: Install apt packages
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: present
     update_cache: yes
     cache_valid_time: 600
   register: install_apt_packages

--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -84,6 +84,7 @@ aptly_miko_mapping:
       - "slushie-{{ rpc_release }}-uca-ocata-updates-xenial"
       - "slushie-{{ rpc_release }}-mariadb-10.1-xenial"
       - "slushie-{{ rpc_release }}-percona-xenial"
+      - "slushie-{{ rpc_release }}-erlang-xenial"
       - "slushie-{{ rpc_release }}-rabbitmq-downloaded-packages-{{ rpc_release }}-ALL"
       - "slushie-{{ rpc_release }}-elastic-logstash-5.5-ALL"
       - "slushie-{{ rpc_release }}-elastic-kibana-5.5-ALL"
@@ -317,6 +318,25 @@ aptly_mirrors:
     state: "present"
     gpg:
       key: "6B73A36E6026DFCA"
+      server: "hkp://keyserver.ubuntu.com:80"
+      keyring: "trustedkeys.gpg"
+    create_flags:
+      - "-keyring='trustedkeys.gpg'"
+    update_flags:
+      - "-keyring='trustedkeys.gpg'"
+    do_update: "{{ aptly_mirror_do_updates }}"
+  # Erlang (used by RabbitMQ):
+  # Got the key from:
+  # wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+  # gpg --list-packets erlang_solutions.asc
+  - name: erlang-xenial
+    archive_url: https://packages.erlang-solutions.com/ubuntu
+    distribution: xenial
+    component1:
+      - contrib
+    state: "present"
+    gpg:
+      key: "D208507CA14F4FCA"
       server: "hkp://keyserver.ubuntu.com:80"
       keyring: "trustedkeys.gpg"
     create_flags:

--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -90,6 +90,16 @@ aptly_miko_mapping:
       - "slushie-{{ rpc_release }}-elastic-kibana-5.5-ALL"
       - "slushie-{{ rpc_release }}-elastic-beats-5.5-ALL"
       - "slushie-{{ rpc_release }}-elastic-es-5.5-ALL"
+      # TODO(odyssey4me):
+      # Remove these once the patch merges which switches the version
+      # used to the more recent ones.
+      # https://github.com/rcbops/rpc-openstack/pull/2332
+      # ref: https://rpc-openstack.atlassian.net/browse/RE-173
+      - "slushie-{{ rpc_release }}-elastic-logstash-2.3-ALL"
+      - "slushie-{{ rpc_release }}-elastic-kibana-4.5-ALL"
+      - "slushie-{{ rpc_release }}-elastic-beats-ALL"
+      - "slushie-{{ rpc_release }}-elastic-es-1.7-ALL"
+      - "slushie-{{ rpc_release }}-elastic-es-2.x-ALL"
 
 # mapping for N (NOT MERGE) snapshots
 # This is a list of the repo/mirror snapshots (slushies) that will be published separately.


### PR DESCRIPTION
Prior to https://github.com/rcbops/rpc-openstack/commit/70b86f6a1759f92ef789e3d7028bb3e75ad6e722 the rpco.list file was copied into the container cache
and worked fine because the deploy node and lxc host were the same.
With that patch, this no longer happens and the cache prep dies.

In order for the lxc cache prep process to make use
of the extra rpco apt source we need to ensure that
the repo source file is copied into the cache prior
to doing any package actions. This patch ensures
that the repo config is there.

The OSA SHA is also updated to ensure that the
unbound variable bug is fixed when installing pip.
ref: https://review.openstack.org/489191

Issue: [RE-155](https://rpc-openstack.atlassian.net/browse/RE-155)

Issue: [RE-174](https://rpc-openstack.atlassian.net/browse/RE-174)

Issue: [RE-173](https://rpc-openstack.atlassian.net/browse/RE-173)