### PR TITLE
RLM-59 Bumps OA_OPS to bring in latest leapfrog fixes

### DIFF
--- a/scripts/leapfrog/ubuntu14-leapfrog.sh
+++ b/scripts/leapfrog/ubuntu14-leapfrog.sh
@@ -47,7 +47,7 @@ export OA_OPS_REPO=${OA_OPS_REPO:-'https://github.com/openstack/openstack-ansibl
 # Please bump the following when a patch for leapfrog is merged into osa-ops
 # If you are developping, just clone your ops repo into (by default)
 # /opc/rpc-leapfrog/openstack-ansible-ops
-export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'c19a606d58aa0533ca58c7f7ad8cf28a372224b1'}
+export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'16e5db982c04118584e25617e6d22343e10454ec'}
 # Instead of storing the debug's log of run in /tmp, we store it in an
 # folder that will get archived for gating logs
 export REDEPLOY_OA_FOLDER="${RPCO_DEFAULT_FOLDER}/openstack-ansible"


### PR DESCRIPTION
Bumps OS_OPS sha to bring in leapfrog fixes:

https://github.com/openstack/openstack-ansible-ops/commit/16e5db982c04118584e25617e6d22343e10454ec

Issue: [RLM-59](https://rpc-openstack.atlassian.net/browse/RLM-59)