### PR TITLE
[RO-3150] Fix partial artifacts installation

### DIFF
--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -19,6 +19,22 @@
   user: root
   gather_facts: true
   pre_tasks:
+    - name: Ensure local facts directory exists
+      file:
+        path: "/etc/ansible/facts.d"
+        state: directory
+        group: "root"
+        owner: "root"
+        mode:  "0755"
+        recurse: no
+
+    - name: initialize local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: initialized
+        value: true
+
     - name: Check for artifacts
       uri:
         url: "{{ rpco_mirror_base_url }}/apt-mirror/integrated/dists/{{ rpc_release }}-{{ ansible_distribution_release }}/Release"
@@ -26,9 +42,27 @@
       failed_when: false
       register: check_artifacts
 
+    - name: Set artifacts found
+      set_fact:
+        apt_artifact_found: "{{ check_artifacts.status == 200 }}"
+
     - name: Set artifacts enabled
       set_fact:
-        artifact_enabled: "{{ check_artifacts.status == 200 }}"
+        apt_artifact_enabled: "{{ apt_artifact_found | bool }}"
+      when:
+        - apt_artifact_enabled is undefined
+
+    - name: Check if artifacts are enabled but not found
+      fail:
+        msg: |
+          The apt artifacts are enabled but not found. The deployment has
+          halted. Please check the artifacts repository is online and available
+          before continuing.
+      when:
+        - apt_artifact_enabled | bool
+        - not apt_artifact_found | bool
+      tags:
+        - always
 
   tasks:
     - name: Sync artifact files (all)
@@ -38,7 +72,8 @@
       with_items:
         - files/apt.yml
       when:
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Determine the existing Ubuntu repo configuration
       shell: 'sed "s/^[ \t]*//" /etc/apt/sources.list | grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)"'
@@ -48,7 +83,8 @@
       changed_when: false
       delegate_to: "{{ physical_host | default(omit) }}"
       when:
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Set host_ubuntu_repo fact
       set_fact:
@@ -56,7 +92,8 @@
       when:
         - host_ubuntu_repo is not defined
         - _ubuntu_repo.stdout_lines is defined
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Replace the apt sources file with our content
       copy:
@@ -67,7 +104,8 @@
         backup: yes
       register: apt_sources_configure
       when:
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Create the rpco apt sources file
       copy:
@@ -78,7 +116,8 @@
         backup: yes
       register: apt_sources_configure_rpco
       when:
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Add rpco keys
       apt_key:
@@ -89,7 +128,8 @@
       retries: 5
       delay: 2
       when:
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Remove extra sources
       lineinfile:
@@ -102,23 +142,23 @@
         - "-security"
         - "-updates"
       when:
-        - artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
 
     - name: Update apt-cache
       apt:
         update_cache: yes
       when:
-        - (artifact_enabled | bool) and (apt_sources_configure | changed or apt_sources_configure_rpco | changed)
+        - (apt_artifact_found | bool) and (apt_sources_configure | changed or apt_sources_configure_rpco | changed)
+        - apt_artifact_enabled | bool
 
-  roles:
-    # We execute the pip_install role here to ensure that all
-    # hosts have the correct rpco repo configured now that
-    # /etc/apt/sources.list has been changed to no longer
-    # include the updates repo.
-    - role: "pip_install"
-      pip_lock_to_internal_repo: false
-      internal_lb_vip_address: localhost
-      pip_upstream_url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ repo_build_os_distro_version }}/get-pip.py"
-      pip_install_upper_constraints: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ repo_build_os_distro_version }}/requirements_absolute_requirements.txt"
-      when:
-        - artifact_enabled | bool
+  post_tasks:
+    - name: Set artifact local fact
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - { option: "apt_artifact_enabled", value: "{{ apt_artifact_enabled }}" }
+        - { option: "apt_artifact_found", value: "{{ apt_artifact_found }}" }

--- a/playbooks/configure-container-sources.yml
+++ b/playbooks/configure-container-sources.yml
@@ -22,6 +22,22 @@
   vars:
     container_search_string: ".*{{ ansible_distribution_release }};.*{{ rpc_release }};"
   pre_tasks:
+    - name: Ensure local facts directory exists
+      file:
+        path: "/etc/ansible/facts.d"
+        state: directory
+        group: "root"
+        owner: "root"
+        mode:  "0755"
+        recurse: no
+
+    - name: initialize local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: initialized
+        value: true
+
     - name: Check for artifacts
       uri:
         url: "{{ rpco_mirror_base_url }}/meta/1.0/index-system"
@@ -32,7 +48,25 @@
 
     - name: Set artifacts enabled
       set_fact:
-        artifact_enabled: "{{ check_artifacts.content is search(container_search_string) }}"
+        container_artifact_found: "{{ check_artifacts.content is search(container_search_string) }}"
+
+    - name: Set artifacts enabled
+      set_fact:
+        container_artifact_enabled: "{{ container_artifact_found | bool }}"
+      when:
+        - container_artifact_enabled is undefined
+
+    - name: Check if artifacts are enabled but not found
+      fail:
+        msg: |
+          The container artifacts are enabled but not found. The deployment has
+          halted. Please check the artifacts repository is online and available
+          before continuing.
+      when:
+        - container_artifact_enabled | bool
+        - not container_artifact_found | bool
+      tags:
+        - always
 
   tasks:
     - name: Sync artifact files (all)
@@ -42,7 +76,8 @@
       with_items:
         - files/lxc.yml
       when:
-        - artifact_enabled | bool
+        - container_artifact_found | bool
+        - container_artifact_enabled | bool
 
     - name: Sync artifact files
       copy:
@@ -65,4 +100,16 @@
         - "files/swift_all.yml"
         - "files/utility_all.yml"
       when:
-        - artifact_enabled | bool
+        - container_artifact_found | bool
+        - container_artifact_enabled | bool
+
+  post_tasks:
+    - name: Set artifact local fact
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - { option: "container_artifact_enabled", value: "{{ container_artifact_enabled }}" }
+        - { option: "container_artifact_found", value: "{{ container_artifact_found }}" }

--- a/playbooks/configure-python-sources.yml
+++ b/playbooks/configure-python-sources.yml
@@ -19,6 +19,22 @@
   connection: local
   user: root
   pre_tasks:
+    - name: Ensure local facts directory exists
+      file:
+        path: "/etc/ansible/facts.d"
+        state: directory
+        group: "root"
+        owner: "root"
+        mode:  "0755"
+        recurse: no
+
+    - name: initialize local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: initialized
+        value: true
+
     - name: Check for artifacts (wheels)
       uri:
         url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ repo_build_os_distro_version }}/MANIFEST.in"
@@ -35,9 +51,26 @@
 
     - name: Set artifacts enabled
       set_fact:
-        artifact_enabled: "{{ (check_artifacts_wheels.status == 200) and (check_artifacts_git.status == 200) }}"
+        py_artifact_found: "{{ (check_artifacts_wheels.status == 200) and (check_artifacts_git.status == 200) }}"
 
-  tasks:
+    - name: Set artifacts enabled
+      set_fact:
+        py_artifact_enabled: "{{ py_artifact_found | bool }}"
+      when:
+        - py_artifact_enabled is undefined
+
+    - name: Check if artifacts are enabled but not found
+      fail:
+        msg: |
+          The python artifacts are enabled but not found. The deployment has
+          halted. Please check the artifacts repository is online and available
+          before continuing.
+      when:
+        - py_artifact_enabled | bool
+        - not py_artifact_found | bool
+      tags:
+        - always
+
     - name: Notify the Deployer
       debug:
         msg: |
@@ -50,13 +83,15 @@
           define the code path in a more intellegent way.
           ********************* NOTICE! *********************
       when:
-        - artifact_enabled | bool
+        - py_artifact_found | bool
+        - py_artifact_enabled | bool
 
     - name: Pause for effect
       pause:
         seconds: 5
       when:
-        - artifact_enabled | bool
+        - py_artifact_found | bool
+        - py_artifact_enabled | bool
 
     - name: Link "repo-build.yml" to "stage-python-artifacts.yml"
       file:
@@ -65,4 +100,32 @@
         force: true
         state: link
       when:
-        - artifact_enabled | bool
+        - py_artifact_found | bool
+        - py_artifact_enabled | bool
+  roles:
+    # We execute the pip_install role here to ensure that all
+    # hosts have the correct rpco repo configured now that
+    # /etc/apt/sources.list has been changed to no longer
+    # include the updates repo. This assumes it's been executed
+    # after the configure-apt-sources.yml playbook. If this option is
+    # undefined this role will skip.
+    - role: "pip_install"
+      pip_lock_to_internal_repo: false
+      internal_lb_vip_address: localhost
+      pip_upstream_url: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ repo_build_os_distro_version }}/get-pip.py"
+      pip_install_upper_constraints: "{{ rpco_mirror_base_url }}/os-releases/{{ rpc_release }}/{{ repo_build_os_distro_version }}/requirements_absolute_requirements.txt"
+      when:
+        - py_artifact_found | bool
+        - py_artifact_enabled | bool
+        - apt_artifact_enabled | default(false) | bool
+
+  post_tasks:
+    - name: Set artifact local fact
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - { option: "py_artifact_enabled", value: "{{ py_artifact_enabled }}" }
+        - { option: "py_artifact_found", value: "{{ py_artifact_found }}" }

--- a/releasenotes/notes/add-option-to-disable-artifacts-23125367d1c1e834.yaml
+++ b/releasenotes/notes/add-option-to-disable-artifacts-23125367d1c1e834.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - The option to enable or disable artifacts has been added giving the
+    deployer the ability to chose how artifacts will be consumed. Three new
+    variables are now available to users, `apt_artifact_enabled`
+    `container_artifact_enabled` `py_artifact_enabled` which are all
+    **Boolean**. If a user defines any of variables it will used as the
+    ultimate source of truth, even if artifacts are "found" for the given
+    release.
+  - Artifacted builds will save facts as an ansible local fact. If a deployer
+    needs to expunge facts from our cached local facts the file
+    `/etc/ansible/facts.d/rpc_openstack.fact` can be modified or removed as
+    needed. All artifacted facts will be saved under the "rpc_artifacts"
+    section.


### PR DESCRIPTION
This change moves the pip install role to the configure-python-sources
task file. This is done so we're only ever executing it to setup our
hosts when our sources are present. This change also uses two facts when
running with artifacts. First the artifacts must be online and availanle.
Second the artifact source must be "enabled". This gives deployers the
ability to enable or disable artifacts as needed.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3150](https://rpc-openstack.atlassian.net/browse/RO-3150)