### PR TITLE
RE-1109 Implement branch overrides in PR tests

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -125,6 +125,19 @@ if ! python_artifacts_available; then
     # has no packages available, ensure that the lock down
     # is disabled.
     echo "pip_lock_to_internal_repo: no" >> ${OA_OVERRIDES}
+
+    # As newton reaches EOL, developer_mode no longer works
+    # as it tries to make use of the stable/newton branch
+    # which no longer exists.
+    # We implement the override here to cater for PR tests
+    # only.
+    eol_repo_list="cinder glance heat horizon keystone magnum_dashboard"
+    eol_repo_list="${eol_repo_list} neutron neutron_dynamic_routing"
+    eol_repo_list="${eol_repo_list} neutron_fwaas neutron_lbaas"
+    eol_repo_list="${eol_repo_list} neutron_vpnaas swift"
+    for svc in ${eol_repo_list}; do
+      echo "${svc}_git_install_branch: newton-eol" >> ${OA_OVERRIDES}
+    done
 fi
 
 # Run playbooks


### PR DESCRIPTION
The artifact build PR tests which test the container
builds use the role developer_mode ability to build
the venv without using python artifacts. This is
necessary for a PR test when the PR includes a change
to rpc_release - reason being that for a new rpc_release
no job has been able to run to build the artifacts.

As newton reaches EOL, developer_mode no longer works
as it tries to make use of the stable/newton branch
which no longer exists.

In this patch we implement the overrides necessary to
make the PR tests use the newton-eol branch.

Test using new tag to verify this capability works:
https://rpc.jenkins.cit.rackspace.net/job/RPC-Artifact-Build_newton-pr/303/

This PR is required in order for the next newton dep
update's artifact test to complete successfully: https://github.com/rcbops/rpc-openstack/pull/2638

Issue: [RE-1109](https://rpc-openstack.atlassian.net/browse/RE-1109)