### PR TITLE
RE-784 Create post merge tests

### DIFF
--- a/gating/post_merge_test
+++ b/gating/post_merge_test
@@ -1,0 +1,1 @@
+pre_merge_test


### PR DESCRIPTION
The testing done in post merge (periodic) is, for now, identical to pre
merge.  As such, we simply symlink the post merge tests to pre merge.

NOTE: This functionality will not be exercised until [1] merges.

[1] https://github.com/rcbops/rpc-gating/pull/492/

Issue: [RE-784](https://rpc-openstack.atlassian.net/browse/RE-784)