### PR TITLE
Clean up cross az attach comment

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -48,11 +48,13 @@ nova_cpu_allocation_ratio: 2.0
 nova_ram_allocation_ratio: 1.0
 
 # Nova config overrides
-# NOTE: Due to a bug with nova, this variable cannot be set to true
-# if the environment needs to be able to boot an instance from
-# a volume
-# https://bugs.launchpad.net/nova/+bug/1648324
+# NOTE: Due to a bug with nova, this variable cannot be set to true if the
+# environment needs to be able to boot an instance from a volume.
+# NOTE(mhayden): Remove this configuration once the OpenStack-Ansible SHA
+# has been bumped to pull in this fix from the Ocata release:
+#   https://review.openstack.org/#/c/469548/
 nova_cross_az_attach: False
+
 nova_console_type: novnc
 
 # RabbitMQ overrides


### PR DESCRIPTION
The old comment was noting a bug that was a duplicate. The bug
was fixed in Pike and backported to Ocata. The configuration should
be removed as soon as the OSA SHA is bumped and the fix is brought
in.