### PR TITLE
RLM-218 Ensure /etc/rpc-release is created

### DIFF
--- a/rpcd/playbooks/rpc-release.yml
+++ b/rpcd/playbooks/rpc-release.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install rpc-release file
+  hosts: hosts
+  gather_facts: true
+  tasks:
+    - name: Install rpc-release file
+      include_role:
+        name: openstack_hosts
+        tasks_from: openstack_release.yml
+      vars:
+        openstack_distrib_id: "RPC"
+        openstack_distrib_release: "{{ rpc_release }}"
+        openstack_distrib_description: "Rackspace Private Cloud powered by OpenStack"
+        openstack_distrib_file: yes
+        openstack_distrib_file_path: "/etc/rpc-release"

--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -31,6 +31,9 @@ copy_default_user_space_files
 # begin the RPC installation
 cd ${RPCD_DIR}/playbooks/
 
+# set /etc/rpc-release
+run_ansible rpc-release.yml
+
 # deploy and configure the ELK stack
 if [[ "${DEPLOY_ELK}" == "yes" ]]; then
     run_ansible setup-logging.yml


### PR DESCRIPTION
Since rpc-support was pulled out of rpc-o, /etc/rpc-release
no longer gets set or updated.  When running a leapfrog, the
rpc-release file is not updated and shows an older version.

This file should live inside rpc-o and removed from the
rpc-support role.

DISTRIB_CODENAME has also been dropped unless we want to
maintain codenames, and if so we could add that back in.

Original template is here:

https://github.com/rsoprivatecloud/openstack-ops/blob/master/templates/rpc-release.j2

Will backport to Newton as well.

Issue: [RLM-218](https://rpc-openstack.atlassian.net/browse/RLM-218)