### PR TITLE
Use the git-clone fetch mode instead of galaxy

### DIFF
--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -26,7 +26,7 @@ source ${BASE_DIR}/scripts/functions.sh
 ## Vars ----------------------------------------------------------------------
 
 # Set the role fetch mode to any option [galaxy, git-clone]
-export ANSIBLE_ROLE_FETCH_MODE=${ANSIBLE_ROLE_FETCH_MODE:-galaxy}
+export ANSIBLE_ROLE_FETCH_MODE=${ANSIBLE_ROLE_FETCH_MODE:-git-clone}
 
 ## Main ----------------------------------------------------------------------
 


### PR DESCRIPTION
This change modifies the fetch mode so that we're keeping the git
history within roles when doing a deployment. This makes it possible to
know which role we're using from the perspective of a checkout and
provides operators the ability to locally fetch refs without having to
re-bootstrap ansible.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>