### PR TITLE
RO-2433 Fix openstack-ops SHA [Backport - Newton]

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -13,7 +13,7 @@
 - name: rcbops_openstack-ops
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
-  version: ef9068d8cde4fd8ea3ea83ea0b026137eb253233
+  version: cf8f2bfc7d09af3d2892492ef9562e6747f79095
 - name: os_octavia
   scm: git
   src: https://github.com/openstack/openstack-ansible-os_octavia.git


### PR DESCRIPTION
The SHA used for openstack-ops has disappeared, likely due to a
forced push. This patch uses the head of openstack-ops within
rpc-openstack.

(cherry picked from commit 32c237e12a5b86ffd12355a6518a33cb50b92e40)

Issue: [RO-2433](https://rpc-openstack.atlassian.net/browse/RO-2433)