### PR TITLE
Remove db pool size overrides

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -18,13 +18,11 @@ rpc_conn_pool_size: 180
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
 db_max_overflow: 60
-db_max_pool_size: 120
 db_pool_timeout: 60
 
 cinder_rpc_executor_thread_pool_size: "{{ rpc_thread_pool_size }}"
 cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
 
-keystone_database_max_pool_size: "{{ db_max_pool_size }}"
 keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
@@ -32,17 +30,14 @@ neutron_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_overflow: "{{ db_max_overflow }}"
-neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
 nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 nova_db_max_overflow: "{{ db_max_overflow }}"
-nova_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_db_pool_timeout: "{{ db_pool_timeout }}"
 nova_api_db_max_overflow: "{{ db_max_overflow }}"
-nova_api_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_api_db_pool_timeout: "{{ db_pool_timeout }}"
 nova_cpu_allocation_ratio: 2.0
 nova_ram_allocation_ratio: 1.0


### PR DESCRIPTION
This default in OSA for db pool size overrides has been 120 since
Newton. We don't need to overrid this in rpc-openstack.

This patch removes those overrides.

Issue: [RO-2432](https://rpc-openstack.atlassian.net/browse/RO-2432)