### PR TITLE
RO-2430 Remove rpc_thread_pool_size override

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -15,11 +15,9 @@
 
 # SQLAlchemy/Olso Thread Pool Settings
 rpc_response_timeout: 180
-rpc_thread_pool_size: 180
 db_max_pool_size: 120
 db_pool_timeout: 60
 
-cinder_rpc_executor_thread_pool_size: "{{ rpc_thread_pool_size }}"
 cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
 
 keystone_database_max_pool_size: "{{ db_max_pool_size }}"
@@ -27,12 +25,10 @@ keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
-neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
-nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 nova_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_db_pool_timeout: "{{ db_pool_timeout }}"
 nova_api_db_max_pool_size: "{{ db_max_pool_size }}"


### PR DESCRIPTION
Building lots of VMs (> 64) at a time in Icehouse/Kilo lead to RPC
thread exhaustion, which means VMs never came online. That was fixed
in a patch to nova during the Kilo release and it's recommended to
use the default of 64 RPC threads. The oslo.messaging project still
recommends this default in Pike.

This patch removes the RPC thread pool overrides, which reduces the
load on RabbitMQ and saves memory.

Upstream fix: https://review.openstack.org/#/c/132202/
Upstream bug: https://bugs.launchpad.net/neutron/+bug/1372049

Issue: [RO-2430](https://rpc-openstack.atlassian.net/browse/RO-2430)