### PR TITLE
[newton] RE-155 Add rpco apt source to lxc base cache

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -25,3 +25,9 @@
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
   version: f49519df7f07a4b0ab487479598fa150d7ed7e1a
+# TODO(odyssey4me)
+# Remove this once this SHA is included in our OSA SHA
+- name: lxc_hosts
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
+  version: 676a0b586565976715093f4360b712f83b1ba4a7

--- a/group_vars/lxc_hosts.yml
+++ b/group_vars/lxc_hosts.yml
@@ -1,0 +1,17 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+lxc_container_cache_files_from_host:
+  - "/etc/apt/sources.list.d/{{ rpco_mirror_apt_filename }}.list"


### PR DESCRIPTION
Prior to https://github.com/rcbops/rpc-openstack/commit/42023951029ec2c6112dbe304001c6c64eadbaae the rpco.list file was copied into the container cache
and worked fine because the deploy node and lxc host were the same.
With that patch, this no longer happens and the cache prep dies.
This issue is not being seen on the newton branch at the moment
as the containers artifacts were built prior to that patch merging.

In order for the lxc cache prep process to make use
of the extra rpco apt source we need to ensure that
the repo source file is copied into the cache prior
to doing any package actions. This patch ensures
that the repo config is there.

The OSA SHA is also updated to ensure that the
unbound variable bug is fixed when installing pip.
ref: https://review.openstack.org/489260

Issue: [RE-155](https://rpc-openstack.atlassian.net/browse/RE-155)