### PR TITLE
RO-1360 Put OS X shenanigans in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ releasenotes/build
 
 # Editor files
 .idea
+
+# Mac OS X files
+*.DS_Store
+.AppleDouble
+.LSOverride


### PR DESCRIPTION
This patch adds files to the .gitignore list that are commonly found
on OS X, MacOS, or whatever the Apple operating system is called in
the future. :trollface:

Issue: [RO-1360](https://rpc-openstack.atlassian.net/browse/RO-1360)