### PR TITLE
RI-88 Remove cinder/heat/horizon from ironic scenario

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -185,10 +185,7 @@
         - name: ceph.yml.aio
           path: "{{ lookup('env', 'RPCD_DIR') ~ '/etc/openstack_deploy/conf.d' }}"
       ironic:
-        - name: cinder.yml.aio
         - name: glance.yml.aio
-        - name: heat.yml.aio
-        - name: horizon.yml.aio
         - name: keystone.yml.aio
         - name: neutron.yml.aio
         - name: nova.yml.aio


### PR DESCRIPTION
Cinder/heat/horizon are not needed as part of the ironic scenario
as they are not required for testing. This ensures unnecessary
items are not installed.

Issue: [RI-88](https://rpc-openstack.atlassian.net/browse/RI-88)