### PR TITLE
RE-184 Ensure that user_defaults are copied

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -122,8 +122,6 @@
         mode: "{{ item.mode | default(omit) }}"
       when: "{{ (item.condition | default(True)) | bool }}"
       with_items:
-        - name: "user_osa_variables_defaults.yml"
-          mode: "0440"
         - name: "env.d/elasticsearch.yml"
           condition: "{{ rpco_deploy_elk | bool }}"
         - name: "env.d/kibana.yml"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -86,8 +86,11 @@ fi
 
 cd ${RPCD_DIR}/playbooks
 
-# set permissions and lay down overrides files
+# Copy the current user-space defaults file and make it read-only
+cp "${RPCD_DIR}/etc/openstack_deploy/user_osa_variables_defaults.yml" /etc/openstack_deploy/
 chmod 0440 /etc/openstack_deploy/user_*_defaults.yml
+
+# Copy the default override files if they do not exist
 if [[ ! -f "${OA_OVERRIDES}" ]]; then
   cp "${RPCD_DIR}/etc/openstack_deploy/user_osa_variables_overrides.yml" "${OA_OVERRIDES}"
 fi


### PR DESCRIPTION
Currently the user_defaults file is only
implemented in the AIO bootstrap, but it
should be implemented for *all* deployments.

This patch switches the implementation into
the deploy script to cover all deployments.

(cherry picked from commit 5f66deea1d73e6bb279a32b5a6e0d2a3560b67b3)

Issue: [RE-184](https://rpc-openstack.atlassian.net/browse/RE-184)