### PR TITLE
RE-724 Implement pre_merge_test hook (kilo)

### DIFF
--- a/gating/pre_merge_test/post
+++ b/gating/pre_merge_test/post
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+## Shell Opts ----------------------------------------------------------------
+
+set -e -u -x
+set -o pipefail
+
+## Vars ----------------------------------------------------------------------
+
+# These vars are set by the CI environment, but are given defaults
+# here to cater for situations where someone is executing the test
+# outside of the CI environment.
+export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
+export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
+
+## Functions -----------------------------------------------------------------
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
+## Main ----------------------------------------------------------------------
+
+# Copy the tempest results to the job results folder
+mkdir -p ${RE_HOOK_RESULT_DIR}
+find /var/lib/lxc/*utility*/ -type f -name 'tempest_results.xml' -exec cp {} ${RE_HOOK_RESULT_DIR}/ \;
+find /opt/kibana-selenium -type f -name 'nosetests.xml' -exec cp {} ${RE_HOOK_RESULT_DIR}/ \;
+
+# Copy the job artifacts to the job artifacts folder
+export RSYNC_CMD="rsync --archive --safe-links --ignore-errors --quiet --no-perms --no-owner --no-group"
+export RSYNC_ETC_CMD="${RSYNC_CMD} --no-links --exclude selinux/"
+
+echo "#### BEGIN LOG COLLECTION ###"
+mkdir -vp \
+    "${RE_HOOK_ARTIFACT_DIR}/logs/host" \
+    "${RE_HOOK_ARTIFACT_DIR}/logs/openstack" \
+    "${RE_HOOK_ARTIFACT_DIR}/etc/host" \
+    "${RE_HOOK_ARTIFACT_DIR}/etc/openstack" \
+    "${RE_HOOK_ARTIFACT_DIR}/kibana"
+
+# Copy the kibana-selenium screen captures
+${RSYNC_CMD} /opt/kibana-selenium/*.png "${RE_HOOK_ARTIFACT_DIR}/kibana/" || true
+
+# Copy the host and container log files
+${RSYNC_CMD} /var/log/ "${RE_HOOK_ARTIFACT_DIR}/logs/host" || true
+if [ -d "/openstack/log" ]; then
+  ${RSYNC_CMD} /openstack/log/ "${RE_HOOK_ARTIFACT_DIR}/logs/openstack" || true
+fi
+
+# Copy the host /etc directory
+${RSYNC_ETC_CMD} /etc/ "${RE_HOOK_ARTIFACT_DIR}/etc/host/" || true
+
+# Loop over each container and archive its /etc directory
+if which lxc-ls &> /dev/null; then
+  for CONTAINER_NAME in `lxc-ls -1`; do
+    CONTAINER_PID=$(lxc-info -p -n ${CONTAINER_NAME} | awk '{print $2}')
+    ETC_DIR="/proc/${CONTAINER_PID}/root/etc/"
+    ${RSYNC_ETC_CMD} ${ETC_DIR} "${RE_HOOK_ARTIFACT_DIR}/etc/openstack/${CONTAINER_NAME}/" || true
+  done
+fi
+
+echo "#### END LOG COLLECTION ###"

--- a/gating/pre_merge_test/pre
+++ b/gating/pre_merge_test/pre
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+## Shell Opts ----------------------------------------------------------------
+
+set -e -u -x
+set -o pipefail
+
+## Vars ----------------------------------------------------------------------
+export KIBANA_SELENIUM_REPO="https://github.com/rcbops-qe/kibana-selenium"
+export KIBANA_SELENIUM_BRANCH="kilo"
+
+## Main ----------------------------------------------------------------------
+
+# If the current folder's basename is rpc-openstack then we assume
+# that it is the root of the git clone. If the git clone is not in
+# /opt then we symlink the current folder there so that all the
+# rpc-openstack scripts work as expected.
+if [[ "$(basename ${PWD})" == "rpc-openstack" ]]; then
+  if [[ "${PWD}" != "/opt/rpc-openstack" ]]; then
+    ln -sfn ${PWD} /opt/rpc-openstack
+  fi
+fi
+
+# Clone the kibana-selenium git repository
+git clone -b ${KIBANA_SELENIUM_BRANCH} ${KIBANA_SELENIUM_REPO} /opt/kibana-selenium
+
+# Prepare for Kibana Selenium Tests
+cd /opt/kibana-selenium
+
+# The phantomjs package on 16.04 is buggy, see:
+# https://github.com/ariya/phantomjs/issues/14900
+# https://bugs.launchpad.net/ubuntu/+source/phantomjs/+bug/1578444
+#apt-get install -y phantomjs
+apt-get install -y fontconfig
+wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+if [[ ! -d ".venv" ]]; then
+  pip install virtualenv
+  virtualenv .venv
+fi
+
+# Work around https://github.com/pypa/virtualenv/issues/1029
+export VIRTUAL_ENV_DISABLE_PROMPT=true
+
+set +x; source .venv/bin/activate; set -x
+
+if [ -f ~/.pip/pip.conf ]; then
+  mv ~/.pip/pip.conf ~/.pip/pip.conf.bak
+  pip install -r requirements.txt
+  mv ~/.pip/pip.conf.bak ~/.pip/pip.conf
+else
+  pip install -r requirements.txt
+fi

--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+## Shell Opts ----------------------------------------------------------------
+
+set -e -u -x
+set -o pipefail
+
+## Display environment
+echo "+-------------------- ENV VARS --------------------+"
+env
+echo "+-------------------- ENV VARS --------------------+"
+
+## Vars ----------------------------------------------------------------------
+export DEPLOY_AIO="yes"
+export TARGET="${TARGET:-aio}"
+export TRIGGER="${TRIGGER:-pr}"
+
+# These vars are set by the CI environment, but are given defaults
+# here to cater for situations where someone is executing the test
+# outside of the CI environment.
+export RE_JOB_NAME="${RE_JOB_NAME:-}"
+export RE_JOB_IMAGE="${RE_JOB_IMAGE:-}"
+export RE_JOB_SCENARIO="${RE_JOB_SCENARIO:-swift}"
+export RE_JOB_ACTION="${RE_JOB_ACTION:-deploy}"
+export RE_JOB_FLAVOR="${RE_JOB_FLAVOR:-}"
+export RE_JOB_TRIGGER="${RE_JOB_TRIGGER:-PR}"
+export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
+export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
+
+## Functions -----------------------------------------------------------------
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
+## Main ----------------------------------------------------------------------
+
+# Set the appropriate scenario variables
+if [[ "${RE_JOB_SCENARIO}" == "ceph" ]]; then
+  export DEPLOY_CEPH="yes"
+  export DEPLOY_SWIFT="no"
+fi
+
+# Run the deployment script
+cd ${BASE_DIR}
+source ${BASE_DIR}/scripts/deploy.sh
+
+# Install tempest
+cd ${BASE_DIR}/rpcd/playbooks
+openstack-ansible ${BASE_DIR}/scripts/run_tempest.yml --skip-tags tempest_execute_tests
+
+# Execute tempest tests (retry if it fails)
+openstack-ansible ${BASE_DIR}/scripts/run_tempest.yml --tags tempest_execute_tests -vv ||\
+  openstack-ansible ${BASE_DIR}/scripts/run_tempest.yml --tags tempest_execute_tests -vv
+
+# Execute Kibana Selenium Tests
+cd /opt/kibana-selenium
+
+# Work around https://github.com/pypa/virtualenv/issues/1029
+export VIRTUAL_ENV_DISABLE_PROMPT=true
+
+set +x; source .venv/bin/activate; set -x
+
+export PYTHONPATH=$(pwd)
+export PATH=$PATH:./phantomjs-2.1.1-linux-x86_64/bin
+
+# Remove any existing screenshots from old runs
+rm -f *.png
+export PASSWORD=$(grep -Ir kibana_password /etc/openstack_deploy/ | tail -1 | sed 's|.*:||')
+
+python conf-gen.py --secure --password $PASSWORD \
+  --vip-file /etc/openstack_deploy/openstack_user_config.yml
+
+nosetests -sv --with-xunit testrepo/kibana/kibana.py


### PR DESCRIPTION
This patch implements the RPC Release Engineering pre_merge_hook
as documented in [1] making use of the existing job definition
in the rpc-gating repo.

For the most part it intentionally does not change how the job
is executed - it is meant to be a simple transfer of all logic
from rpc-gating into the rpc-openstack repository so that the
RPC-O team can own the entire test execution in a branched
repository.

The job which uses this hook is defined in https://github.com/rcbops/rpc-gating/pull/462

[1] https://rpc-openstack.atlassian.net/wiki/spaces/RE/pages/19005457/RE+for+Projects

Issue: [RE-724](https://rpc-openstack.atlassian.net/browse/RE-724)