### PR TITLE
RE-473 Downgrade pkgs to apt artifact versions

### DIFF
--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -71,6 +71,7 @@ popd
 # bootstrap-ansible script for putting together the apt artifacts.
 if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]] && apt_artifacts_available; then
   configure_apt_sources
+  downgrade_installed_packages
 fi
 
 # begin the bootstrap process


### PR DESCRIPTION
When using images which have unattended upgrades
enabled, or have been built using packages which
are more recent than the available apt artifacts
the builds fail in strange ways.

This patch implements a function which will try
to downgrade any packages installed on the
deployment host and not available in the apt
artifacts to the versions which are.

Issue: [RE-473](https://rpc-openstack.atlassian.net/browse/RE-473)