### PR TITLE
RE-196 Add script for generating release notes

### DIFF
--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+
+# This script is run within a docker container to generate release notes.
+
+url=$(git remote -v |awk '/origin.*fetch/{print $2}')
+rpc-differ --debug -r "$url" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
+pandoc --from rst --to markdown_github < notes.rst > notes.md

--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y python-pip build-essential python-dev libssl-dev
+RUN apt-get install -y libffi-dev
+RUN apt-get install -y sudo
+RUN apt-get install -y git-core
+RUN useradd jenkins --shell /bin/bash --create-home --uid 500
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN apt-get install -y pandoc
+
+# use released versions of the differs when they are available.
+RUN pip install rpc_differ==0.3.0 reno==2.5.0
+RUN pip install git+https://github.com/major/osa_differ@0.3.1
+
+RUN rpc-differ --debug --update master master
+COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
+CMD /generate_release_notes.sh

--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+# This script is called by Jenkins to generate release notes.
+
+# The resulting notes must be written to $WORKSPACE/artifacts/release_notes
+
+# It runs in docker as it requires pandoc which is an apt package, and
+# apt packages can't be installed on shared Jenkins slaves.
+
+docker_tag="${BUILD_TAG:-rpco_reno_$(date +%d%m%Y_%H%M)}"
+docker_tag_filtered="$(tr A-Z a-z <<<$docker_tag |tr -dc 'a-z0-9-_.')"
+docker build \
+  -f \
+  gating/generate_release_notes/release_notes_dockerfile \
+  -t $docker_tag_filtered .
+docker run \
+  -e "PREVIOUS_TAG=${RE_HOOK_PREVIOUS_VERSION}" \
+  -e "NEW_TAG=${RE_HOOK_VERSION}" \
+  -v "$(pwd)":"$(pwd)" \
+  -w "$(pwd)" \
+  $docker_tag_filtered
+
+cp notes.md "${RE_HOOK_RELEASE_NOTES}"


### PR DESCRIPTION
This will be used by the RE release job, to create the release notes.
These notes will be used in mail notifications and the body of the
github release.

Issue: [RE-196](https://rpc-openstack.atlassian.net/browse/RE-196)