### PR TITLE
LA-394 Ensure checkout is done if folder exists

### DIFF
--- a/scripts/leapfrog/ubuntu14-leapfrog.sh
+++ b/scripts/leapfrog/ubuntu14-leapfrog.sh
@@ -97,12 +97,14 @@ pushd ${LEAPFROG_DIR}
 
     # Get the OSA LEAPFROG
     if [[ ! -d "openstack-ansible-ops" ]]; then
-        git clone ${OA_OPS_REPO}
-        pushd openstack-ansible-ops
-            git checkout ${OA_OPS_REPO_BRANCH}
-        popd
+        git clone ${OA_OPS_REPO} openstack-ansible-ops
         log "clone" "ok"
     fi
+    pushd openstack-ansible-ops
+        git fetch --all
+        git checkout ${OA_OPS_REPO_BRANCH}
+        log "osa-ops-checkout" "ok"
+    popd
 
     # Prepare rpc folder
     if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpc-prep.complete" ]]; then


### PR DESCRIPTION
If the openstack-ansible-ops repo exists, the checkout won't
be done. Re-running the leapfrog after modifying the ops repo
branch env variable won't be taken into account.

This should fix it.

Issue: [LA-394](https://rpc-openstack.atlassian.net/browse/LA-394)