### PR TITLE
RLM-216 Remove Horizon logo files variable

### DIFF
--- a/scripts/leapfrog/pre_leap.sh
+++ b/scripts/leapfrog/pre_leap.sh
@@ -34,3 +34,15 @@ pushd $OSA_PATH
         exit 1
     fi
 popd
+
+# Remove horizon static files variables from user_variables.yml as this is now
+# maintained in group_vars.
+if grep '^rackspace_static_files_folder\:' /etc/openstack_deploy/user_variables.yml; then
+  sed -i '/^rackspace_static_files_folder:.*/d' /etc/openstack_deploy/user_variables.yml
+fi
+
+# Remove horizon_custom_uploads block from user_variables.yml as this is maintained in
+# group_vars
+if grep '^horizon_custom_uploads\:' /etc/openstack_deploy/user_variables.yml; then
+  sed -i '/horizon_custom_uploads:/,/src:.*logo-splash.png/d' /etc/openstack_deploy/user_variables.yml
+fi


### PR DESCRIPTION
The location of the rackspace_static_files_folder has changed so update variable to reflect that before the leap.

There's no version detection at this point in the process, but it's a relatively minor change that could be reverted and more than likely if the script is being run, the intent is to forge ahead.

Issue: [RLM-216](https://rpc-openstack.atlassian.net/browse/RLM-216)