### PR TITLE
RE-178 Use rpc-maas 1.0.0 tag

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
@@ -42,7 +42,7 @@ maas_target_alias: public0_v4
 maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled | default(false) }}"
 
 # MaaS pathing and versions
-maas_release: master
+maas_release: "1.0.0"
 maas_venv: "/openstack/venvs/maas-{{ maas_release }}"
 maas_venv_bin: "{{ maas_venv }}/bin"
 


### PR DESCRIPTION
This is in preparation for the r14.1.1 rpco release and the 2017.8 meta
release. It is important that we use a tagged version of rpc-maas so
that the 2017.8 meta release can be accurately recreated.

Issue: [RE-178](https://rpc-openstack.atlassian.net/browse/RE-178)