### PR TITLE
RO-2479 Correct git repo preparation for OSA

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -16,7 +16,7 @@
 ## Vars ----------------------------------------------------------------------
 
 # OSA SHA
-export OSA_RELEASE=${OSA_RELEASE:-"045c4c5601a7f1d2e63303c7420e9fd518704c4b"}
+export OSA_RELEASE=${OSA_RELEASE:-"27fbd63f21baa74319a273310d94e2c9477ae601"} # Head of stable/ocata as of 2017-09-20
 
 # Gating
 export BUILD_TAG=${BUILD_TAG:-}


### PR DESCRIPTION
The current preparation process does not work when
executing it on an existing rpc-openstack checkout.
It tries to use a submodule folder moved to a
different location, then updating it as a normal
git repo. This process fails.

If the user then tries to switch back to a different
branch which does have the submodule, it no longer
works properly either, leaving both repositories
broken.

This patch simplifies the process and prevents it
making any changes or doing a git fetch if the SHA
for openstack-ansible is already correct.

Issue: [RO-2479](https://rpc-openstack.atlassian.net/browse/RO-2479)