### PR TITLE
RO-2436 Remove rpc_conn_pool_size overrides

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 # SQLAlchemy/Olso Thread Pool Settings
-rpc_conn_pool_size: 180
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
 db_max_overflow: 60
@@ -28,14 +27,12 @@ keystone_database_max_pool_size: "{{ db_max_pool_size }}"
 keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
-neutron_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_overflow: "{{ db_max_overflow }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
-nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 nova_db_max_overflow: "{{ db_max_overflow }}"


### PR DESCRIPTION
This patch removes the rpc_conn_pool_size overrides from RPC-O. These
overrides were necessary back in Icehouse/Kilo, but the bugs that
required these increases have long been fixed.

Upstream fix: https://review.openstack.org/#/c/132202
Upstream bug: https://bugs.launchpad.net/neutron/+bug/1372049

Issue: [RO-2436](https://rpc-openstack.atlassian.net/browse/RO-2436)