### PR TITLE
RLM-207 Update rpc-maas SHA

### DIFF
--- a/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_rpcm_variables.yml
@@ -42,7 +42,7 @@ maas_target_alias: public0_v4
 maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled | default(false) }}"
 
 # MaaS pathing and versions
-maas_release: master
+maas_release: "74e83189a48f3b9ecd2eaff4a9a43625d346fecf"
 maas_venv: "/openstack/venvs/maas-{{ maas_release }}"
 maas_venv_bin: "{{ maas_venv }}/bin"
 


### PR DESCRIPTION
`maas_release` is updated to a match the SHA used by newton and master.

(cherry picked from commit 7a1ad78e05bbc1a4f3aad773983e4efb3b7e498f)

Issue: [RLM-207](https://rpc-openstack.atlassian.net/browse/RLM-207)