### PR TITLE
RO-2429 Remove neutron_api_workers override

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -25,7 +25,6 @@ cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
 keystone_database_max_pool_size: "{{ db_max_pool_size }}"
 keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
-neutron_api_workers: 64
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"


### PR DESCRIPTION
This patch removes the `neutron_api_workers` override that set the
number of API workers to 64. OSA already has code that calculates
an optimal number of neutron api workers by taking the number of
CPU cores and dividing by 2. If that value is incorrect, we should
change the logic in OSA.

Issue: [RO-2429](https://rpc-openstack.atlassian.net/browse/RO-2429)