### PR TITLE
RO-3179 Bump OSA SHA for 16.0.5 release

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -16,7 +16,7 @@
 ## Vars ----------------------------------------------------------------------
 
 # OSA SHA
-export OSA_RELEASE="${OSA_RELEASE:-27fa064a0eb2c2b17c361e176abe06375f8dc55f}"
+export OSA_RELEASE="${OSA_RELEASE:-16c69046bfd90d1b984de43bc6267fece6b75f1c}"
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 
 # Gating


### PR DESCRIPTION
The OSA SHAs for 16.0.5 have just been bumped and this patch brings
RPC-O's master branch in line with those changes.

Issue: [RO-3179](https://rpc-openstack.atlassian.net/browse/RO-3179)