### PR TITLE
Override os_neutron role SHA

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -7,3 +7,7 @@
 - name: ceph.ceph-osd
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
+- name: os_neutron
+  scm: git
+  src: https://github.com/rcbops/neutron.git
+  version: 0e75032744fac365b4f3ff1df67f5009a31a3994

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -7,7 +7,3 @@
 - name: ceph.ceph-osd
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
-- name: os_neutron
-  scm: git
-  src: https://github.com/rcbops/neutron.git
-  version: 0e75032744fac365b4f3ff1df67f5009a31a3994

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -202,3 +202,6 @@ openstack_kernel_options:
   - { key: 'net.ipv6.neigh.default.gc_interval', value: 60 }
   - { key: 'net.ipv6.neigh.default.gc_stale_time', value: 120 }
   - { key: 'fs.aio-max-nr', value: 131072 }
+
+neutron_git_repo: https://github.com/rcbops/neutron.git
+neutron_git_install_branch: 0e75032744fac365b4f3ff1df67f5009a31a3994


### PR DESCRIPTION
The os_neutron role for Mitaka was forked and patched in order to
allow customization of the metatdata_proxy_threads setting.  This
SHA should override the os_neutron SHA specified in OSA to pull in
that change.