### PR TITLE
RO-2938

### DIFF
--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -167,7 +167,7 @@
     - name: Create release index entries
       lineinfile:
         dest: "{{ built_container_artifact_metadata_file }}"
-        line: "{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};{{ build_id }};/{{ rpc_mirror_container_relative_image_location }}"
+        line: "{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};{{ build_id }};/{{ rpc_mirror_container_relative_image_location }}/"
         create: yes
         state: present
     - name: create sha256sums


### PR DESCRIPTION
The index-system items need to all have a trailing slash otherwise the
lxc-container-create, lxc-host, and the lxc-create command will not
parse the URL correctly. This change adds the trailing slash to all
itmes as they're being added to the index list.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-2938](https://rpc-openstack.atlassian.net/browse/RO-2938)