### PR TITLE
[Newton] Backport override removal to newton

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 # SQLAlchemy/Olso Thread Pool Settings
-rpc_conn_pool_size: 180
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
 db_max_overflow: 60
@@ -28,14 +27,12 @@ keystone_database_max_pool_size: "{{ db_max_pool_size }}"
 keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 
 neutron_api_workers: 64
-neutron_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 neutron_db_max_overflow: "{{ db_max_overflow }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
-nova_rpc_conn_pool_size: "{{ rpc_conn_pool_size }}"
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
 nova_db_max_overflow: "{{ db_max_overflow }}"

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -16,7 +16,6 @@
 # SQLAlchemy/Olso Thread Pool Settings
 rpc_response_timeout: 180
 rpc_thread_pool_size: 180
-db_max_overflow: 60
 db_max_pool_size: 120
 db_pool_timeout: 60
 
@@ -29,16 +28,13 @@ keystone_database_pool_timeout: "{{ db_pool_timeout }}"
 neutron_api_workers: 64
 neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
 neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-neutron_db_max_overflow: "{{ db_max_overflow }}"
 neutron_db_max_pool_size: "{{ db_max_pool_size }}"
 neutron_db_pool_timeout: "{{ db_pool_timeout }}"
 
 nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
 nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-nova_db_max_overflow: "{{ db_max_overflow }}"
 nova_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_db_pool_timeout: "{{ db_pool_timeout }}"
-nova_api_db_max_overflow: "{{ db_max_overflow }}"
 nova_api_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_api_db_pool_timeout: "{{ db_pool_timeout }}"
 

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -44,8 +44,6 @@ nova_db_pool_timeout: "{{ db_pool_timeout }}"
 nova_api_db_max_overflow: "{{ db_max_overflow }}"
 nova_api_db_max_pool_size: "{{ db_max_pool_size }}"
 nova_api_db_pool_timeout: "{{ db_pool_timeout }}"
-nova_cpu_allocation_ratio: 2.0
-nova_ram_allocation_ratio: 1.0
 
 # Nova config overrides
 # NOTE: Due to a bug with nova, this variable cannot be set to true

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -13,31 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SQLAlchemy/Olso Thread Pool Settings
-rpc_response_timeout: 180
-rpc_thread_pool_size: 180
-db_max_pool_size: 120
-db_pool_timeout: 60
-
-cinder_rpc_executor_thread_pool_size: "{{ rpc_thread_pool_size }}"
-cinder_rpc_response_timeout: "{{ rpc_response_timeout }}"
-
-keystone_database_max_pool_size: "{{ db_max_pool_size }}"
-keystone_database_pool_timeout: "{{ db_pool_timeout }}"
-
-neutron_api_workers: 64
-neutron_rpc_response_timeout: "{{ rpc_response_timeout }}"
-neutron_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-neutron_db_max_pool_size: "{{ db_max_pool_size }}"
-neutron_db_pool_timeout: "{{ db_pool_timeout }}"
-
-nova_rpc_response_timeout: "{{ rpc_response_timeout }}"
-nova_rpc_thread_pool_size: "{{ rpc_thread_pool_size }}"
-nova_db_max_pool_size: "{{ db_max_pool_size }}"
-nova_db_pool_timeout: "{{ db_pool_timeout }}"
-nova_api_db_max_pool_size: "{{ db_max_pool_size }}"
-nova_api_db_pool_timeout: "{{ db_pool_timeout }}"
-
 # Nova config overrides
 # NOTE: Due to a bug with nova, this variable cannot be set to true
 # if the environment needs to be able to boot an instance from


### PR DESCRIPTION
This is a combined backport of multiple patches from master that
remove unneeded overrides. This includes:

    b064af3e Remove unneeded overrides (#2516)
    94fe0728 RO-2435 Remove max_overflow overrides
    d46140b0 RO-2436 Remove rpc_conn_pool_size overrides
    6f094657 RO-2437 Remove CPU/RAM allocation ratio overrides

Issue: [RO-2439](https://rpc-openstack.atlassian.net/browse/RO-2439)

Issue: [RO-2429](https://rpc-openstack.atlassian.net/browse/RO-2429)