### PR TITLE
DOCS-58 Hiding the staging release notes from elasticsearch

### DIFF
--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -61,6 +61,9 @@ master_doc = 'index'
 # builder = 'deconst-serial'
 builder = 'deconst-single'
 
+# Exclude content from elastic search index
+deconst_default_unsearchable = True
+
 # General information about the project.
 project = u'Rackspace Private Cloud powered by OpenStack Release Notes'
 copyright = u'2016, Rackspace'


### PR DESCRIPTION
The master branch holding the release notes are set up as displaying on both staging (https://github.com/rackerlabs/nexus-control/blob/master/config/content.d/staging.horse.json#L5) and production (https://github.com/rackerlabs/nexus-control/blob/master/config/content.d/developer.rackspace.com.json#L35).

If you do not want the staging links to show up in search, this PR should be merged. However, it will hide the release notes from search on production, as well. This duplicate appearance of master on both staging and production might be why the system isn't working properly.

Issue: [DOCS-58](https://rpc-openstack.atlassian.net/browse/DOCS-58)