### PR TITLE
RE-1082 Hotfix issues with nova deployment

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -18,3 +18,12 @@
   scm: git
   src: https://github.com/openstack/openstack-ansible-os_octavia.git
   version: f8c0f7689ecd9651b27a7bf58cbdac35e0c48793
+# This overrides the OSA integrated repo role SHA in order
+# to include two critical fixes:
+# - Ensure nova is started after everything else
+# - Force the installation of qemu packages
+# ref: RE-1082
+- name: os_nova
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-os_nova
+  version: 9f5706b948104af6fd08c70d25a902375dea7988


### PR DESCRIPTION
This overrides the OSA integrated repo role SHA in order
to include two critical fixes:

- Ensure nova is started after everything else
  This affects Trusty deployment (including leapfrogs).

- Force the installation of qemu packages
  If this is not done, libvirt fails to restart properly.

Issue: [RE-1082](https://rpc-openstack.atlassian.net/browse/RE-1082)