### PR TITLE
RO-2435 Remove max_overflow overrides

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -17,7 +17,6 @@
 rpc_conn_pool_size: 180
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
-db_max_overflow: 60
 db_max_pool_size: 120
 db_pool_timeout: 60
 
@@ -31,17 +30,14 @@ neutron_api_workers: 64
 neutron_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-neutron_db_max_overflow: "{{ db_max_overflow }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
 nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-nova_db_max_overflow: "{{ db_max_overflow }}"
 nova_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_db_pool_timeout: "{{ db_pool_timeout }}"
-nova_api_db_max_overflow: "{{ db_max_overflow }}"
 nova_api_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_api_db_pool_timeout: "{{ db_pool_timeout }}"
 nova_cpu_allocation_ratio: 2.0


### PR DESCRIPTION
The max_overflow override sets the maximum number of simultaneous
connected database threads. SQLAlchemy recommends setting this to 10
and oslo.db accepts this default. OSA uses the default for most
services but it bumps the max to 20 for very busy services, such as
nova and neutron.

This patch removes the override since it is no longer necessary to
override the max_overflow value. Bugs existed in Icehouse/Kilo that
caused excessive database threads when lots of instances were being
built, but those bugs have been fixed for years.

Issue: [RO-2435](https://rpc-openstack.atlassian.net/browse/RO-2435)