### PR TITLE
RO-3117 Force the correct owner on artifact files

### DIFF
--- a/scripts/artifacts-building/apt/aptly-all.yml
+++ b/scripts/artifacts-building/apt/aptly-all.yml
@@ -111,6 +111,8 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: push
         delete: yes
+        group: no
+        owner: no
         rsync_opts:
           - "--quiet"
           - "--stats"
@@ -129,3 +131,17 @@
         owner: "{{ webservice_owner }}"
         group: "www-data"
       when: "{{ lookup('ENV','PUSH_TO_MIRROR') | bool }}"
+
+    # The rsync to rpc-repo does not always set
+    # the right user:group, so we force the right
+    # user:group ownership over all the files in
+    # the artifact directory here.
+    - name: Set appropriate owner and group
+      file:
+        path: "{{ artifacts_aptrepos_dest_folder }}"
+        state: directory
+        owner: "{{ webservice_owner }}"
+        group: "www-data"
+        recurse: yes
+      when: "{{ lookup('ENV','PUSH_TO_MIRROR') | bool }}"
+


### PR DESCRIPTION
When synchronising the aptly database to rpc-repo
rsync changes the owner:group to root when it is only
modifying the attributes of the file instead of the
contents - at least I think that's the condition.

After spending several hours trying to figure out
how to do it better in the rsync options, and failing,
this patch opts to use a simpler change which just
forces the owner:group after the sync is completed.

Included are the setting of --no-owner and --nogroup
when doing the pull. These are important to make it
behave correctly but are unfortunately not enough.

Issue: [RO-3117](https://rpc-openstack.atlassian.net/browse/RO-3117)