### PR TITLE
RO-2434 Remove pool_timeout overrides

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -17,19 +17,16 @@
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
 db_max_pool_size: 120
-db_pool_timeout: 60
 
 cinder_rpc_executor_thread_pool_size: "{{ rpc_thread_pool_size }}"
 cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
 
 keystone_database_max_pool_size: "{{ db_max_pool_size }}"
-keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
-neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"


### PR DESCRIPTION
RPC-O overrides the pool_timeout to 60 seconds, wheras oslo.db,
SQLAlchemy, and OSA all recommend 30 seconds as a maximum. There
were some bugs around building lots of instances and hitting db pool
timeouts back in the Icehouse/Kilo timeframes, but these bugs have
been fixes for quite some time.

This patch removes the override and uses the OSA default of 30 seconds.
If we're really expecting to wait up to 60 seconds for a successful
database connection, then we're making some serious MariaDB/OpenStack
issues in a deployment.

Issue: [RO-2434](https://rpc-openstack.atlassian.net/browse/RO-2434)