### PR TITLE
RO-2938 (#2622)

### DIFF
--- a/scripts/artifacts-building/containers/artifact-build-chroot.yml
+++ b/scripts/artifacts-building/containers/artifact-build-chroot.yml
@@ -155,7 +155,7 @@
     - name: Create release index entries
       lineinfile:
         dest: "{{ built_container_artifact_metadata_file }}"
-        line: "{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};{{ build_id }};/{{ rpc_mirror_container_relative_image_location }}"
+        line: "{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};{{ build_id }};/{{ rpc_mirror_container_relative_image_location }}/"
         create: yes
         state: present
     - name: create sha256sums


### PR DESCRIPTION
The index-system items need to all have a trailing slash otherwise the
lxc-container-create, lxc-host, and the lxc-create command will not
parse the URL correctly. This change adds the trailing slash to all
itmes as they're being added to the index list.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
(cherry picked from commit 5d6ac040bc0e3d21b6c41f174da2676ad42637fa)

Issue: [RO-2938](https://rpc-openstack.atlassian.net/browse/RO-2938)