### PR TITLE
RE-694 Replace artifacts if it is safe to do so

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -65,9 +65,23 @@ cp "/opt/rpc-openstack/rpcd/etc/openstack_deploy/user_osa_variables_defaults.yml
 # that no containers are created in the inventory.
 rm -f /etc/openstack_deploy/conf.d/*
 
-# If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if container_artifacts_available; then
-  export PUSH_TO_MIRROR="NO"
+# Figure out when it is safe to automatically replace artifacts
+if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
+
+  if container_artifacts_available; then
+    # If there are artifacts for this release already, and it is not
+    # safe to replace them, then set PUSH_TO_MIRROR to NO to prevent
+    # them from being overwritten.
+    if ! safe_to_replace_artifacts; then
+      export PUSH_TO_MIRROR="NO"
+
+    # If there are artifacts for this release already, and it is safe
+    # to replace them, then set REPLACE_ARTIFACTS to YES to ensure
+    # that they do get replaced.
+    else
+      export REPLACE_ARTIFACTS="YES"
+    fi
+  fi
 fi
 
 # If REPLACE_ARTIFACTS is YES then set PUSH_TO_MIRROR to YES

--- a/scripts/artifacts-building/git/build-git-artifacts.sh
+++ b/scripts/artifacts-building/git/build-git-artifacts.sh
@@ -53,9 +53,23 @@ openstack-ansible -i /opt/inventory \
                   -e rpc_release=${RPC_RELEASE} \
                   ${ANSIBLE_PARAMETERS}
 
-# If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if git_artifacts_available; then
-  export PUSH_TO_MIRROR="NO"
+# Figure out when it is safe to automatically replace artifacts
+if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
+
+  if git_artifacts_available; then
+    # If there are artifacts for this release already, and it is not
+    # safe to replace them, then set PUSH_TO_MIRROR to NO to prevent
+    # them from being overwritten.
+    if ! safe_to_replace_artifacts; then
+      export PUSH_TO_MIRROR="NO"
+
+    # If there are artifacts for this release already, and it is safe
+    # to replace them, then set REPLACE_ARTIFACTS to YES to ensure
+    # that they do get replaced.
+    else
+      export REPLACE_ARTIFACTS="YES"
+    fi
+  fi
 fi
 
 # If REPLACE_ARTIFACTS is YES then force PUSH_TO_MIRROR to YES

--- a/scripts/artifacts-building/python/build-python-artifacts.sh
+++ b/scripts/artifacts-building/python/build-python-artifacts.sh
@@ -113,9 +113,23 @@ openstack-ansible repo-install.yml \
                   ${ANSIBLE_PARAMETERS}
 
 
-# If there are artifacts for this release, then set PUSH_TO_MIRROR to NO
-if python_artifacts_available; then
-  export PUSH_TO_MIRROR="NO"
+# Figure out when it is safe to automatically replace artifacts
+if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
+
+  if python_artifacts_available; then
+    # If there are artifacts for this release already, and it is not
+    # safe to replace them, then set PUSH_TO_MIRROR to NO to prevent
+    # them from being overwritten.
+    if ! safe_to_replace_artifacts; then
+      export PUSH_TO_MIRROR="NO"
+
+    # If there are artifacts for this release already, and it is safe
+    # to replace them, then set REPLACE_ARTIFACTS to YES to ensure
+    # that they do get replaced.
+    else
+      export REPLACE_ARTIFACTS="YES"
+    fi
+  fi
 fi
 
 # If REPLACE_ARTIFACTS is YES then set PUSH_TO_MIRROR to YES

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -180,3 +180,26 @@ function configure_apt_sources {
   curl --silent --fail ${HOST_RCBOPS_REPO}/apt-mirror/rcbops-release-signing-key.asc | apt-key add -
 
 }
+
+function safe_to_replace_artifacts {
+
+  # This function is used by the artifact pipeline to determine whether it
+  # is safe to rebuild artifacts for the current head of the mainline branch.
+  # It is only ever safe when the mainline and rc branches are different
+  # versions or if there is no rc branch. When this is the case, the function
+  # will return 0.
+
+  rc_branch="master-rc"
+
+  if git show origin/${rc_branch} &>/dev/null; then
+    rc_branch_version="$(git show origin/${rc_branch}:group_vars/all/release.yml \
+                         | awk '/rpc_release/{print $2}' | tr -d '"')"
+    if [[ "${rc_branch_version}" == "${RPC_RELEASE}" ]]; then
+      return 1
+    else
+      return 0
+    fi
+  else
+    return 0
+  fi
+}


### PR DESCRIPTION
Currently the periodic job which builds artifacts is not
set to replace the artifacts every time it runs. Instead
of setting that on, therefore always replacing them, we
use a function to verify that the rpc_release version
set in the mainline branch differs from the value set in
the release candidate branch.

This protection is implemented to prevent artifacts from
being replaced by mistake once a new release candidate
branch has been cut, but the mainline branch has not had
the rpc_release value changed to the next version yet.

Using this method still allows the periodic job to be
executed manually with REPLACE_ARTIFACTS="YES", forcing
them to be replaced.

We only implement this check when PUSH_TO_MIRROR is already
set to "YES" when the script executes. This is only the
case in the periodic jobs which are the ones designed to
be run in sequence to to upload their changes.

(cherry picked from commit eb4284551ed5041c2f05c01767fb696e044eef31)

Issue: [RE-694](https://rpc-openstack.atlassian.net/browse/RE-694)