### PR TITLE
Remove the git submodule for OpenStack-Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ target/
 rpcd/playbooks/roles/ceph.ceph-common
 rpcd/playbooks/roles/ceph.ceph-mon
 rpcd/playbooks/roles/ceph.ceph-osd
+openstack-ansible
 
 # Files created by releasenotes build
 releasenotes/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "openstack-ansible"]
-	path = openstack-ansible
-	url = https://git.openstack.org/openstack/openstack-ansible

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,6 @@ node(){
         # The dir() jenkinsfile step doesn't work within docker.inside.
         # https://issues.jenkins-ci.org/browse/JENKINS-33510
         cd rpc-openstack
-        git submodule update --init
         TOX_WORK_DIR=/tmp tox -e flake8,ansible-lint,releasenotes,bashate,release-script
       """
     }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 ## Major and minor releases
 1. Work (meaning bugfixes and feature development) is performed in the ```master``` branch in preparation for a major or minor release (e.g. ```12.0.0``` or ```12.2.0```).
-2. When all criteria for the targeted release are fulfilled, a release branch is created using the naming convention **series-Major.minor** (e.g. ```liberty-12.0```, or ```mitaka-13.1```). Once the branch is made, QE will begin their virtualized testing off this branch and report back any changes or fixes that need to be addressed. Once QE deems the branch to be in a stable place, an rc (release candidate) tag will be cut. The rc tag will be made available to anyone for further testing. 
+2. When all criteria for the targeted release are fulfilled, a release branch is created using the naming convention **series-Major.minor** (e.g. ```liberty-12.0```, or ```mitaka-13.1```). Once the branch is made, QE will begin their virtualized testing off this branch and report back any changes or fixes that need to be addressed. Once QE deems the branch to be in a stable place, an rc (release candidate) tag will be cut. The rc tag will be made available to anyone for further testing.
 3. Work continues in ```master``` on features and bugs targeted at the next major or minor release (e.g. ```12.1.0```).
 4. As QE (and potentially support and other teams) progress their testing on the release candidate, bugs will be identified in the rc tag that was handed to them. These bugs should be fixed in ```master``` and cherry-picked to the release branch. **No other bug fixes should be cherry-picked into this branch** so that this branch can remain a non-moving target for QE.
 5. Once all bugs from the initial release candidate have been cherry-picked into the release branch, a new release candidate should be tagged (e.g. ```r12.0.0rc2```) if necessary.
@@ -12,7 +12,7 @@
 ## Patch releases
 1. Work (bugfixes) is performed in the ```master``` branch and cherry-picked into the release branch (e.g. ```liberty-12.1``` or ```mitaka-13.1```). OR work (bugfixes) is performed directly in the release branch if it is release specific and doesn't affect ```master```.
 2. Every 2 weeks (approximately) a new release tag (e.g. ```12.1.1```) is made.
-3. Immediately after tagging, all external projects included either via submodules, ansible-galaxy or some other mechanism, will have the version/revision/SHA updated to point to the HEAD of that project (in vernacular, we'll do a SHA bump). This allows an immediate set of gate jobs to run on those SHA bumps, as well as the next 2 weeks of development to happen against those new SHA's. This will allow us to stay current and only have to cope with incremental change in external projects.
+3. Immediately after tagging, all external projects included either via ansible-galaxy or some other mechanism, will have the version/revision/SHA updated to point to the HEAD of that project (in vernacular, we'll do a SHA bump). This allows an immediate set of gate jobs to run on those SHA bumps, as well as the next 2 weeks of development to happen against those new SHA's. This will allow us to stay current and only have to cope with incremental change in external projects.
 
 # Release Process
 - [ ] Create the tag.

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -24,9 +24,6 @@ source ${BASE_DIR}/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 
-# Check the openstack-ansible submodule status
-check_submodule_status
-
 # Get minimum disk size
 DATA_DISK_MIN_SIZE="$((1024**3 * $(awk '/bootstrap_host_data_disk_min_size/{print $2}' ${OA_DIR}/tests/roles/bootstrap-host/defaults/main.yml) ))"
 # Determine the largest secondary disk device available for repartitioning which meets the minimum size requirements

--- a/scripts/bootstrap-artifacts.sh
+++ b/scripts/bootstrap-artifacts.sh
@@ -25,9 +25,6 @@ source ${BASE_DIR}/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 
-# Check the openstack-ansible submodule status
-check_submodule_status
-
 # begin the bootstrap process
 pushd ${OA_DIR}
     openstack-ansible ${RPCD_DIR}/playbooks/stage-apt-artifacts.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,9 +35,6 @@ if [[ "$DEPLOY_AIO" != "yes" ]] && [[ "$DEPLOY_HARDENING" != "yes" ]]; then
   exit 1
 fi
 
-# Check the openstack-ansible submodule status
-check_submodule_status
-
 # Bootstrap Ansible
 source "$(dirname "${0}")/bootstrap-ansible.sh"
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -15,6 +15,9 @@
 
 ## Vars ----------------------------------------------------------------------
 
+# OSA SHA
+export OSA_RELEASE=${OSA_RELEASE:-"045c4c5601a7f1d2e63303c7420e9fd518704c4b"}
+
 # Gating
 export BUILD_TAG=${BUILD_TAG:-}
 export INFLUX_IP=${INFLUX_IP:-}
@@ -86,24 +89,6 @@ fi
 
 function run_ansible {
   openstack-ansible ${ANSIBLE_PARAMETERS} $@
-}
-
-function check_submodule_status {
-  # Confirm OA_DIR is properly checked out
-  submodulestatus=$(git submodule status ${OA_DIR})
-  case "${submodulestatus:0:1}" in
-    "-")
-      echo "ERROR: rpc-openstack submodule is not properly checked out"
-      exit 1
-      ;;
-    "+")
-      echo "WARNING: rpc-openstack submodule does not match the expected SHA"
-      ;;
-    "U")
-      echo "ERROR: rpc-openstack submodule has merge conflicts"
-      exit 1
-      ;;
-  esac
 }
 
 function copy_default_user_space_files {

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     {toxinidir}/scripts/linting-pep8.sh
 
 [testenv:bashate]
-commands = 
+commands =
     {toxinidir}/scripts/linting-bashate.sh
 
 [testenv:ansible-lint]
@@ -58,7 +58,7 @@ commands = python -m unittest discover -s scripts -p test_release.py -v
 #     F403 'from ansible.module_utils.basic import *' used; unable to detect undefined names
 #     H303  No wildcard (*) import.
 #     R     excludes all of the RPC specific checks
-# Excluding our upstream submodule, and our vendored f5 configuration script.
+# Excluding our vendored f5 configuration script.
 
 ignore=F403,H303,R
 exclude=openstack-ansible/*,f5-config.py


### PR DESCRIPTION
The submodule we use for OSA has long complicated our delivery process
and has been something we've stuck with for reasons unbeknownst to most and
has been known to be error prone to both the development and operators
This change modifies RPC-O to remove the submodule. While the submodule is
gone, the interface remains by creating a link to the OSA git checkout from
within RPC-O. Interface compatibility has been implemented so that DEV has
time to convert tooling to use the well defined and documented OSA
directory path'ing instead of depending on our nested structure.

This change will create a lot more consistency within the RPC-O deliverable
and the upstream community. It will also help operators better understand
the product long term as they can now use the upstream documentation more
readily.

This change is being done as part of [Phase 1](https://github.com/rcbops/architecture-review/blob/master/blueprints/rpco-modernization.md#phase-1) of the RPCO modernization
effort.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [phase-1](https://rpc-openstack.atlassian.net/browse/phase-1)