### PR TITLE
RO-2438 Cleanup RabbitMQ ulimit comment

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -56,6 +56,8 @@ nova_cross_az_attach: False
 nova_console_type: novnc
 
 # RabbitMQ overrides
+# NOTE(mhayden): Remove this override once the OpenStack-Ansible SHA is bumped
+# to include: https://review.openstack.org/#/c/500054/
 rabbitmq_ulimit: 65535
 
 # Set RabbitMQ message replication count to 2


### PR DESCRIPTION
This patch adds a comment to remove the rabbitmq uliimt override
once the patch merges into OSA and is backported.

Patch: https://review.openstack.org/#/c/500054/

Issue: [RO-2438](https://rpc-openstack.atlassian.net/browse/RO-2438)