### PR TITLE
RLM-218 Fix typo on rpc-release

### DIFF
--- a/rpcd/playbooks/rpc-release.yml
+++ b/rpcd/playbooks/rpc-release.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Delete rpc-release file
+- name: Symlink rpc-release file
   hosts: hosts
   gather_facts: false
   tasks:


### PR DESCRIPTION
Update the playbook name with correct action.

Issue: [RLM-218](https://rpc-openstack.atlassian.net/browse/RLM-218)