### PR TITLE
RO-3148 Remove double when

### DIFF
--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -78,11 +78,10 @@
     - name: Determine the existing Ubuntu repo configuration
       shell: 'sed "s/^[ \t]*//" /etc/apt/sources.list | grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)"'
       register: _ubuntu_repo
-      when:
-        - host_ubuntu_repo is not defined
       changed_when: false
       delegate_to: "{{ physical_host | default(omit) }}"
       when:
+        - host_ubuntu_repo is not defined
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 


### PR DESCRIPTION
This patch removes the double `when` clause from the apt sources
tasks.

Issue: [RO-3148](https://rpc-openstack.atlassian.net/browse/RO-3148)