### PR TITLE
RE-622 Update osa-differ to fix rpc-differ links

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,9 +8,8 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-# use released versions of the differs when they are available.
 RUN pip install rpc_differ==0.3.0 reno==2.5.1
-RUN pip install git+https://github.com/major/osa_differ@0.3.1
+RUN pip install git+https://github.com/major/osa_differ@0.3.2
 
 RUN rpc-differ --debug --update master master
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh


### PR DESCRIPTION
Updating osa-differ ensures that the report, produced by rpc-differ,
includes valid links when a GitHub URL, used by the tool, ends with
`".git"`.

Test release with working links: https://github.com/wherenoworg/rpc-openstack/releases/tag/r987.654.3213 created by https://rpc.jenkins.cit.rackspace.net/job/RE-Release/98

Issue: [RE-622](https://rpc-openstack.atlassian.net/browse/RE-622)