### PR TITLE
RE-621 Use repo URL env var with rpc-differ

### DIFF
--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -2,6 +2,5 @@
 
 # This script is run within a docker container to generate release notes.
 
-url=$(git remote -v |awk '/origin.*fetch/{print $2}')
-rpc-differ --debug -r "$url" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
+rpc-differ --debug -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
 pandoc --from rst --to markdown_github < notes.rst > notes.md

--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -16,6 +16,7 @@ docker build \
 docker run \
   -e "PREVIOUS_TAG=${RE_HOOK_PREVIOUS_VERSION}" \
   -e "NEW_TAG=${RE_HOOK_VERSION}" \
+  -e "REPO_URL=${RE_HOOK_REPO_HTTP_URL}" \
   -v "$(pwd)":"$(pwd)" \
   -w "$(pwd)" \
   $docker_tag_filtered


### PR DESCRIPTION
This change removes the need to inspect the local repo by using the
explicitly provided env var `RE_HOOK_REPO_HTTP_URL`.

(cherry picked from commit 9c841fdeeaf40a7ed2370f923ed6ac96e16cc0c5)

Issue: [RE-621](https://rpc-openstack.atlassian.net/browse/RE-621)