### PR TITLE
RLM-219 Reduce memory usage in AIOs

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2015, Rackspace US, Inc.
+# Copyright 2017, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,85 @@
               sha256: "e137062a4dfbb4c225971b67781bc52183d14517170e16a3841d16f962ae7470"
             - url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-uec.tar.gz"
               sha256: "32ca0867f4099f33537625a2fcb1bc5fea1621c62833cdc58eaef2f93e10f154"
-
+          ## Galera settings
+          galera_innodb_buffer_pool_size: 16M
+          galera_innodb_log_buffer_size: 4M
+          galera_wsrep_provider_options:
+           - { option: "gcache.size", value: "4M" } 
+          ### Set workers for all services to optimise memory usage
+          repo_nginx_threads: 2
+          keystone_httpd_mpm_start_servers: 2
+          keystone_httpd_mpm_min_spare_threads: 1
+          keystone_httpd_mpm_max_spare_threads: 2
+          keystone_httpd_mpm_thread_limit: 2
+          keystone_httpd_mpm_thread_child: 1
+          keystone_wsgi_threads: 1
+          keystone_wsgi_processes_max: 2
+          barbican_wsgi_processes: 2
+          barbican_wsgi_threads: 1
+          cinder_wsgi_processes_max: 2
+          cinder_wsgi_threads: 1
+          cinder_wsgi_buffer_size: 16384
+          cinder_osapi_volume_workers_max: 2
+          glance_api_threads_max: 2
+          glance_api_threads: 1
+          glance_api_workers: 1
+          glance_registry_workers: 1
+          nova_wsgi_threads: 1
+          nova_wsgi_processes_max: 2
+          nova_wsgi_processes: 2
+          nova_wsgi_buffer_size: 16384
+          nova_api_threads_max: 2
+          nova_api_threads: 1
+          nova_osapi_compute_workers: 1
+          nova_conductor_workers: 1
+          nova_metadata_workers: 1
+          neutron_rpc_workers: 1
+          neutron_metadata_workers: 1
+          neutron_api_workers: 1
+          neutron_api_threads_max: 2
+          neutron_api_threads: 2
+          neutron_num_sync_threads: 1
+          heat_api_workers: 1
+          heat_api_threads_max: 2
+          heat_api_threads: 1
+          heat_wsgi_threads: 1
+          heat_wsgi_processes_max: 2
+          heat_wsgi_processes: 1
+          heat_wsgi_buffer_size: 16384
+          horizon_wsgi_processes: 1
+          horizon_wsgi_threads: 1
+          horizon_wsgi_threads_max: 2
+          ceilometer_notification_workers_max: 2
+          ceilometer_notification_workers: 1
+          aodh_wsgi_threads: 1
+          aodh_wsgi_processes_max: 2
+          aodh_wsgi_processes: 1
+          gnocchi_wsgi_threads: 1
+          gnocchi_wsgi_processes_max: 2
+          gnocchi_wsgi_processes: 1
+          swift_account_server_replicator_workers: 1
+          swift_server_replicator_workers: 1
+          swift_object_replicator_workers: 1
+          swift_account_server_workers: 1
+          swift_container_server_workers: 1
+          swift_object_server_workers: 1
+          swift_proxy_server_workers_max: 2
+          swift_proxy_server_workers_not_capped: 1
+          swift_proxy_server_workers_capped: 1
+          swift_proxy_server_workers: 1
+          ironic_wsgi_threads: 1
+          ironic_wsgi_processes_max: 2
+          ironic_wsgi_processes: 1
+          trove_api_workers_max: 2
+          trove_api_workers: 1
+          trove_conductor_workers_max: 2
+          trove_conductor_workers: 1
+          trove_wsgi_threads: 1
+          trove_wsgi_processes_max: 2
+          trove_wsgi_processes: 1
+          sahara_api_workers_max: 2
+          sahara_api_workers: 1
 
     # migrated from rpc-gating/playbooks/vars/all.yml
     - name: Set gating overrides fact

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -47,22 +47,11 @@
           keystone_httpd_mpm_max_spare_threads: 2
           keystone_httpd_mpm_thread_limit: 2
           keystone_httpd_mpm_thread_child: 1
-          keystone_wsgi_threads: 1
-          keystone_wsgi_processes_max: 2
-          barbican_wsgi_processes: 2
-          barbican_wsgi_threads: 1
-          cinder_wsgi_processes_max: 2
-          cinder_wsgi_threads: 1
-          cinder_wsgi_buffer_size: 16384
           cinder_osapi_volume_workers_max: 2
           glance_api_threads_max: 2
           glance_api_threads: 1
           glance_api_workers: 1
           glance_registry_workers: 1
-          nova_wsgi_threads: 1
-          nova_wsgi_processes_max: 2
-          nova_wsgi_processes: 2
-          nova_wsgi_buffer_size: 16384
           nova_api_threads_max: 2
           nova_api_threads: 1
           nova_osapi_compute_workers: 1
@@ -77,21 +66,11 @@
           heat_api_workers: 1
           heat_api_threads_max: 2
           heat_api_threads: 1
-          heat_wsgi_threads: 1
-          heat_wsgi_processes_max: 2
-          heat_wsgi_processes: 1
-          heat_wsgi_buffer_size: 16384
           horizon_wsgi_processes: 1
           horizon_wsgi_threads: 1
           horizon_wsgi_threads_max: 2
           ceilometer_notification_workers_max: 2
           ceilometer_notification_workers: 1
-          aodh_wsgi_threads: 1
-          aodh_wsgi_processes_max: 2
-          aodh_wsgi_processes: 1
-          gnocchi_wsgi_threads: 1
-          gnocchi_wsgi_processes_max: 2
-          gnocchi_wsgi_processes: 1
           swift_account_server_replicator_workers: 1
           swift_server_replicator_workers: 1
           swift_object_replicator_workers: 1
@@ -102,16 +81,10 @@
           swift_proxy_server_workers_not_capped: 1
           swift_proxy_server_workers_capped: 1
           swift_proxy_server_workers: 1
-          ironic_wsgi_threads: 1
-          ironic_wsgi_processes_max: 2
-          ironic_wsgi_processes: 1
           trove_api_workers_max: 2
           trove_api_workers: 1
           trove_conductor_workers_max: 2
           trove_conductor_workers: 1
-          trove_wsgi_threads: 1
-          trove_wsgi_processes_max: 2
-          trove_wsgi_processes: 1
           sahara_api_workers_max: 2
           sahara_api_workers: 1
 


### PR DESCRIPTION
This adds a few optimizations for Galera and reduces the number of threads and workers in AIOs to help alleviate memory pressure and allow failing Tempest tests to pass.

Will backport this to Newton branch as well.

Issue: [RLM-219](https://rpc-openstack.atlassian.net/browse/RLM-219)