### PR TITLE
RO-2428 Bump RabbitMQ role SHA

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -18,3 +18,11 @@
   scm: git
   src: https://github.com/openstack/openstack-ansible-os_octavia.git
   version: f8c0f7689ecd9651b27a7bf58cbdac35e0c48793
+# NOTE(mhayden): This role was bumped early to fix two RPC-O issues:
+#   - RO-2428: RPC-O 14.x rabbitmq & erlang stability issue
+#   - RO-2438: Push RabbitMQ ulimit override upstream
+# Remove this once our OSA SHA bump includes this role.
+- name: rabbitmq_server
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-rabbitmq_server
+  version: f2d110a1fae658edfc790d6d1a00cf481f51e9f2

--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -55,9 +55,6 @@ nova_ram_allocation_ratio: 1.0
 #nova_cross_az_attach: False
 nova_console_type: novnc
 
-# RabbitMQ overrides
-rabbitmq_ulimit: 65535
-
 # Memcached overrides
 # https://github.com/rcbops/rpc-openstack/issues/1048
 # memcached_memory is calculated via https://github.com/openstack/openstack-ansible-memcached_server/blob/master/defaults/main.yml#L33

--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -39,3 +39,8 @@ octavia_git_repo: 'https://git.openstack.org/openstack/octavia'
 octavia_git_project_group: 'octavia_all'
 octavia_git_install_fragments: "venvwithindex=True&ignorerequirements=True"
 
+# RabbitMQ
+rabbitmq_install_method: "external_repo"
+rabbitmq_repo: "{{ rpco_apt_repo }}"
+rabbitmq_erlang_repo: "{{ rpco_apt_repo }}"
+rabbitmq_gpg_keys: "{{ rpco_apt_gpg_keys }}"

--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -74,6 +74,7 @@ aptly_miko_mapping:
       - "slushie-{{ rpc_release }}-uca-newton-updates-xenial"
       - "slushie-{{ rpc_release }}-mariadb-10.0-xenial"
       - "slushie-{{ rpc_release }}-percona-xenial"
+      - "slushie-{{ rpc_release }}-erlang-xenial"
       - "slushie-{{ rpc_release }}-rabbitmq-downloaded-packages-{{ rpc_release }}-ALL"
       - "slushie-{{ rpc_release }}-elastic-logstash-2.3-ALL"
       - "slushie-{{ rpc_release }}-elastic-kibana-4.5-ALL"
@@ -274,6 +275,25 @@ aptly_mirrors:
     state: "present"
     gpg:
       key: "6B73A36E6026DFCA"
+      server: "hkp://keyserver.ubuntu.com:80"
+      keyring: "trustedkeys.gpg"
+    create_flags:
+      - "-keyring='trustedkeys.gpg'"
+    update_flags:
+      - "-keyring='trustedkeys.gpg'"
+    do_update: "{{ aptly_mirror_do_updates }}"
+  # Erlang (used by RabbitMQ):
+  # Got the key from:
+  # wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+  # gpg --list-packets erlang_solutions.asc
+  - name: erlang-xenial
+    archive_url: https://packages.erlang-solutions.com/ubuntu
+    distribution: xenial
+    component1:
+      - contrib
+    state: "present"
+    gpg:
+      key: "D208507CA14F4FCA"
       server: "hkp://keyserver.ubuntu.com:80"
       keyring: "trustedkeys.gpg"
     create_flags:


### PR DESCRIPTION
This patch provides some temporary relief from RO-2428 until there is
an upstream release of OpenStack-Ansible's Newton branch that
includes the fix.

This also brings in the fix for RO-2438.

Issue: [RO-2428](https://rpc-openstack.atlassian.net/browse/RO-2428)