### PR TITLE
Set kernel params to ensure iptables are never left open

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -196,3 +196,29 @@ hwraid_apt_repos:
     state: "present"
     filename: "hwraid"
 hwraid_apt_keys: "{{ rpco_apt_gpg_keys }}"
+
+openstack_kernel_options:
+  - { key: 'fs.inotify.max_user_watches', value: 36864 }
+  - { key: 'net.ipv4.conf.all.rp_filter', value: 0 }
+  - { key: 'net.ipv4.conf.default.rp_filter', value: 0 }
+  - { key: 'net.ipv4.ip_forward', value: 1 }
+  - { key: 'net.netfilter.nf_conntrack_max', value: 262144 }
+  - { key: 'vm.dirty_background_ratio', value: 5 }
+  - { key: 'vm.dirty_ratio', value: 10 }
+  - { key: 'vm.swappiness', value: 5 }
+  - { key: 'net.bridge.bridge-nf-call-ip6tables', value: 1 }
+  - { key: 'net.bridge.bridge-nf-call-iptables', value: 1 }
+  - { key: 'net.bridge.bridge-nf-call-arptables', value: 1 }
+  - { key: 'net.ipv4.neigh.default.gc_thresh1', value: "{{ set_gc_val | int // 2 }}" }
+  - { key: 'net.ipv4.neigh.default.gc_thresh2', value: "{{ set_gc_val | int }}" }
+  - { key: 'net.ipv4.neigh.default.gc_thresh3', value: "{{ set_gc_val | int * 2 }}" }
+  - { key: 'net.ipv4.route.gc_thresh', value: "{{ set_gc_val | int * 2 }}" }
+  - { key: 'net.ipv4.neigh.default.gc_interval', value: 60 }
+  - { key: 'net.ipv4.neigh.default.gc_stale_time', value: 120 }
+  - { key: 'net.ipv6.neigh.default.gc_thresh1', value: "{{ set_gc_val | int // 2 }}" }
+  - { key: 'net.ipv6.neigh.default.gc_thresh2', value: "{{ set_gc_val | int }}" }
+  - { key: 'net.ipv6.neigh.default.gc_thresh3', value: "{{ set_gc_val | int * 2 }}" }
+  - { key: 'net.ipv6.route.gc_thresh', value: "{{ set_gc_val | int * 2 }}" }
+  - { key: 'net.ipv6.neigh.default.gc_interval', value: 60 }
+  - { key: 'net.ipv6.neigh.default.gc_stale_time', value: 120 }
+  - { key: 'fs.aio-max-nr', value: 131072 }


### PR DESCRIPTION
The current settings within this role set the kernel params for iptables
on bridges to 0. While this was originally done in the liberty timeframe
for performance reasons, it can cause a flapping problem should this role
be executed "stand alone" on an existing OpenStack deployment. If these
values get set to 0 it could allow traffic to bypass neutron security groups
which has the potential to expose workloads even when port security and security
groups were previously protecting them. It should be noted that the
agent will ensure the kernel params are set correctly at start time
however it does not monitor the values at runtime so running this role
on an existing deployment could have adverse effects if the neutron
agent is never restarted.

This patch sets the "net.bridge.bridge-nf-call-*" kernel params to 1
from the very beginning which will ensure no deployment is effected by
the potential flapping values.

This change overrides the `openstack_kernel_options` list because mitaka
does not use a branch or stable tag for roles.

Change-Id: Ic319a4ca929c46d4ebd515521ca2c4b437377cd2
Adapted-From: commit acfb458ea86e86d7f8ffc979d31fed059100ca85
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>