### PR TITLE
RO-2428 Bump OSA SHA to head of Newton

### DIFF
--- a/group_vars/all/apt.yml
+++ b/group_vars/all/apt.yml
@@ -66,6 +66,7 @@ haproxy_gpg_keys: "{{ rpco_apt_gpg_keys }}"
 # RabbitMQ
 rabbitmq_install_method: "external_repo"
 rabbitmq_repo: "{{ rpco_apt_repo }}"
+rabbitmq_erlang_repo: "{{ rpco_apt_repo }}"
 rabbitmq_gpg_keys: "{{ rpco_apt_gpg_keys }}"
 
 # ceph_client wiring

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -55,9 +55,6 @@ nova_ram_allocation_ratio: 1.0
 #nova_cross_az_attach: False
 nova_console_type: novnc
 
-# RabbitMQ overrides
-rabbitmq_ulimit: 65535
-
 # Memcached overrides
 # https://github.com/rcbops/rpc-openstack/issues/1048
 # memcached_memory is calculated via https://github.com/openstack/openstack-ansible-memcached_server/blob/master/defaults/main.yml#L33

--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -60,6 +60,7 @@ aptly_miko_mapping:
       - "slushie-{{ rpc_release }}-uca-mitaka-updates-trusty"
       - "slushie-{{ rpc_release }}-mariadb-10.0-trusty"
       - "slushie-{{ rpc_release }}-percona-trusty"
+      - "slushie-{{ rpc_release }}-erlang-trusty"
       - "slushie-{{ rpc_release }}-haproxy-trusty"
       - "slushie-{{ rpc_release }}-rabbitmq-downloaded-packages-{{ rpc_release }}-ALL"
       - "slushie-{{ rpc_release }}-elastic-logstash-2.3-ALL"
@@ -74,6 +75,7 @@ aptly_miko_mapping:
       - "slushie-{{ rpc_release }}-uca-newton-updates-xenial"
       - "slushie-{{ rpc_release }}-mariadb-10.0-xenial"
       - "slushie-{{ rpc_release }}-percona-xenial"
+      - "slushie-{{ rpc_release }}-erlang-xenial"
       - "slushie-{{ rpc_release }}-rabbitmq-downloaded-packages-{{ rpc_release }}-ALL"
       - "slushie-{{ rpc_release }}-elastic-logstash-2.3-ALL"
       - "slushie-{{ rpc_release }}-elastic-kibana-4.5-ALL"
@@ -274,6 +276,40 @@ aptly_mirrors:
     state: "present"
     gpg:
       key: "6B73A36E6026DFCA"
+      server: "hkp://keyserver.ubuntu.com:80"
+      keyring: "trustedkeys.gpg"
+    create_flags:
+      - "-keyring='trustedkeys.gpg'"
+    update_flags:
+      - "-keyring='trustedkeys.gpg'"
+    do_update: "{{ aptly_mirror_do_updates }}"
+  # Erlang (used by RabbitMQ):
+  # Got the key from:
+  # wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+  # gpg --list-packets erlang_solutions.asc
+  - name: erlang-trusty
+    archive_url: https://packages.erlang-solutions.com/ubuntu
+    distribution: trusty
+    component1:
+      - contrib
+    state: "present"
+    gpg:
+      key: "D208507CA14F4FCA"
+      server: "hkp://keyserver.ubuntu.com:80"
+      keyring: "trustedkeys.gpg"
+    create_flags:
+      - "-keyring='trustedkeys.gpg'"
+    update_flags:
+      - "-keyring='trustedkeys.gpg'"
+    do_update: "{{ aptly_mirror_do_updates }}"
+  - name: erlang-xenial
+    archive_url: https://packages.erlang-solutions.com/ubuntu
+    distribution: xenial
+    component1:
+      - contrib
+    state: "present"
+    gpg:
+      key: "D208507CA14F4FCA"
       server: "hkp://keyserver.ubuntu.com:80"
       keyring: "trustedkeys.gpg"
     create_flags:


### PR DESCRIPTION
This patch bumps the OSA SHA to the head of the Newton branch.

    9b8f3ffd Update SHA for os_tempest
    dff42ad3 Switch to use ansible-hardening
    c351cdb8 Suppress curl warning w/shell module
    6d10e575 Fix LXC container start order

This one is important since it has the `openstack-ansible-security` > `ansible-hardening` changeover.