### PR TITLE
RE-2451 Clone openstack-ansible in ansible-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ before_script:
 # the shallow clone that travis creates, then clones
 # the full repository
 install:
-  - git clone --recursive https://github.com/rcbops/rpc-openstack.git rcbops/rpc-openstack
+  - git clone https://github.com/rcbops/rpc-openstack.git rcbops/rpc-openstack
   - cd rcbops/rpc-openstack
   - "if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge && git checkout -qf FETCH_HEAD; else git checkout -qf $TRAVIS_COMMIT; fi"
+  - git submodule update --init
 
 script: tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,10 +45,15 @@ commands =
 
 [testenv:ansible-lint]
 commands =
-    bash -c "sed '/etc\/ansible/d' {toxinidir}/openstack-ansible/ansible-role-requirements.yml | tee -a {homedir}/openstack-ansible-role-requirements.yml; \
+    bash -c 'source {toxinidir}/scripts/functions.sh; \
+        test -d {toxinidir}/openstack-ansible || git clone https://git.openstack.org/openstack/openstack-ansible {toxinidir}/openstack-ansible; \
+        pushd {toxinidir}/openstack-ansible; \
+        git checkout "$OSA_RELEASE"; \
+        popd; \
+        sed "/etc\/ansible/d" {toxinidir}/openstack-ansible/ansible-role-requirements.yml | tee -a {homedir}/openstack-ansible-role-requirements.yml; \
         ansible-galaxy install -r {toxinidir}/ansible-role-requirements.yml; \
         ansible-galaxy install -r {homedir}/openstack-ansible-role-requirements.yml; \
-        {toxinidir}/scripts/linting-ansible.sh"
+        {toxinidir}/scripts/linting-ansible.sh'
 
 [testenv:release-script]
 commands = python -m unittest discover -s scripts -p test_release.py -v


### PR DESCRIPTION
In #2483, we drop the use of submodules but did not update tox.ini to
handle the clone of openstack-ansible.  The reason this passed the lint
check on #2483 is because it first checked out master, did a submodule
update, then checked out that commit and proceeded to run tests.  At
that point, the submodules had already been cloned and therefore
ansible-lint worked as expected.

This commit simply updates ansible-lint to clone openstack-ansible,
check out the correct commit, and then proceed as it did before.

Note that we also update how we handle submodules in .travis.yml.  This
isn't an issue in master for now (since we dropped submodules), but it
currently affects other branches since we checkout a differing commit
and then never update submodules.

Issue: [RE-2451](https://rpc-openstack.atlassian.net/browse/RE-2451)