### PR TITLE
LA-438 Fix role path

### DIFF
--- a/scripts/leapfrog/pre_redeploy.sh
+++ b/scripts/leapfrog/pre_redeploy.sh
@@ -101,9 +101,7 @@ pushd ${LEAPFROG_DIR}
     fi
     if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rebootstrap-ansible-for-rpc.complete" ]]; then
         pushd ${RPCO_DEFAULT_FOLDER}
-            ansible-galaxy install --force -r ansible-role-requirements.yml
-            sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${RPCO_DEFAULT_FOLDER}/openstack-ansible/playbooks/inventory/group_vars/:${RPCO_DEFAULT_FOLDER}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-            sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${RPCO_DEFAULT_FOLDER}/openstack-ansible/playbooks/inventory/host_vars/:${RPCO_DEFAULT_FOLDER}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
+            scripts/bootstrap-ansible.sh
             source /usr/local/bin/openstack-ansible.rc
         popd
         log "rebootstrap-ansible-for-rpc" "ok"


### PR DESCRIPTION
ANSIBLE_ROLES_PATH has to be reset in the leapfrog, this way
we are ensuring the proper folder is used, and the proper roles
are used.

We can however re-use the bootstrap ansible, that does all
of this for us now.

Issue: [LA-438](https://rpc-openstack.atlassian.net/browse/LA-438)