### PR TITLE
Make pre upgrade tasks kilo compatible

### DIFF
--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -12,6 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+- name: Gather openstack CLI version
+  shell: "source ~/openrc; openstack --version 2>&1"
+  args:
+    executable: /bin/bash
+  register: openstack_cli_version
+
+- name: Gather neutron CLI version
+  shell: "source ~/openrc; neutron --version 2>&1"
+  args:
+    executable: /bin/bash
+  register: neutron_cli_version
 
 - name: Check rabbit cluster status
   shell: "rabbitmqctl cluster_status"
@@ -49,6 +60,15 @@
   args:
     executable: /bin/bash
   register: orchestration_servicelist_result
+  when: openstack_cli_version.stdout.split('openstack')[1] >= "2.3.0"
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Gather heat service list
+  shell: "source ~/openrc; heat --insecure service-list"
+  args:
+    executable: /bin/bash
+  register: orchestration_servicelist_result
+  when: openstack_cli_version.stdout.split('openstack')[1] < "2.3.0"
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Gather openstack endpoint list
@@ -84,14 +104,14 @@
 - name: Obtain a list of neutron routers
   shell: |
     . {{ ansible_env.HOME }}/openrc
-    neutron router-list -f value --column id
+    neutron router-list -f table --column id |awk '/([A-Fa-f0-9]+\-)+[A-Fa-f0-9]+/ {print $2}'
   register: neutron_routers
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Check agent assigned to each neutron router
   shell: |
     . {{ ansible_env.HOME }}/openrc
-    neutron l3-agent-list-hosting-router -f value --column host {{ item }}
+    neutron l3-agent-list-hosting-router -f table --column host {{ item }} |awk '/([A-Fa-f0-9]+\-)+[A-Fa-f0-9]+/ {print $2}'
   with_items: "{{ neutron_routers.stdout_lines }}"
   register: neutron_routers_agents
   delegate_to: "{{ groups['utility_all'][0] }}"

--- a/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
+++ b/rpcd/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Rotate openstack aggregate logs
-  shell: 'find /openstack/log -name *\.log -size 64M -ls -exec gzip --suffix -$$.gz {} \;'
+  shell: 'find /openstack/log -name \*\.log -size 64M -ls -exec gzip --suffix -$$.gz {} \;'
   register: large_logs
   delegate_to: "{{ item }}"
   with_items: "{{ groups['hosts'] }}"


### PR DESCRIPTION
In a leapfrog case, the pre upgrade tasks are
executed against a Kilo environment.
The tasks are now compatible with the older
python-openstack and neutron client.

This is a back port of 274d9d98d0e8903c5a1c48bdf955eb5f689d684f

Issue: [RLM-64](https://rpc-openstack.atlassian.net/browse/RLM-64)