### PR TITLE
LA-391 Patch os_cinder to ensure API available

### DIFF
--- a/rpcd/patches/os_cinder_add_backend_api_check.patch
+++ b/rpcd/patches/os_cinder_add_backend_api_check.patch
@@ -1,0 +1,26 @@
+diff --git a/playbooks/roles/os_cinder/tasks/cinder_backends.yml b/playbooks/roles/os_cinder/tasks/cinder_backends.yml
+index 31192f0..5597810 100644
+--- a/playbooks/roles/os_cinder/tasks/cinder_backends.yml
++++ b/playbooks/roles/os_cinder/tasks/cinder_backends.yml
+@@ -13,13 +13,14 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+-- name: Ensure cinder api ip/port are responsive
+-  wait_for:
+-    port: "{{ cinder_service_port }}"
+-    delay: 10
+-    host: "{{ internal_lb_vip_address }}"
+-  tags:
+-    - cinder-backends
++- name: Ensure cinder api is available
++  uri:
++    url: "{{ cinder_service_internaluri }}"
++    status_code: 200
++  register: api_status
++  until: api_status |success
++  retries: 10
++  delay: 10
+
+ - name: Add in cinder devices types
+   shell: |

--- a/rpcd/playbooks/patcher.yml
+++ b/rpcd/playbooks/patcher.yml
@@ -28,3 +28,4 @@
     patcher_files:
       - openstack-hosts-u-suk-dev-issues-1629.patch
       - os_neutron/neutron-metadata-checksum-fix.patch
+      - os_cinder_add_backend_api_check.patch


### PR DESCRIPTION
openstack-ansible commit 9d03db957aca27f28af994131dd25a1a70bd05c8 is
applied here as a patch to prevent failures deploying Kilo. The API
check causes regular failures when performing multi-node AIO
deployments.