### PR TITLE
RE-144 Fix OSA path in ansible wrapper

### DIFF
--- a/scripts/leapfrog/post_leap.sh
+++ b/scripts/leapfrog/post_leap.sh
@@ -31,6 +31,7 @@ if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/deploy-rpc.complete" ]]; then
   pushd ${RPCO_DEFAULT_FOLDER}/rpcd/playbooks/
     unset ANSIBLE_INVENTORY
     sed -i 's#export ANSIBLE_INVENTORY=.*#export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/opt/rpc-openstack/openstack-ansible/playbooks/inventory}"#g' /usr/local/bin/openstack-ansible.rc
+    sed -i 's#\*"/opt/openstack-ansible"\*#\*"/opt/rpc-openstack/openstack-ansible"\*#' /usr/local/bin/ansible
     # TODO(remove the following hack to restart the neutron agents, when fixed upstream)
     ansible -m shell -a "restart neutron-linuxbridge-agent" nova_compute -i /opt/rpc-openstack/openstack-ansible/playbooks/inventory/dynamic_inventory.py
     openstack-ansible ${RPCO_DEFAULT_FOLDER}/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml


### PR DESCRIPTION
Currently, after a leapfrog upgrade is done, executing the ansible cli
under /opt/rpc-openstack/openstack-ansible/playbooks does not source
the ansible RC file, which results in the inventory not being found.
This is because the leapfrog upgrade modifies the ansible wrapper
pre-upgrade, but does not reset it back after the upgrade is done.

This commit simply resets the OSA path in the ansible wrapper post
upgrade.

Issue: [RE-144](https://rpc-openstack.atlassian.net/browse/RE-144)