### PR TITLE
Add playbooks to create images and flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Upon completion of the deployment run `scripts/deploy-rpco.sh` script to
 apply the RPC-OpenStack value added services; you may also run the playbooks
 `site-logging.yml` to accomplish much of the same things.
 
+Post deployment run the **optional** `openstack-image-setup.yml` and
+`openstack-flavor-setup.yml` playbooks to setup default flavors and images.
+
 ### Testing & Gating
 
 Please see the documentation in [rpc-gating/README.md](https://github.com/rcbops/rpc-gating/blob/master/README.md)
-

--- a/playbooks/openstack-flavor-setup.yml
+++ b/playbooks/openstack-flavor-setup.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: OpenStack flavor setup
+  hosts: utility_all[0]
+  user: root
+  tasks:
+    - name: Install shade
+      pip:
+        name: "shade"
+        state: "present"
+      register: install_packages
+      until: install_packages|success
+      retries: 5
+      delay: 2
+
+    - name: Create flavors of nova VMs
+      os_nova_flavor:
+        endpoint_type: internal
+        cloud: default
+        state: present
+        name: "{{ item.name }}"
+        ram: "{{ item.ram }}"
+        vcpus: "{{ item.vcpus }}"
+        disk: "{{ item.disk }}"
+        swap: "{{ item.swap }}"
+        ephemeral: "{{ item.ephemeral }}"
+      with_items: "{{ openstack_vm_flavors }}"
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  vars_files:
+    - vars/openstack-service-config.yml

--- a/playbooks/openstack-image-setup.yml
+++ b/playbooks/openstack-image-setup.yml
@@ -1,0 +1,55 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: OpenStack image setup
+  hosts: utility_all[0]
+  user: root
+  tasks:
+    - name: Install shade
+      pip:
+        name: "shade"
+        state: "present"
+      register: install_packages
+      until: install_packages|success
+      retries: 5
+      delay: 2
+
+    - name: Download system image file
+      get_url:
+        url: "{{ item.url }}"
+        dest: "/var/backup/os_image_{{ item.name }}"
+        timeout: 1200
+      with_items: "{{ openstack_images }}"
+
+    - name: Install system image
+      os_image:
+        endpoint_type: internal
+        cloud: default
+        state: present
+        is_public: true
+        name: "{{ item.name }}"
+        filename: "/var/backup/os_image_{{ item.name }}"
+        disk_format: "{{ item.format }}"
+      with_items: "{{ openstack_images }}"
+
+    - name: Clean up temp file
+      file:
+        path: "/var/backup/os_image_{{ item.name }}"
+        state: absent
+      with_items: "{{ openstack_images }}"
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  vars_files:
+    - vars/openstack-service-config.yml

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -15,3 +15,5 @@
 
 - include: site-logging.yml
 - include: site-artifacts.yml
+- include: openstack-image-setup.yml
+- include: openstack-flavor-setup.yml

--- a/playbooks/vars/openstack-service-config.yml
+++ b/playbooks/vars/openstack-service-config.yml
@@ -1,0 +1,84 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+openstack_vm_flavors:
+  - name: m1.micro
+    ram: 256
+    vcpus: 1
+    disk: 1
+    swap: 0
+    ephemeral: 0
+  - name: m1.tiny
+    ram: 512
+    vcpus: 1
+    disk: 1
+    swap: 0
+    ephemeral: 0
+  - name: m1.mini
+    ram: 1024
+    vcpus: 2
+    disk: 3
+    swap: 0
+    ephemeral: 0
+  - name: m1.small
+    ram: 2048
+    vcpus: 3
+    disk: 12
+    swap: 4
+    ephemeral: 4
+  - name: m1.medium
+    ram: 4096
+    vcpus: 6
+    disk: 60
+    swap: 4
+    ephemeral: 20
+  - name: m1.large
+    ram: 8192
+    vcpus: 12
+    disk: 300
+    swap: 4
+    ephemeral: 150
+  - name: m1.xlarge
+    ram: 16384
+    vcpus: 24
+    disk: 600
+    swap: 4
+    ephemeral: 256
+  - name: m1.heavy
+    ram: 32768
+    vcpus: 48
+    disk: 1200
+    swap: 4
+    ephemeral: 256
+
+openstack_images:
+  - name: CentOS 7
+    format: qcow2
+    url: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+  - name: Cirros-0.3.5
+    format: qcow2
+    url: http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
+  - name: Debian 9
+    format: qcow2
+    url: http://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
+  - name: OpenSuse Leap 42.3
+    format: qcow2
+    url: http://download.opensuse.org/repositories/Cloud:/Images:/Leap_42.3/images/openSUSE-Leap-42.3-OpenStack.x86_64.qcow2
+  - name: Ubuntu 14.04 LTS
+    format: qcow2
+    url: http://uec-images.ubuntu.com/releases/14.04/release/ubuntu-14.04-server-cloudimg-amd64-disk1.img
+  - name: Ubuntu 16.04
+    format: qcow2
+    url: http://uec-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img

--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -79,6 +79,10 @@ done
 pushd "${SCRIPT_PATH}/../playbooks"
   # Deploy and configure the ELK stack
   openstack-ansible site-logging.yml
+  # Create default VM images
+  openstack-ansible openstack-image-setup.yml
+  # Create default VM flavors
+  openstack-ansible openstack-flavor-setup.yml
 popd
 
 pushd /opt/rpc-maas/playbooks


### PR DESCRIPTION
At present we've nothing to create images and flavors post deployment,
which is the default behaviour in OpenStack however in RPC-OpenStack we
want the ability to automagically create defaults for users. These
playbooks do just that.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>