### PR TITLE
RO-2439 Optimize AIO with one galera/rabbit node

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -194,13 +194,6 @@
         - name: nova.yml.aio
         - name: swift.yml.aio
         - name: ironic.yml.aio
-    openstack_user_config_overrides:
-      shared-infra_hosts:
-        aio1:
-          affinity:
-            galera_container: 3
-            rabbit_mq_container: 3
-          ip: 172.29.236.100
 
 - name: Execute the RPC-O AIO adjustments
   hosts: localhost


### PR DESCRIPTION
In OSA, we thoroughly test building three Galera nodes and three
RabbitMQ nodes, including upgrading both. The OSA AIO builds only
use one Galera/RabbitMQ node each to save time/resources since the
role tests are quite thorough.

It would make sense to use one Galera/RabbitMQ node each in RPC-O
AIO builds to save time and resources. This patch removes the
configuration override and allows the OSA defaults to be used.

Issue: [RO-2439](https://rpc-openstack.atlassian.net/browse/RO-2439)