### PR TITLE
RE-219 Bump percona-xtrabackup

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -205,3 +205,6 @@ openstack_kernel_options:
 
 neutron_git_repo: https://github.com/rcbops/neutron.git
 neutron_git_install_branch: 0e75032744fac365b4f3ff1df67f5009a31a3994
+
+galera_package_url: "https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.3.5/binary/debian/trusty/x86_64/percona-xtrabackup_2.3.5-1.trusty_amd64.deb"
+galera_package_sha256: "7b407be253b922f8bb772d87877486c0ce8eef8af1304abec702dba962b497dd"


### PR DESCRIPTION
Liberty/mitaka builds are failing to build due to galera not deploying
as a result of an implicit bump of mariadb (10.0.31 to 10.0.32) which
now requires a newer version of XtraBackup than what we deploy.  The
galera cluster fails to build as 2/3 nodes cannot perform a state
transfer from the primary node. The logged error is:

```
WSREP_SST: [ERROR] FATAL: The innobackupex version is 1.5.1. \
Needs xtrabackup-2.3.5 or higher to perform SST (20170823 15:11:28.126)
```

This commit simply updates user_osa_variables_defaults.yml so we deploy
a more current version of percona-xtrabackup.  The specified version is
2.3.5 exactly (the minimum requirement) to keep the amount of change as
minimal as possible.

Issue: [RE-219](https://rpc-openstack.atlassian.net/browse/RE-219)