### PR TITLE
RLM-263 Bump OA-OPS sha for mariadb repo cleanup

### DIFF
--- a/scripts/leapfrog/ubuntu14-leapfrog.sh
+++ b/scripts/leapfrog/ubuntu14-leapfrog.sh
@@ -47,7 +47,7 @@ export OA_OPS_REPO=${OA_OPS_REPO:-'https://github.com/openstack/openstack-ansibl
 # Please bump the following when a patch for leapfrog is merged into osa-ops
 # If you are developping, just clone your ops repo into (by default)
 # /opc/rpc-leapfrog/openstack-ansible-ops
-export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'37ff5563ec7a5a1008211ff6c7231dda1244db63'}
+export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'0690bb608527b90596e5522cc852ffa655228807'}
 # Instead of storing the debug's log of run in /tmp, we store it in an
 # folder that will get archived for gating logs
 export REDEPLOY_OA_FOLDER="${RPCO_DEFAULT_FOLDER}/openstack-ansible"


### PR DESCRIPTION
Bumps to latest master for mariadb repo cleanup to fix galera client install issues.

https://github.com/openstack/openstack-ansible-ops/commit/0690bb608527b90596e5522cc852ffa655228807

Issue: [RLM-263](https://rpc-openstack.atlassian.net/browse/RLM-263)