### PR TITLE
RI-72 Create ironic config script for gating

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -158,7 +158,7 @@
   include: "{{ lookup('env', 'OA_DIR') }}/tests/bootstrap-aio.yml"
   vars:
     bootstrap_host_apt_distribution_suffix_list: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary([], ['updates', 'backports']) }}"
-    bootstrap_host_scenario: "{{ (lookup('env', 'DEPLOY_CEPH') | bool) | ternary('ceph','swift') }}"
+    bootstrap_host_scenario: "{% if lookup('env', 'DEPLOY_MAGNUM') == 'yes' %}magnum{% elif lookup('env', 'DEPLOY_IRONIC') == 'yes' %}ironic{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
     bootstrap_user_variables_template: "user_variables.aio.yml.j2"
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"
@@ -184,6 +184,23 @@
         - name: swift.yml.aio
         - name: ceph.yml.aio
           path: "{{ lookup('env', 'RPCD_DIR') ~ '/etc/openstack_deploy/conf.d' }}"
+      ironic:
+        - name: cinder.yml.aio
+        - name: glance.yml.aio
+        - name: heat.yml.aio
+        - name: horizon.yml.aio
+        - name: keystone.yml.aio
+        - name: neutron.yml.aio
+        - name: nova.yml.aio
+        - name: swift.yml.aio
+        - name: ironic.yml.aio
+    openstack_user_config_overrides:
+      shared-infra_hosts:
+        aio1:
+          affinity:
+            galera_container: 3
+            rabbit_mq_container: 3
+          ip: 172.29.236.100
 
 - name: Execute the RPC-O AIO adjustments
   hosts: localhost

--- a/scripts/ironic/deploy-ironic-aio.sh
+++ b/scripts/ironic/deploy-ironic-aio.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -e -u -x
+set -o pipefail
+
+## Functions -----------------------------------------------------------------
+
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
+## Main ----------------------------------------------------------------------
+
+# Check the openstack-ansible submodule status
+check_submodule_status
+
+# Ansible and AIO setup
+DEPLOY_IRONIC="yes" DEPLOY_AIO="yes" DEPLOY_RPC="no" DEPLOY_OA="no" ${BASE_DIR}/scripts/deploy.sh
+# Pre-deployment configuration for ironic
+openstack-ansible ${BASE_DIR}/scripts/ironic/playbooks/ironic-pre-config.yml
+# Deploy RPC
+${BASE_DIR}/scripts/deploy.sh
+# Post-deployment configuration for ironic
+openstack-ansible ${BASE_DIR}/scripts/ironic/playbooks/ironic-post-install-config.yml
+# Re-run ironic installation to include the post-config
+openstack-ansible ${OA_DIR}/playbooks/os-ironic-install.yml

--- a/scripts/ironic/playbooks/ironic-post-install-config.yml
+++ b/scripts/ironic/playbooks/ironic-post-install-config.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- name: Ironic post install config
+  hosts: utility_all[0]
+  tasks:
+    - name: Setup neutron network
+      shell: ". /root/openrc && neutron net-create --shared --provider:physical_network tftp --provider:network_type flat tftp"
+
+    - name: Setup neutron subnet
+      shell: ". /root/openrc && neutron subnet-create --name ironic-tftp --allocation-pool start=172.29.233.0,end=172.29.234.0  --dns-nameserver=4.4.4.4 tftp 172.29.232.0/22"
+
+    - name: Configure the cleaning network
+      delegate_to: localhost
+      config_template:
+         src: "/etc/openstack_deploy/user_osa_variables_overrides.yml"
+         dest: "/etc/openstack_deploy/user_osa_variables_overrides.yml"
+         owner: "root"
+         group: "root"
+         mode: "0644"
+         config_overrides: "{{ ironic_cleaning_config }}"
+         config_type: "yaml"
+  vars:
+    ironic_cleaning_config:
+      ironic_neutron_cleaning_network_name: "tftp"
+      ironic_ironic_conf_overrides:
+        conductor:
+          automated_clean: true

--- a/scripts/ironic/playbooks/ironic-pre-config.yml
+++ b/scripts/ironic/playbooks/ironic-pre-config.yml
@@ -1,0 +1,112 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- name: Pre install config for ironic
+  hosts: localhost
+  tasks:
+    - name: Create ironic network configurations
+      blockinfile:
+        dest: /etc/network/interfaces.d/osa_ironic_interfaces.cfg
+        create: yes
+        block: |
+          auto none
+          auto br-ironic-ipmi
+          iface br-ironic-ipmi inet static
+              bridge_stp off
+              bridge_waitport 10
+              bridge_fd 0
+              bridge_ports none
+              address 172.29.228.100
+              netmask 255.255.252.0
+              offload-sg off
+
+          auto none
+          iface none inet manual
+          auto br-tftp
+          iface br-tftp inet static
+              bridge_stp off
+              bridge_waitport 10
+              bridge_fd 0
+              bridge_ports none
+              address 172.29.232.100
+              netmask 255.255.252.0
+              offload-sg off
+
+    - name: Start the ironic network interfaces
+      command: "ifup {{ item }}"
+      with_items:
+        - br-tftp
+        - br-ironic-ipmi
+
+    - name: Configure ironic network variables
+      config_template:
+        src: "/etc/openstack_deploy/openstack_user_config.yml"
+        dest: "/etc/openstack_deploy/openstack_user_config.yml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+        config_overrides: "{{ ironic_network_config }}"
+        config_type: "yaml"
+        list_extend: true
+
+    - name: Configure ironic OSA variables
+      config_template:
+        src: "/etc/openstack_deploy/user_osa_variables_overrides.yml"
+        dest: "/etc/openstack_deploy/user_osa_variables_overrides.yml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+        config_overrides: "{{ ironic_osa_config }}"
+        config_type: "yaml"
+
+  vars:
+    ironic_network_config:
+      cidr_networks:
+        tftp: "172.29.232.0/22"
+        ironic-ipmi: "172.29.228.0/22"
+      used_ips:
+        - "172.29.232.1,172.29.232.50"
+        - "172.29.228.1,172.29.228.50"
+      global_overrides:
+        provider_networks:
+          - network:
+              container_bridge: "br-ironic-ipmi"
+              container_type: "veth"
+              container_interface: "eth_ipmi"
+              ip_from_q: "ironic-ipmi"
+              type: "raw"
+              group_binds:
+                - ironic-infra_hosts
+          - network:
+              container_bridge: "br-tftp"
+              container_type: "veth"
+              container_interface: "eth_tftp"
+              ip_from_q: "ironic-ipmi"
+              type: "flat"
+              net_name: "tftp"
+              ip_from_q: "tftp"
+              group_binds:
+                - neutron_linuxbridge_agent
+                - ironic_all
+    ironic_osa_config:
+      extra_lb_vip_addresses:
+        - "{{ external_lb_vip_address }}"
+      ironic_openstack_api_url: "{{ external_lb_vip_address }}:{{ ironic_service_port }}"
+      ironic_swift_endpoint: "{{ external_lb_vip_address }}:8080"
+      neutron_dhcp_config:
+        dhcp-option-force: "26,1500"
+        dhcp-ignore: "tag:!known"
+        log-facility: "/var/log/neutron/dnsmasq.log"
+      nova_scheduler_use_baremetal_filters: False
+      ironic_openstack_driver_list: "agent_ipmitool, fake"


### PR DESCRIPTION
This commit provides the steps required for gating to be able to
run tests against a fully configured ironic deployment.

(cherry picked from commit c83c2f243a14389c6ad6cac6f6ddda1430944d37)

Issue: [RI-72](https://rpc-openstack.atlassian.net/browse/RI-72)