### PR TITLE
RE-1178 Remove initial rpc-differ in release_notes_dockerfile

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -11,7 +11,10 @@ RUN apt-get install -y pandoc
 RUN pip install rpc_differ==0.3.0 reno==2.5.1
 RUN pip install git+https://github.com/major/osa_differ@0.3.2
 
-RUN rpc-differ --debug --update master master
+# TODO(odyssey4me):
+# Remove this once https://github.com/major/osa_differ/pull/16 has merged.
+RUN git clone https://github.com/rcbops/rpc-openstack.git /root/.osa-differ/rpc-openstack
+
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh
 COPY gating/generate_release_notes/generate_commit_diff_notes.sh /generate_commit_diff_notes.sh


### PR DESCRIPTION
The initial rpc-differ which is run in the dockerfile
is not really necessary as the later execution will
pull down everything it needs.

Due to changes in the master repo, the execution of
rpc-differ is failing for the newton branch. This is
caused by the hard coded use of the master branch for
in the dockerfile.

As it's not needed, and we'd prefer not to have the
branches interfere with each other, we remove this
line.

A clone of the rpc-openstack repo is added to ensure
that osa-differ properly updates it. This is a work
around until the issue noted is resolved.

Issue: [RE-1178](https://rpc-openstack.atlassian.net/browse/RE-1178)