### PR TITLE
LA-395 Cleanup apt sources

### DIFF
--- a/scripts/leapfrog/pre_redeploy.sh
+++ b/scripts/leapfrog/pre_redeploy.sh
@@ -109,3 +109,6 @@ pushd ${LEAPFROG_DIR}
         log "rebootstrap-ansible-for-rpc" "ok"
     fi
 popd
+pushd ${RPCO_DEFAULT_FOLDER}/rpcd/playbooks
+    openstack-ansible configure-apt-sources.yml
+popd


### PR DESCRIPTION
Artifacts should be deployed with a clean host, this way the
containers inherit from only the good stuff(TM).

Issue: [LA-395](https://rpc-openstack.atlassian.net/browse/LA-395)