### PR TITLE
 RE-2451 Clone openstack-ansible in ansible-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ before_script:
 # the shallow clone that travis creates, then clones
 # the full repository
 install:
-  - git clone --recursive https://github.com/rcbops/rpc-openstack.git rcbops/rpc-openstack
+  - git clone https://github.com/rcbops/rpc-openstack.git rcbops/rpc-openstack
   - cd rcbops/rpc-openstack
   - "if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge && git checkout -qf FETCH_HEAD; else git checkout -qf $TRAVIS_COMMIT; fi"
+  - git submodule update --init
 
 script: tox
 


### PR DESCRIPTION
 In #2483, we drop the use of submodules but did not update tox.ini to
 handle the clone of openstack-ansible.  The reason this passed the lint
 check on #2483 is because it first checked out master, did a submodule
 update, then checked out that commit and proceeded to run tests.  At
 that point, the submodules had already been cloned and therefore
 ansible-lint worked as expected.

 This commit simply updates ansible-lint to clone openstack-ansible,
 check out the correct commit, and then proceed as it did before.

 Note that we also update how we handle submodules in .travis.yml.  This
 isn't an issue in master for now (since we dropped submodules), but it
 currently affects other branches since we checkout a differing commit
 and then never update submodules.

(cherry picked from commit b8a749ab99962c40a1b129921c30a8d695aa76a0)

Issue: [RE-2451](https://rpc-openstack.atlassian.net/browse/RE-2451)