### PR TITLE
RO-3149 Update rpc_release file location

### DIFF
--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -41,15 +41,15 @@ maas_release: "'${latest_maas_tag}'"' etc/openstack_deploy/group_vars/all/releas
 
 # can't use derive-artifact-version.sh as that hardcodes the rpc repo path
 extract_rpc_release(){
-  awk '/rpc_release/{print $2}' | tr -d '"'
+  awk '/^rpc_release/{print $2}' | tr -d '"'
 }
 
 update_rpc_release(){
-  rc_branch_version="$(git show origin/${rc_branch}:group_vars/all/release.yml \
+  rc_branch_version="$(git show origin/${rc_branch}:etc/openstack_deploy/group_vars/all/release.yml \
                       | extract_rpc_release)"
   echo "rpc_release version from rc-branch (${rc_branch}): ${rc_branch_version}"
 
-  current_branch_version="$(extract_rpc_release < group_vars/all/release.yml)"
+  current_branch_version="$(extract_rpc_release < etc/openstack_deploy/group_vars/all/release.yml)"
   echo "rpc_release version from current branch (${rpco_branch}): ${current_branch_version}"
 
   # Extract the required version info
@@ -64,7 +64,7 @@ update_rpc_release(){
   echo "Incremented rpc_release version: ${incremented_version}"
 
   sed -i "s/${current_branch_version}/${incremented_version}/" \
-    group_vars/all/release.yml
+    etc/openstack_deploy/group_vars/all/release.yml
 }
 
 # Update rpc_release. The mainline branch should always be one version


### PR DESCRIPTION
The dep_update script checks the value of the rpc_release
in the rc branch and the current branch, then does things
from there. Currently the location of the file is wrong,
so the script is failing.

Issue: [RO-3149](https://rpc-openstack.atlassian.net/browse/RO-3149)