### PR TITLE
RLM-218 Ensure /etc/rpc-release is symlinked

### DIFF
--- a/rpcd/playbooks/rpc-release.yml
+++ b/rpcd/playbooks/rpc-release.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Delete rpc-release file
+  hosts: hosts
+  gather_facts: false
+  tasks:
+    - name: Symlink rpc-release to openstack-release
+      file:
+        dest: /etc/rpc-release
+        src: /etc/openstack-release
+        state: link
+        force: true

--- a/scripts/deploy-rpc-playbooks.sh
+++ b/scripts/deploy-rpc-playbooks.sh
@@ -31,6 +31,9 @@ copy_default_user_space_files
 # begin the RPC installation
 cd ${RPCD_DIR}/playbooks/
 
+# set /etc/rpc-release
+run_ansible rpc-release.yml
+
 # deploy and configure the ELK stack
 if [[ "${DEPLOY_ELK}" == "yes" ]]; then
     run_ansible setup-logging.yml


### PR DESCRIPTION
Since rpc-support was pulled out of rpc-o, /etc/rpc-release
no longer gets set or updated.  This creates a symlink to openstack-release to prevent tests from breaking.

Issue: [RLM-218](https://rpc-openstack.atlassian.net/browse/RLM-218)