### PR TITLE
LA-361 Stage python artifacts during re-deployment

### DIFF
--- a/scripts/leapfrog/ubuntu14-leapfrog.sh
+++ b/scripts/leapfrog/ubuntu14-leapfrog.sh
@@ -155,6 +155,7 @@ pushd ${LEAPFROG_DIR}
 
     if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/osa-leap.complete" ]]; then
         pushd openstack-ansible-ops/leap-upgrades/
+            export PRE_SETUP_INFRASTRUCTURE_HOOK=${RPCO_DEFAULT_FOLDER}/rpcd/playbooks/stage-python-artifacts.yml
             export REDEPLOY_EXTRA_SCRIPT=${RPCO_DEFAULT_FOLDER}/scripts/leapfrog/pre_redeploy.sh
             . ./run-stages.sh
         popd


### PR DESCRIPTION
To ensure that the pre-built python and git artifacts
are used, the python artifact staging playbook is
inserted into the redeploy process through the use of
a new hook implemented into the process by the patch
noted below.

The python artifact staging will download all the
required repo server contents including git
repositories, python wheels and python venvs.

The redeployment process will still execute the
repo-build playbook, but that process will only do
anything if requirements have been changed through
configuration in user-space for the wheels/venvs. If
no such change has been made, the repo-build will skip
and continue.

This also has the side-benefit of not requiring retries
for the git clone (ref: LA-326) because the git content
is downloaded using a much faster and more reliable
method.

Depends-on: https://review.openstack.org/498167

Issue: [LA-361](https://rpc-openstack.atlassian.net/browse/LA-361)

Related: [LA-326](https://rpc-openstack.atlassian.net/browse/LA-326)
