### PR TITLE
RO-2469: Bumping sha to top of rcp-ops newton - cherry pick from newton

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -13,7 +13,7 @@
 - name: rcbops_openstack-ops
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
-  version: ef9068d8cde4fd8ea3ea83ea0b026137eb253233
+  version: dfc2180e9bf28c8f59baca2a233db2a726b97bcb
 - name: os_octavia
   scm: git
   src: https://github.com/openstack/openstack-ansible-os_octavia.git


### PR DESCRIPTION
JIRA link: https://rpc-openstack.atlassian.net/browse/RO-2469 -- the current sha will overwrite the arp-utils so Floating IPs won't work on a new install of rpc-o. This sha is taking top of the openstack-ops package per  @BjoernT  suggestion

Issue: [RO-2469](https://rpc-openstack.atlassian.net/browse/RO-2469)