### PR TITLE
[newton] RI-88 Remove cinder/heat/horizon ironic scenario

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -244,10 +244,7 @@
         - name: ceph.yml.aio
           path: "{{ lookup('env', 'RPCD_DIR') ~ '/etc/openstack_deploy/conf.d' }}"
       ironic:
-        - name: cinder.yml.aio
         - name: glance.yml.aio
-        - name: heat.yml.aio
-        - name: horizon.yml.aio
         - name: keystone.yml.aio
         - name: neutron.yml.aio
         - name: nova.yml.aio


### PR DESCRIPTION
Cinder/heat/horizon are not needed as part of the ironic scenario
as they are not required for testing. This ensures unnecessary
items are not installed.

(cherry picked from commit 47a26958df09e4802af0ad33b3b318d8a9abb3c0)

Issue: [RI-88](https://rpc-openstack.atlassian.net/browse/RI-88)