### PR TITLE
RLM-54 Exclude ES re-deploy from post leap stage

### DIFF
--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+
+# This script is run within a docker container to generate release notes.
+
+url=$(git remote -v |awk '/origin.*fetch/{print $2}')
+rpc-differ --debug -r "$url" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
+pandoc --from rst --to markdown_github < notes.rst > notes.md

--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -2,6 +2,5 @@
 
 # This script is run within a docker container to generate release notes.
 
-url=$(git remote -v |awk '/origin.*fetch/{print $2}')
-rpc-differ --debug -r "$url" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
+rpc-differ --debug -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
 pandoc --from rst --to markdown_github < notes.rst > notes.md

--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y python-pip build-essential python-dev libssl-dev
+RUN apt-get install -y libffi-dev
+RUN apt-get install -y sudo
+RUN apt-get install -y git-core
+RUN useradd jenkins --shell /bin/bash --create-home --uid 500
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN apt-get install -y pandoc
+
+# use released versions of the differs when they are available.
+RUN pip install rpc_differ==0.3.0 reno==2.5.0
+RUN pip install git+https://github.com/major/osa_differ@0.3.1
+
+RUN rpc-differ --debug --update master master
+COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
+CMD /generate_release_notes.sh

--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -16,6 +16,7 @@ docker build \
 docker run \
   -e "PREVIOUS_TAG=${RE_HOOK_PREVIOUS_VERSION}" \
   -e "NEW_TAG=${RE_HOOK_VERSION}" \
+  -e "REPO_URL=${RE_HOOK_REPO_HTTP_URL}" \
   -v "$(pwd)":"$(pwd)" \
   -w "$(pwd)" \
   $docker_tag_filtered

--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+# This script is called by Jenkins to generate release notes.
+
+# The resulting notes must be written to $WORKSPACE/artifacts/release_notes
+
+# It runs in docker as it requires pandoc which is an apt package, and
+# apt packages can't be installed on shared Jenkins slaves.
+
+docker_tag="${BUILD_TAG:-rpco_reno_$(date +%d%m%Y_%H%M)}"
+docker_tag_filtered="$(tr A-Z a-z <<<$docker_tag |tr -dc 'a-z0-9-_.')"
+docker build \
+  -f \
+  gating/generate_release_notes/release_notes_dockerfile \
+  -t $docker_tag_filtered .
+docker run \
+  -e "PREVIOUS_TAG=${RE_HOOK_PREVIOUS_VERSION}" \
+  -e "NEW_TAG=${RE_HOOK_VERSION}" \
+  -v "$(pwd)":"$(pwd)" \
+  -w "$(pwd)" \
+  $docker_tag_filtered
+
+cp notes.md "${RE_HOOK_RELEASE_NOTES}"

--- a/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
+++ b/rpcd/playbooks/roles/elasticsearch/tasks/upgrade_elasticsearch_pre.yml
@@ -231,7 +231,7 @@
     - elasticsearch-reindex
 
 - name: Monitor reindexing process
-  shell: /opt/reindex-liberty.py --host "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}" --monitor --continuous
+  shell: /opt/reindex-liberty.py --host "{{ hostvars[groups['elasticsearch_container'][0]]['container_address'] }}" --monitor --continuous --verbose
   async: 259200
   poll: 5
   delegate_to: "{{ groups['elasticsearch_all'][0] }}"

--- a/scripts/leapfrog/post_leap.sh
+++ b/scripts/leapfrog/post_leap.sh
@@ -29,6 +29,8 @@ if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/deploy-rpc.complete" ]]; then
     # TODO(remove the following hack to restart the neutron agents, when fixed upstream)
     ansible -m shell -a "restart neutron-linuxbridge-agent" nova_compute -i /opt/rpc-openstack/openstack-ansible/playbooks/inventory/dynamic_inventory.py
     openstack-ansible ${RPCO_DEFAULT_FOLDER}/scripts/leapfrog/playbooks/remove-old-agents-from-maas.yml
+    # TO-DO exclude Elasticsearch, upgrade it after leap
+    sed -i "s/- include: elasticsearch.yml$/#- include: elasticsearch.yml/" ${RPCO_DEFAULT_FOLDER}/rpcd/playbooks/setup-logging.yml
     . ${RPCO_DEFAULT_FOLDER}/scripts/deploy-rpc-playbooks.sh
   popd
   log "deploy-rpc" "ok"


### PR DESCRIPTION
Our goal is to make all ES logs are kept and barely changed in leap.
So we are supposed to separate Elasticsearch upgrade from whole leap
ugprade for now, because it needs pre-requisite operations both on ES
container and logstash container. For ease sake, we make ES ugprade into
post stage of leapfrog upgrade. And next to-do is integrating these step
back to leapfrog post ugprade script again.

Issue: [RE-621](https://rpc-openstack.atlassian.net/browse/RE-621)