### PR TITLE
Bump OSA SHA to head of Ocata

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -16,7 +16,7 @@
 ## Vars ----------------------------------------------------------------------
 
 # OSA SHA
-export OSA_RELEASE=${OSA_RELEASE:-"045c4c5601a7f1d2e63303c7420e9fd518704c4b"}
+export OSA_RELEASE=${OSA_RELEASE:-"27fbd63f21baa74319a273310d94e2c9477ae601"} # Head of stable/ocata as of 2017-09-20
 
 # Gating
 export BUILD_TAG=${BUILD_TAG:-}


### PR DESCRIPTION
This patch bumps the OSA SHA to the head of the Ocata branch.

    c6fa7d8b (HEAD, origin/stable/ocata) Remove urllib3/requests from requirements
    417406b5 Suppress curl warning w/shell module
    a9964643 Pin Shade to last known version
    1c580c3f Bump ceph-ansible to 2.2.11 tag
    bc2b1eb5 Fix LXC container start order
    aac4e020 Update role SHA's for online migration fixes
    d5048ca8 Correct cinder online migrations command
    9cb4ecc8 Update documentation redirects
    f2c5e891 Remove global pin for ldappool
    d27e24c1 Set serial to 100% for nova_compute
    add34f5b Update all SHAs for 15.1.9
    25becb3c Allow Keepalived to read haproxy pid file
    d5d2988a Test containerised cinder-volume
    bb71f16e Reduce CentOS AIO bootstrap pkg list
    3c348cbc Update the playbook serial settings
    7e5af2a9 Update lxc_* roles to include NB fixes
    74add88d Bootstrap Ansible fails if partial keypair exists
    289c2fb9 Remove repeated pip_install role execution
    14e8d1e7 Move rally_all.yml into utility_all.yml
    4d3ea009 Improve proxy vars in user_variables.yml
    ab0c0b98 Use LXC reverse proxy in OpenStack-CI
    997a37ae Update fastest-infra-wheel-mirror