### PR TITLE
Remove the inline injections for better upstream support

### DIFF
--- a/releasenotes/notes/ro-group-host-vars-1e72a733eebb9cfa.yaml
+++ b/releasenotes/notes/ro-group-host-vars-1e72a733eebb9cfa.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - `{group,host}_vars` are now set in the `/etc/openstack_deploy` directory
+    and are being set to READ ONLY. This ensures we're able to control our
+    defaults in a sane way without having to modify the OSA interfaces to
+    suit our needs. Should a deployer need want to modify one of our default
+    settings they can follow our existing override pattern by setting their
+    desired option within the `user_.*` files.

--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -50,9 +50,15 @@ if [[ "${PWD}" != "/opt/rpc-openstack" ]]; then
 fi
 
 # Bootstrap Ansible
+cd /opt/rpc-openstack
+
+# Remove the AIO configuration relating to the use
+# of container artifacts. This needs to be done
+# because the container artifacts do not exist yet.
+./scripts/artifacts-building/remove-container-aio-config.sh
+
 # This script is sourced to ensure that the common
 # functions and vars are available.
-cd /opt/rpc-openstack
 source scripts/bootstrap-ansible.sh
 
 # Bootstrap the AIO configuration
@@ -74,11 +80,6 @@ fi
 if [[ "$(echo ${REPLACE_ARTIFACTS} | tr [a-z] [A-Z])" == "YES" ]]; then
   export PUSH_TO_MIRROR="YES"
 fi
-
-# Remove the AIO configuration relating to the use
-# of container artifacts. This needs to be done
-# because the container artifacts do not exist yet.
-./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
 cd scripts/artifacts-building/
@@ -195,4 +196,3 @@ if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
 else
   echo "Skipping upload to rpc-repo as the PUSH_TO_MIRROR env var is not set to 'YES'."
 fi
-

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -47,9 +47,15 @@ if [[ "${PWD}" != "/opt/rpc-openstack" ]]; then
 fi
 
 # Bootstrap Ansible
+cd /opt/rpc-openstack
+
+# Remove the AIO configuration relating to the use
+# of container artifacts. This needs to be done
+# because the container artifacts do not exist yet.
+./scripts/artifacts-building/remove-container-aio-config.sh
+
 # This script is sourced to ensure that the common
 # functions and vars are available.
-cd /opt/rpc-openstack
 source scripts/bootstrap-ansible.sh
 
 # Bootstrap the AIO configuration
@@ -57,11 +63,6 @@ source scripts/bootstrap-ansible.sh
 
 # Copy the current user-space defaults file
 cp "/opt/rpc-openstack/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml" /etc/openstack_deploy/
-
-# Remove the AIO configuration relating to the use
-# of container artifacts. This needs to be done
-# because the container artifacts do not exist yet.
-./scripts/artifacts-building/remove-container-aio-config.sh
 
 # Set override vars for the artifact build
 echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml

--- a/scripts/artifacts-building/remove-container-aio-config.sh
+++ b/scripts/artifacts-building/remove-container-aio-config.sh
@@ -18,7 +18,8 @@
 # Remove the env.d configurations that set the build to use
 # container artifacts. We don't want this because container
 # artifacts do not currently exist when this script is used.
-sed -i.bak '/lxc_container_variant: /d' /opt/rpc-openstack/group_vars/*.yml
+sed -i.bak '/lxc_container_variant: /d' /opt/rpc-openstack/group_vars/*.yml \
+                                        /opt/rpc-openstack/group_vars/all/*.yml
 
 # Remove the RPC-O default configurations that are necessary
 # for deployment, but cause the build to break due to the fact

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -60,16 +60,6 @@ if ! container_artifacts_available; then
   ./scripts/artifacts-building/remove-container-aio-config.sh
 fi
 
-# Run AIO bootstrap playbook
-# Setting GROUP_VARS and HOST_VARS to their original
-# values here so that the OSA bootstrap playbooks
-# can run with the correct variables.
-export GROUP_VARS_PATH="/etc/openstack_deploy/group_vars/"
-export HOST_VARS_PATH="/etc/openstack_deploy/host_vars/"
 openstack-ansible -vvv ${BASE_DIR}/scripts/bootstrap-aio.yml \
                   -i "localhost," -c local \
                   -e "${BOOTSTRAP_OPTS}"
-# Unset GROUP_VARS_PATH and HOST_VARS_PATH so that the
-# defaults are taken in openstack-ansible.rc
-unset GROUP_VARS_PATH
-unset HOST_VARS_PATH

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -91,8 +91,19 @@ pushd ${OA_DIR}
     exit 99
   fi
 
-  # Now use GROUP_VARS of OSA and RPC
-  sed -i "s|GROUP_VARS_PATH=.*|GROUP_VARS_PATH=\"\${GROUP_VARS_PATH:-${OA_DIR}/playbooks/inventory/group_vars/:${BASE_DIR}/group_vars/:/etc/openstack_deploy/group_vars/}\"|" /usr/local/bin/openstack-ansible.rc
-  sed -i "s|HOST_VARS_PATH=.*|HOST_VARS_PATH=\"\${HOST_VARS_PATH:-${OA_DIR}/playbooks/inventory/host_vars/:${BASE_DIR}/host_vars/:/etc/openstack_deploy/host_vars/}\"|" /usr/local/bin/openstack-ansible.rc
+  # NOTE(cloudnull): Sync {group,host}_vars from rpc-o into the proper OSA
+  #                  directory which supports the default override interface.
+  #                  to ensure our group and host vars are always in sync the
+  #                  rsync command is used with the --delete flag and the vars
+  #                  are set to read only. If a deployer wishes to override our
+  #                  defaults they can do so using the user_.* files.
+  for dir_name in group_vars host_vars; do
+    if [[ -d "${BASE_DIR}/${dir_name}" ]];then
+      rsync -av --exclude '*.bak' --delete "${BASE_DIR}/${dir_name}" /etc/openstack_deploy/
+      if [[ -d "/etc/openstack_deploy/${dir_name}" ]]; then
+        chmod ugo+rX "/etc/openstack_deploy/${dir_name}"
+      fi
+    fi
+  done
 
 popd


### PR DESCRIPTION
This change removes the injections being done with `sed` so that we're
not breaking use of our upstream tools by injecting our own code into
the default rc file. Prior to this commit any use of the upstream
bootstrap script would break RPC-O almost entirely. Using the known
interfaces, we can sync {group,host}_vars into the
"/etc/openstack_ansible" directory which retain upstream tool
compatibility.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>