### PR TITLE
RE-191 Fix failing major upgrade builds

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -86,4 +86,6 @@ tempest_run_tempest_opts:
 # Tempest testr options
 tempest_testr_opts: []
 # Tempest tests to run. A one-line, space-delimited string
-tempest_test_sets: "scenario defcore cinder_backup"
+# NOTE: We do not test cinder_backup in mitaka branch due to this:
+#       https://github.com/rcbops/rpc-openstack/issues/2258
+tempest_test_sets: "scenario defcore"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -30,9 +30,10 @@ source ${BASE_DIR}/scripts/functions.sh
 # Issue: Variables files have been reorganized, run a migration script to move
 #        them to the new location.
 # WARNING: In no way should the migrate-yaml.py script be run with
-#          --for-testing-take-new-vars-only in production environments.
+#          --for-testing-take-new-vars-only or --for-testing-keep-old-overrides-only
+#          in production environments.
 if [[ ! -f "/etc/openstack_deploy/user_rpco_variables_overrides.yml" ]]; then
-  "${BASE_DIR}"/scripts/migrate-yaml.py --for-testing-take-new-vars-only \
+  "${BASE_DIR}"/scripts/migrate-yaml.py --for-testing-keep-old-overrides-only \
       --defaults "${RPCD_DIR}"/etc/openstack_deploy/user_rpco_variables_defaults.yml \
       --overrides /etc/openstack_deploy/user_extras_variables.yml \
       --output-file /etc/openstack_deploy/user_rpco_variables_overrides.yml


### PR DESCRIPTION
In #2479, we added an new flag to migrate-yaml.py called
`--for-testing-keep-old-overrides-only`.  This was necessary as
rpc-gating no longer carries an overrides file and our configured
rpco overrides were getting wiped by the upgrade when using
--for-testing-take-new-vars-only.  Specifically, ceph-related overrides
dropped by deploy.sh on the initial deployment were not getting carried
through the upgrade, resulting in the 2nd run of the ceph playbooks to
fail:

```
TASK: [ceph.ceph-common | verify only one osd scenario was chosen] \
    ************
failed: [ramtmcp-45-8e71_ceph_osd_container-b6f12eeb] => \
    {"failed": true}
msg: please select only one osd scenario[0m
failed: [ramtmcp-45-8e71_ceph_osd_container-26348b7f] => \
    {"failed": true}
msg: please select only one osd scenario[0m
failed: [ramtmcp-45-8e71_ceph_osd_container-ca75c203] => \
    {"failed": true}
msg: please select only one osd scenario
```

This commit updates scripts/test-upgrade.sh to use
--for-testing-keep-old-overrides-only on user_extras_variables.yml since
no new rpco overrides are added in the mitaka release.

NOTE: Ideally what we want to do is simply blow away all overrides and
      allow an upgrade to redeploy overrides via deploy.sh.  However, this
      will require additional work and this commit serves to unblock the
      currently broken gate.

Additionally, we remove cinder_backup from `tempest_test_sets` since
this is causing major upgrade failures due to [1].

[1] https://github.com/rcbops/rpc-openstack/issues/2258

Issue: [RE-191](https://rpc-openstack.atlassian.net/browse/RE-191)