### PR TITLE
RLM-217 Fix MaaS Ceph monitoring

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
@@ -42,9 +42,12 @@ maas_target_alias: public0_v4
 maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled | default(false) }}"
 
 # MaaS pathing and versions
-maas_release: master
+maas_release: "74e83189a48f3b9ecd2eaff4a9a43625d346fecf"
 maas_venv: "/openstack/venvs/maas-{{ maas_release }}"
 maas_venv_bin: "{{ maas_venv }}/bin"
 
 # Allow all of the host machiens running maas agents to restart once at the end of a maas playbook.
 maas_restart_independent: false
+
+# Enable MaaS testing of Ceph compatible Liberty
+maas_rpc_legacy_ceph: true


### PR DESCRIPTION
Liberty has been consuming the HEAD of rpc-maas master, changes to that
branch earlier in the month have broken MaaS Ceph monitoring and Liberty
Ceph jobs.

This commit pins to a specific SHA and enables support in rpc-maas for
Liberty Ceph deployments.

Related-bug: https://rpc-openstack.atlassian.net/browse/RLM-207

Issue: [RLM-217](https://rpc-openstack.atlassian.net/browse/RLM-217)