### PR TITLE
RE-191 Add testing flag to migrate-yaml.py

### DIFF
--- a/scripts/migrate-yaml.py
+++ b/scripts/migrate-yaml.py
@@ -37,6 +37,10 @@ def parse_args():
     parser.add_argument('--for-testing-take-new-vars-only', dest='testing',
                         action="store_true",
                         help="don't take old overrides over new defaults")
+    parser.add_argument('--for-testing-keep-old-overrides-only',
+                        dest='testing_keep_overrides',
+                        action="store_true",
+                        help="take old overrides over new defaults")
     return parser.parse_args()
 
 
@@ -113,6 +117,11 @@ def main():
         if args.testing:
             for key in returned_combined['NEW_DEFAULTS'].keys():
                 returned_combined[key] = returned_combined['NEW_DEFAULTS'][key]
+            del returned_combined['NEW_DEFAULTS']
+            del returned_combined['OLD_OVERRIDES']
+        if args.testing_keep_overrides:
+            for k in returned_combined['OLD_OVERRIDES'].keys():
+                returned_combined[k] = returned_combined['OLD_OVERRIDES'][k]
             del returned_combined['NEW_DEFAULTS']
             del returned_combined['OLD_OVERRIDES']
         else:

--- a/scripts/migrate-yaml.py
+++ b/scripts/migrate-yaml.py
@@ -34,13 +34,14 @@ def parse_args():
                         help='The path to the file with defaults.')
     parser.add_argument('--output-file', dest='output_file', required=True,
                         help='The path to the new overrides file location')
-    parser.add_argument('--for-testing-take-new-vars-only', dest='testing',
-                        action="store_true",
-                        help="don't take old overrides over new defaults")
-    parser.add_argument('--for-testing-keep-old-overrides-only',
-                        dest='testing_keep_overrides',
-                        action="store_true",
-                        help="take old overrides over new defaults")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--for-testing-take-new-vars-only', dest='testing',
+                       action="store_true",
+                       help="don't take old overrides over new defaults")
+    group.add_argument('--for-testing-keep-old-overrides-only',
+                       dest='testing_keep_overrides',
+                       action="store_true",
+                       help="take old overrides over new defaults")
     return parser.parse_args()
 
 
@@ -119,7 +120,7 @@ def main():
                 returned_combined[key] = returned_combined['NEW_DEFAULTS'][key]
             del returned_combined['NEW_DEFAULTS']
             del returned_combined['OLD_OVERRIDES']
-        if args.testing_keep_overrides:
+        elif args.testing_keep_overrides:
             for k in returned_combined['OLD_OVERRIDES'].keys():
                 returned_combined[k] = returned_combined['OLD_OVERRIDES'][k]
             del returned_combined['NEW_DEFAULTS']


### PR DESCRIPTION
For gating purposes, we need a flag in scripts/migrate.yml.py that does
the opposite of --for-testing-take-new-vars-only.  When we do a major
upgrade, for example, we do not re-run deploy.sh and therefore we do
not want to wipe out our previously defined overrides.  This commit
adds a new flag called --for-testing-keep-old-overrides-only which
keeps the old overrides rather than the new conflicting defaults.

Note that this was never an issue in gating as we wrote gating-specific
overrides to a gating overrides file which was never touched by the
upgrade process.  However, as we move away from making gating-related
changes we need to handle this properly in rpc-openstack itself.

This change is necessary to unblock a ceph gating major upgrade gating
failure as the upgrade is wiping out some flags which we used to
override in rpc-gating itself.

(cherry picked from commit 663e2eb7fc360ac4522ea97cd08961fe6c15614e)
(cherry picked from commit 8b4336a73c7d5a6474775e635e11b9b226bf15a2)

Issue: [RE-191](https://rpc-openstack.atlassian.net/browse/RE-191)