### PR TITLE
RE-191 Make options mutually exclusive

### DIFF
--- a/scripts/migrate-yaml.py
+++ b/scripts/migrate-yaml.py
@@ -34,13 +34,14 @@ def parse_args():
                         help='The path to the file with defaults.')
     parser.add_argument('--output-file', dest='output_file', required=True,
                         help='The path to the new overrides file location')
-    parser.add_argument('--for-testing-take-new-vars-only', dest='testing',
-                        action="store_true",
-                        help="don't take old overrides over new defaults")
-    parser.add_argument('--for-testing-keep-old-overrides-only',
-                        dest='testing_keep_overrides',
-                        action="store_true",
-                        help="take old overrides over new defaults")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--for-testing-take-new-vars-only', dest='testing',
+                       action="store_true",
+                       help="don't take old overrides over new defaults")
+    group.add_argument('--for-testing-keep-old-overrides-only',
+                       dest='testing_keep_overrides',
+                       action="store_true",
+                       help="take old overrides over new defaults")
     return parser.parse_args()
 
 
@@ -119,7 +120,7 @@ def main():
                 returned_combined[key] = returned_combined['NEW_DEFAULTS'][key]
             del returned_combined['NEW_DEFAULTS']
             del returned_combined['OLD_OVERRIDES']
-        if args.testing_keep_overrides:
+        elif args.testing_keep_overrides:
             for k in returned_combined['OLD_OVERRIDES'].keys():
                 returned_combined[k] = returned_combined['OLD_OVERRIDES'][k]
             del returned_combined['NEW_DEFAULTS']


### PR DESCRIPTION
This commit makes the options --for-testing-take-new-vars-only and
--for-testing-keep-old-overrides-only mutually exclusive so that both
cannot be provided at the same time, and also fixes an issue with the
conditional in main() where the error should be displayed when neither
--for-testing-take-new-vars-only or
--for-testing-keep-old-overrides-only have been provided.

Issue: [RE-191](https://rpc-openstack.atlassian.net/browse/RE-191)