### PR TITLE
RE-1174 Add workaround for nova-novncproxy fail

### DIFF
--- a/releasenotes/notes/nova-novncproxy-reload-37a9c0ddeee8d2d8.yaml
+++ b/releasenotes/notes/nova-novncproxy-reload-37a9c0ddeee8d2d8.yaml
@@ -1,0 +1,17 @@
+---
+issues:
+  - |
+    For releases between r14.1.0 and r14.6.0 when executing an upgrade
+    the ``nova-novncproxy`` and ``nova-spicehtml5proxy`` services will
+    fail to reload after the upgrade. The workaround to resolve this
+    issue is to restart the services.
+
+    .. code-block:: shell-session
+
+      cd /opt/rpc-openstack/openstack-ansible/playbooks
+      # start the service again
+      ansible nova_console -m service -a 'name=nova-novncproxy state=started'
+      # set the appropriate facts to prevent the playbook trying
+      # to reload it again when the playbook is run again
+      ansible nova_console -m ini_file -a 'dest=/etc/ansible/facts.d/openstack_ansible.fact section=nova option=need_service_restart value=False'
+


### PR DESCRIPTION
When upgrading the nova playbook will try to reload
nova-novncproxy and fail. This patch adds a release
note to describe this as a known issue and to provide
a workaround.

Issue: [RE-1174](https://rpc-openstack.atlassian.net/browse/RE-1174)