### PR TITLE
RO-2431 Remove rpc_response_timeout overrides

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -14,24 +14,20 @@
 # limitations under the License.
 
 # SQLAlchemy/Olso Thread Pool Settings
-rpc_response_timeout: 180
 rpc_thread_pool_size: 180
 db_max_pool_size: 120
 db_pool_timeout: 60
 
 cinder_rpc_executor_thread_pool_size: "{{ rpc_thread_pool_size }}"
-cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
 
 keystone_database_max_pool_size: "{{ db_max_pool_size }}"
 keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
-neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
-nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 nova_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_db_pool_timeout: "{{ db_pool_timeout }}"


### PR DESCRIPTION
In the Havana/Grizzly releases, RPC thread response timeout overrides
were required because of an issue with iptables when lots of
simultaneous builds were occurring. This was fixed in the Havana
release and these overrides are no longer needed.

The OSA default of 60 seconds is strongly recommended by the
oslo.messaging project. This patch removes the override so that the
safe default can be used.

Upstream Bug: https://bugs.launchpad.net/nova/+bug/1199433
Upstream Fix: https://review.openstack.org/#/c/40688/

Issue: [RO-2431](https://rpc-openstack.atlassian.net/browse/RO-2431)