### PR TITLE
RE-1178 Update OSA Differ and remove workaround

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -9,11 +9,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN apt-get install -y pandoc
 
 RUN pip install rpc_differ==0.3.0 reno==2.5.1
-RUN pip install git+https://github.com/major/osa_differ@0.3.2
-
-# TODO(odyssey4me):
-# Remove this once https://github.com/major/osa_differ/pull/16 has merged.
-RUN git clone https://github.com/rcbops/rpc-openstack.git /root/.osa-differ/rpc-openstack
+RUN pip install git+https://github.com/major/osa_differ@0.3.3
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
OSA differ 0.3.3 correctly pulls refs for fresh clones so
the pre-clone added as a workaround is no longer required.

Issue: [RE-1178](https://rpc-openstack.atlassian.net/browse/RE-1178)