### PR TITLE
RLM-207 Correct influxdb/grafana repo overrides

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -74,13 +74,19 @@ maas_keys:
   state: "present"
 
 # Influxdata
-maas_influxdata_repo: "{{ rpco_apt_repo }}"
+maas_influxdata_repo:
+  url: "{{ rpco_mirror_apt_deb_line }}"
+  filename: "{{ rpco_mirror_apt_filename }}"
+
 maas_influxdata_key:
   id:  "{{ rpco_gpg_key_id }}"
   url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
 
 # Grafana
-maas_grafana_repo: "{{ rpco_apt_repo }}"
+maas_grafana_repo:
+  url: "{{ rpco_mirror_apt_deb_line }}"
+  filename: "{{ rpco_mirror_apt_filename }}"
+
 maas_grafana_key:
   id:  "{{ rpco_gpg_key_id }}"
   url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"

--- a/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
@@ -73,6 +73,12 @@ maas_keys:
   url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
   state: "present"
 
+# Influxdata
+maas_influxdata_repo: "{{ rpco_apt_repo }}"
+maas_influxdata_key:
+  id:  "{{ rpco_gpg_key_id }}"
+  url: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
+
 # Grafana
 maas_grafana_repo: "{{ rpco_apt_repo }}"
 maas_grafana_key:


### PR DESCRIPTION
The data structure used in rpc-maas is different to
all the OSA repositories, so the standard data in
'rpco_apt_repo' does not work.

In this PR we revert the previous patch which removed
the configuration and we correct the overrides to ensure
that the right data structure is provided to make
use of the apt artifacts when executing the rpc-maas
playbooks.

Issue: [RLM-207](https://rpc-openstack.atlassian.net/browse/RLM-207)