### PR TITLE
RO-3077 Remove testing link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,3 @@ apply the RPC-OpenStack value added services; you may also run the playbooks
 
 Please see the documentation in [rpc-gating/README.md](https://github.com/rcbops/rpc-gating/blob/master/README.md)
 
-### Testing
-
-Please see [Testing](Testing.md) for an overview of RPC-OpenStack testing.


### PR DESCRIPTION
The content no longer exists for this link and the link has been
removed in this patch.