### PR TITLE
RO-2540 Add OSA git checkout to py_pkgs lookup

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
@@ -25,7 +25,7 @@ openstack_release: "{{ rpc_release }}"
 # This var lists the locations for the package builder to
 # look for files that contain pip packages and git repos to build from
 pkg_locations:
-  - ../
+  - /opt/openstack-ansible
   - /etc/ansible/roles
   - /etc/openstack_deploy
   - /opt/rpc-openstack/rpcd

--- a/scripts/artifacts-building/git/openstackgit-update.yml
+++ b/scripts/artifacts-building/git/openstackgit-update.yml
@@ -33,6 +33,7 @@
         msg: "Looking up repositories"
       with_py_pkgs:
         - "{{ working_dir }}/"
+        - "/opt/openstack-ansible"
         - "/etc/ansible/roles"
       register: local_packages
 


### PR DESCRIPTION
In 4d12456 the use of a submodule was removed and
replaced with a symlink in the same location. The
py_pkgs lookup for the git artifact preparation
no longer works properly in this configuration as
the checkout is not in the expected place and/or
the lookup appears not to traverse the symlink.

This patch ensures that the /opt/openstack-ansible
folder is added to the list given to the lookup.
The path set is forced by the ansible bootstrap
script, regardless of where the rpc-openstack
checkout is.

Issue: [RO-2540](https://rpc-openstack.atlassian.net/browse/RO-2540)