### PR TITLE
RE-694 Correct RC branch name

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -189,7 +189,7 @@ function safe_to_replace_artifacts {
   # versions or if there is no rc branch. When this is the case, the function
   # will return 0.
 
-  rc_branch="master-rc"
+  rc_branch="newton-rc"
 
   if git show origin/${rc_branch} &>/dev/null; then
     rc_branch_version="$(git show origin/${rc_branch}:group_vars/all/release.yml \


### PR DESCRIPTION
The current verification is happening against
the wrong RC branch, causing artifacts to always
refresh, which was not the intent. It should only
refresh when the mainline and RC branch differ
in the value of rpc_release.

Issue: [RE-694](https://rpc-openstack.atlassian.net/browse/RE-694)