### PR TITLE
RLM-207 Update rpc-maas SHA to use ping plugin

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -73,12 +73,6 @@ maas_keys:
   url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
   state: "present"
 
-# Influxdata
-maas_influxdata_repo: "{{ rpco_apt_repo }}"
-maas_influxdata_key:
-  id:  "{{ rpco_gpg_key_id }}"
-  url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
-
 # Grafana
 maas_grafana_repo: "{{ rpco_apt_repo }}"
 maas_grafana_key:

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -42,7 +42,7 @@ maas_target_alias: public0_v4
 maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled | default(false) }}"
 
 # MaaS pathing and versions
-maas_release: "1.0.0"
+maas_release: "74e83189a48f3b9ecd2eaff4a9a43625d346fecf"
 maas_venv: "/openstack/venvs/maas-{{ maas_release }}"
 maas_venv_bin: "{{ maas_venv }}/bin"
 


### PR DESCRIPTION
The override for `maas_influxdata_repo` is incorrect, rpc-maas is
looking for `maas_influxdata_repo.url` whereas the override provides
`maas_influxdata_repo.repo`. When this is corrected the telegraf package
is not found. These overrides are removed until telegraf is stored as an
artefact.

Instance monitoring for leapfrog upgrades makes use of the Telegraf ping
plugin. `maas_release` is updated to a SHA that support this
functionality.

Issue: [RLM-207](https://rpc-openstack.atlassian.net/browse/RLM-207)