### PR TITLE
RE-360 Include Reno notes in release notes

### DIFF
--- a/gating/generate_release_notes/generate_commit_diff_notes.sh
+++ b/gating/generate_release_notes/generate_commit_diff_notes.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+
+rpc-differ --debug -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file diff_notes.rst
+pandoc --from rst --to markdown_github < diff_notes.rst > diff_notes.md

--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -2,5 +2,6 @@
 
 # This script is run within a docker container to generate release notes.
 
-rpc-differ --debug -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file notes.rst
-pandoc --from rst --to markdown_github < notes.rst > notes.md
+/generate_commit_diff_notes.sh
+/generate_reno_report.sh $NEW_TAG reno_report.md
+cat reno_report.md diff_notes.md > all_notes.md

--- a/gating/generate_release_notes/generate_reno_report.sh
+++ b/gating/generate_release_notes/generate_reno_report.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -x
+
+release=${1}
+out_file=${2}
+err_file=${out_file}.err
+rst_file=${out_file}.rst
+
+reno report --branch ${release} --version ${release} --no-show-source --output ${rst_file} &> ${err_file}
+return_code=$?
+cat $err_file
+
+if [[ ${return_code} != 0 ]]; then
+  if grep -q "KeyError: '${release}'" ${err_file}; then
+    cat > ${out_file} << EOF
+Release Notes
+=============
+
+${release}
+-------------
+
+### No release notes
+
+EOF
+    return_code=0
+    echo "Warning: No new Reno release notes found, this can indicate an issue with the tag."
+  else
+    echo "Failure: Reno failed to generate the report."
+  fi
+else
+  pandoc --from rst --to markdown_github < ${rst_file} > ${out_file}
+  echo "Success: New Reno release notes found."
+fi
+
+exit ${return_code}

--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -9,9 +9,11 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN apt-get install -y pandoc
 
 # use released versions of the differs when they are available.
-RUN pip install rpc_differ==0.3.0 reno==2.5.0
+RUN pip install rpc_differ==0.3.0 reno==2.5.1
 RUN pip install git+https://github.com/major/osa_differ@0.3.1
 
 RUN rpc-differ --debug --update master master
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
+COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh
+COPY gating/generate_release_notes/generate_commit_diff_notes.sh /generate_commit_diff_notes.sh
 CMD /generate_release_notes.sh

--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -21,4 +21,4 @@ docker run \
   -w "$(pwd)" \
   $docker_tag_filtered
 
-cp notes.md "${RE_HOOK_RELEASE_NOTES}"
+cp all_notes.md "${RE_HOOK_RELEASE_NOTES}"


### PR DESCRIPTION
This changes updates the release notes that will be generated by the
rpc-gating generate_release_notes hook to include those managed by Reno.

The result of this change is that the release notes now returned will be
any Reno notes followed by those produced by rpc-differ. If there are no
Reno notes for the release that will be explicitly stated in the release
notes.

The code was restructured so that the code for generating the different
types of notes could be kept separate. A wrapper script is used to
create a single set of notes from the separate files.

(cherry picked from commit 773413d94a6df65576c27fe8f68733e43f4c4b8a)

Issue: [RE-360](https://rpc-openstack.atlassian.net/browse/RE-360)