### PR TITLE
RLM-9 Preserve ES logs

### DIFF
--- a/rpcd/playbooks/setup-logging.yml
+++ b/rpcd/playbooks/setup-logging.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 - include: elasticsearch.yml
+  when:
+    - not lookup('env', 'UPGRADE_ELASTICSEARCH') | bool
 - include: logstash.yml
 - include: kibana.yml
 - include: filebeat.yml

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -58,6 +58,9 @@ export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
 # Derive the rpc_release version from the group vars
 export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
 
+# Upgrade of Elasticsearch in leapfrog
+export UPGRADE_ELASTICSEARCH=${UPGRADE_ELASTICSEARCH:-"no"}
+
 # Read the OS information
 source /etc/os-release
 source /etc/lsb-release


### PR DESCRIPTION
Create new env var 'UPGRADE_ELASTICSEARCH' to indicate if user wishes to
upgrade and preserve Elasticsearch logs in leapfrog. New playbook
condition to skip re-deployment on Elasticsearch container from destroying ES
data in leapfrog.