### PR TITLE
Update the RPC-OpenStack playbooks for multi-release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ There are two different types of RPC-OpenStack deployments available:
   than one server with at least three nodes available to run the internal
   cloud services.
 
+* **Upgrading the RPC-OpenStack Product.** Upgrading the RPC-OpenStack Product
+  using intra-series releases.
+
 ### All-In-One (AIO) Deployment Quickstart
 
 Clone the RPC-OpenStack repository:
@@ -33,7 +36,9 @@ Run the ``deploy.sh`` script within a tmux or screen session:
 ``` shell
 tmux
 cd /opt/rpc-openstack
-DEPLOY_AIO=true OSA_RELEASE="stable/pike" ./scripts/deploy.sh
+export DEPLOY_AIO=true
+export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stable product will be used
+./scripts/deploy.sh
 ```
 
 The `deploy.sh` script will run all of the necessary playbooks to deploy an
@@ -47,34 +52,123 @@ Clone the RPC-OpenStack repository:
 git clone https://github.com/rcbops/rpc-openstack /opt/rpc-openstack
 ```
 
+#### Run the basic system installation
+
 Start a screen or tmux session (to ensure that the deployment continues even
 if the ssh connection is broken) and run `deploy.sh`:
 
 Run the ``deploy.sh`` script within a tmux or screen session:
 
 ``` shell
-tmux
 cd /opt/rpc-openstack
-OSA_RELEASE="stable/pike" ./scripts/deploy.sh
+export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stable product will be used
+./scripts/deploy.sh
 ```
+
+#### Configure and deploy the cloud
 
 To configure the installation please refer to the upstream OpenStack-Ansible
 documentation regarding basic [system setup](https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/configure.html).
 
-Prior to running the playbooks ensure your system(s) are using the latest
-artifacts. To ensure all hosts have the same artifacts run the RPC-OpenStack
-playbook `site-artifacts.yml`.
+Prior to running the OpenStack-Ansible playbooks ensure your system(s) are using
+the latest artifacts. To ensure all hosts have the same artifacts run the
+RPC-OpenStack playbook `site-artifacts.yml`.
+
+``` shell
+cd /opt/rpc-openstack
+export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stable product will be used
+openstack-ansible site-artifacts.yml
+```
 
 Once the deploy configuration has been completed please refer to the
 OpenStack-Ansible documentation regarding [running the playbooks](https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/run-playbooks.html).
+
+#### Optional | Disable Artifacts
+
+It is possible to disable parts of the artifact deployment system RPC-OpenStack
+provides. To disable the artifact components any of the following variables
+can be set to **false** when running the `site-artifacts.yml` playbook.
+
+* apt_artifact_enabled
+* container_artifact_enabled
+* py_artifact_enabled
+
+If these variables are unset, they will automatically flip to **true** when the
+respective artifacts are found. These settings are stored in the local fact file
+`/etc/ansible/facts.d/rpc_openstack.fact`. If a deployer needs to completely
+reset the state of artifacts, this file can be removed or modified as needed.
+
+``` shell
+openstack-ansible site-artifacts.yml -e 'apt_artifact_enabled=false' -e 'container_artifact_enabled=false' -e 'py_artifact_enabled=false'
+```
+
+These variables can be set on the CLI or within the `user_variables.yml` file.
+
+#### Optional | Setting the OpenStack-Ansible release
+
+It is possible to set the OSA release outside of the predefined "stable" release
+curated by the RPC-OpenStack product. To set the release define the Ansible
+variable `osa_release` to a SHA, Branch, or Tag and run the `site-release.yml`
+playbook.
+
+``` shell
+openstack-ansible site-release.yml -e 'osa_release=master'
+```
+
+This option can be set on the CLI or within the `user_variables.yml` file.
+
+#### Deploy the Rackspace Value Added Services
 
 Upon completion of the deployment run `scripts/deploy-rpco.sh` script to
 apply the RPC-OpenStack value added services; you may also run the playbooks
 `site-logging.yml` to accomplish much of the same things.
 
-Post deployment run the **optional** `openstack-image-setup.yml` and
-`openstack-flavor-setup.yml` playbooks to setup default flavors and images.
+``` shell
+cd /opt/rpc-openstack
+openstack-ansible site-logging.yml
+```
 
-### Testing & Gating
+Post deployment run the **optional** `site-openstack.yml` playbooks to setup
+default flavors and images.
+
+``` shell
+cd /opt/rpc-openstack
+openstack-ansible site-openstack.yml
+```
+
+### Perform an Intra-Series Product Upgrade
+
+To run a basic system upgrade set the `${RPC_PRODUCT_RELEASE}` option, re-run
+`deploy.sh`, and setup the artifact configuration for the deployment.
+
+``` shell
+tmux
+cd /opt/rpc-openstack
+export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stable product will be used
+./scripts/deploy.sh
+openstack-ansible site-artifacts.yml
+```
+
+Once basic system configuration has completed, [run through the upgrade process](https://docs.openstack.org/openstack-ansible/pike/user/minor-upgrade.html)
+for the specified product release.  
+
+### Perform a Major Product Upgrade (BETA)
+
+To run a major upgrade set the `${RPC_PRODUCT_RELEASE}` option, re-run
+`deploy.sh`, and setup the artifact configuration for the deployment.
+
+``` shell
+tmux
+cd /opt/rpc-openstack
+export RPC_PRODUCT_RELEASE="master"  # This needs to be set to the new product
+./scripts/deploy.sh
+openstack-ansible site-artifacts.yml
+```
+
+Once the deployment is ready either [run the major upgrade script](https://docs.openstack.org/openstack-ansible/pike/user/script-upgrade.html)
+or [run the manual upgrade](https://docs.openstack.org/openstack-ansible/pike/user/manual-upgrade.html)
+process.
+
+### Testing and Gating
 
 Please see the documentation in [rpc-gating/README.md](https://github.com/rcbops/rpc-gating/blob/master/README.md)

--- a/ansible-role-master-requirements.yml
+++ b/ansible-role-master-requirements.yml
@@ -16,16 +16,22 @@
 - name: logstash
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
-  version: f42bd2ccdc9c4608e2a357a9f088e3873a6ecad4
+  version: master
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: ce4c1b16e9bfd7b27a874b95218cde2bc1293bec
+  version: master
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git
-  version: 85fa8ed1881282a1b850dccfcd31de3d6a157cbb
+  version: master
 - name: elasticsearch
   scm: git
   src: https://github.com/elastic/ansible-elasticsearch
-  version: 0bffa37035652fc06b547c8ef68c2aaf15b92f80
+  version: master
+
+# RPC-Support specific role
+- name: rcbops_openstack-ops
+  scm: git
+  src: https://github.com/rsoprivatecloud/openstack-ops
+  version: master

--- a/ansible-role-newton-requirements.yml
+++ b/ansible-role-newton-requirements.yml
@@ -1,0 +1,37 @@
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE(cloudnull): Logging Specific roles
+- name: logstash
+  scm: git
+  src: https://github.com/rcbops/rpc-role-logstash.git
+  version: f42bd2ccdc9c4608e2a357a9f088e3873a6ecad4
+- name: filebeat
+  scm: git
+  src: https://github.com/rcbops/rpc-role-filebeat.git
+  version: ce4c1b16e9bfd7b27a874b95218cde2bc1293bec
+- name: kibana
+  scm: git
+  src: https://github.com/rcbops/rpc-role-kibana.git
+  version: 85fa8ed1881282a1b850dccfcd31de3d6a157cbb
+- name: elasticsearch
+  scm: git
+  src: https://github.com/d34dh0r53/ansible-elasticsearch
+  version: 757d875cceb5912939af8f7712ea247a0cdc8284
+
+# RPC-Support specific role
+- name: rcbops_openstack-ops
+  scm: git
+  src: https://github.com/rsoprivatecloud/openstack-ops
+  version: dfc2180e9bf28c8f59baca2a233db2a726b97bcb

--- a/ansible-role-ocata-requirements.yml
+++ b/ansible-role-ocata-requirements.yml
@@ -1,0 +1,37 @@
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE(cloudnull): Logging Specific roles
+- name: logstash
+  scm: git
+  src: https://github.com/rcbops/rpc-role-logstash.git
+  version: f42bd2ccdc9c4608e2a357a9f088e3873a6ecad4
+- name: filebeat
+  scm: git
+  src: https://github.com/rcbops/rpc-role-filebeat.git
+  version: ce4c1b16e9bfd7b27a874b95218cde2bc1293bec
+- name: kibana
+  scm: git
+  src: https://github.com/rcbops/rpc-role-kibana.git
+  version: 85fa8ed1881282a1b850dccfcd31de3d6a157cbb
+- name: elasticsearch
+  scm: git
+  src: https://github.com/elastic/ansible-elasticsearch
+  version: 0bffa37035652fc06b547c8ef68c2aaf15b92f80
+
+# RPC-Support specific role
+- name: rcbops_openstack-ops
+  scm: git
+  src: https://github.com/rsoprivatecloud/openstack-ops
+  version: dfc2180e9bf28c8f59baca2a233db2a726b97bcb

--- a/ansible-role-pike-requirements.yml
+++ b/ansible-role-pike-requirements.yml
@@ -1,0 +1,37 @@
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE(cloudnull): Logging Specific roles
+- name: logstash
+  scm: git
+  src: https://github.com/rcbops/rpc-role-logstash.git
+  version: f42bd2ccdc9c4608e2a357a9f088e3873a6ecad4
+- name: filebeat
+  scm: git
+  src: https://github.com/rcbops/rpc-role-filebeat.git
+  version: ce4c1b16e9bfd7b27a874b95218cde2bc1293bec
+- name: kibana
+  scm: git
+  src: https://github.com/rcbops/rpc-role-kibana.git
+  version: 85fa8ed1881282a1b850dccfcd31de3d6a157cbb
+- name: elasticsearch
+  scm: git
+  src: https://github.com/elastic/ansible-elasticsearch
+  version: 0bffa37035652fc06b547c8ef68c2aaf15b92f80
+
+# RPC-Support specific role
+- name: rcbops_openstack-ops
+  scm: git
+  src: https://github.com/rsoprivatecloud/openstack-ops
+  version: dfc2180e9bf28c8f59baca2a233db2a726b97bcb

--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -1,9 +1,11 @@
 #!/bin/bash -xe
 
+export GATING_PATH="$(readlink -f $(dirname ${0}))"
+source "${GATING_PATH}/../../scripts/functions.sh"
+
 ## Update OSA SHA to head of stable/pike
 # These var must be set per branch of RPC-Openstack
-osa_branch=stable/pike
-rpco_branch=${BRANCH:-master} # BRANCH injected by Jenkins.
+rpco_branch="${BRANCH:-master}" # BRANCH injected by Jenkins.
 
 # Env vars injected by Jenkins:
 WORKSPACE="${WORKSPACE:-/opt}"
@@ -17,27 +19,35 @@ git submodule update --init --remote
 
 # Get current head of osa
 osa_dir="${WORKSPACE}/openstack-ansible"
-git clone "https://github.com/openstack/openstack-ansible" ${osa_dir}
-pushd ${osa_dir}
-  git checkout $osa_branch
+git clone "https://github.com/openstack/openstack-ansible" "${osa_dir}"
+pushd "${osa_dir}"
+  git checkout "${OSA_RELEASE}"
   osa_sha="$(git log -n 1 --format=%H)"
 popd
-sed -i "s|^export OSA_RELEASE.*|export OSA_RELEASE=\"\${OSA_RELEASE:-${osa_sha}}\"|g" scripts/functions.sh
-
 
 ## Update rpc-maas to latest tag
 rpc_maas_dir="${WORKSPACE}/rpc-maas"
-git clone https://github.com/rcbops/rpc-maas $rpc_maas_dir
-pushd $rpc_maas_dir
+git clone https://github.com/rcbops/rpc-maas "${rpc_maas_dir}"
+pushd "${rpc_maas_dir}"
   # the maas repo includes old tags eg v9.x.x and 9.x.x when the version
   #  at the time of writing is 1.x.x. All tags that include a character
   #  or that start with 9 or 10 are filtered out.
   latest_maas_tag="$(git tag -l |grep -v '[a-zA-Z]\|^\(9\.\|10\.\)' |sort -n |tail -n 1)"
 popd
-# Insert latest maas tag into rpcd/etc/openstack_deploy/user_rpco_variables_defaults.yml
-#  Insert current SHA into functions.sh
-sed -i '/^maas_release:/ c\
-maas_release: "'${latest_maas_tag}'"' etc/openstack_deploy/group_vars/all/release.yml
+
+# Write to the rpc-release file
+python <<EOC
+import yaml
+release_file = "${GATING_PATH}/../../playbooks/vars/rpc-release.yml"
+with open(release_file) as f:
+  x = yaml.safe_load(f.read())
+release_data = x['rpc_product_releases']["${RPC_PRODUCT_RELEASE}"]
+release_data['maas_release'] = "${latest_maas_tag}"
+release_data['osa_release'] = "${osa_sha}"
+with open(release_file, 'w') as f:
+  f.write(yaml.safe_dump(x, default_flow_style=False, width=1000))
+print('Product release set: [%s]' % release_data)
+EOC
 
 # can't use derive-artifact-version.sh as that hardcodes the rpc repo path
 extract_rpc_release(){
@@ -53,12 +63,12 @@ update_rpc_release(){
   echo "rpc_release version from current branch (${rpco_branch}): ${current_branch_version}"
 
   # Extract the required version info
-  major_version=$( echo ${rc_branch_version} | cut -d. -f1 )
-  minor_version=$( echo ${rc_branch_version} | cut -d. -f2 )
-  patch_version=$( echo ${rc_branch_version} | cut -d. -f3 )
+  major_version="$( echo ${rc_branch_version} | cut -d. -f1 )"
+  minor_version="$( echo ${rc_branch_version} | cut -d. -f2 )"
+  patch_version="$( echo ${rc_branch_version} | cut -d. -f3 )"
 
   # increment the minor version
-  minor_version=$(( minor_version + 1 ))
+  minor_version="$(( minor_version + 1 ))"
 
   incremented_version="${major_version}.${minor_version}.${patch_version}"
   echo "Incremented rpc_release version: ${incremented_version}"
@@ -77,7 +87,7 @@ update_rpc_release(){
 # Get RC branch version
 rc_branch="${rpco_branch}-rc"
 git fetch origin
-if git show origin/${rc_branch}; then
+if git show "origin/${rc_branch}"; then
   update_rpc_release
 else
   echo "RC branch ${rc_branch} not found, skipping rpc_release version bump.

--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -21,7 +21,7 @@
   pre_tasks:
     - name: Ensure local facts directory exists
       file:
-        path: "/etc/ansible/facts.d"
+        dest: "/etc/ansible/facts.d"
         state: directory
         group: "root"
         owner: "root"
@@ -34,6 +34,24 @@
         section: "rpc_artifacts"
         option: initialized
         value: true
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Set the rpc-openstack variables
+      set_fact:
+        rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_artifacts'] }}"
+
+    - name: Set the rpc-artifact variables
+      set_fact:
+        apt_artifact_enabled: "{{ rpc_openstack['apt_artifact_enabled'] }}"
+      when:
+        - rpc_openstack['apt_artifact_enabled'] is defined
+        - apt_artifact_enabled is undefined
 
     - name: Check for artifacts
       uri:
@@ -72,6 +90,8 @@
       with_items:
         - files/apt.yml
         - files/maas.yml
+      run_once: true
+      delegate_to: localhost
       when:
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
@@ -133,7 +153,7 @@
 
     - name: Remove extra sources
       lineinfile:
-        path: /etc/apt/sources.list
+        dest: /etc/apt/sources.list
         state: absent
         regexp: "{{ item }}"
       with_items:
@@ -162,3 +182,6 @@
       with_items:
         - { option: "apt_artifact_enabled", value: "{{ apt_artifact_enabled }}" }
         - { option: "apt_artifact_found", value: "{{ apt_artifact_found }}" }
+
+  tags:
+    - rpc

--- a/playbooks/configure-container-sources.yml
+++ b/playbooks/configure-container-sources.yml
@@ -24,7 +24,7 @@
   pre_tasks:
     - name: Ensure local facts directory exists
       file:
-        path: "/etc/ansible/facts.d"
+        dest: "/etc/ansible/facts.d"
         state: directory
         group: "root"
         owner: "root"
@@ -37,6 +37,24 @@
         section: "rpc_artifacts"
         option: initialized
         value: true
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Set the rpc-openstack variables
+      set_fact:
+        rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_artifacts'] }}"
+
+    - name: Set the rpc-artifact variables
+      set_fact:
+        container_artifact_enabled: "{{ rpc_openstack['container_artifact_enabled'] }}"
+      when:
+        - rpc_openstack['container_artifact_enabled'] is defined
+        - container_artifact_enabled is undefined
 
     - name: Check for artifacts
       uri:
@@ -113,3 +131,6 @@
       with_items:
         - { option: "container_artifact_enabled", value: "{{ container_artifact_enabled }}" }
         - { option: "container_artifact_found", value: "{{ container_artifact_found }}" }
+
+  tags:
+    - rpc

--- a/playbooks/configure-python-sources.yml
+++ b/playbooks/configure-python-sources.yml
@@ -21,7 +21,7 @@
   pre_tasks:
     - name: Ensure local facts directory exists
       file:
-        path: "/etc/ansible/facts.d"
+        dest: "/etc/ansible/facts.d"
         state: directory
         group: "root"
         owner: "root"
@@ -34,6 +34,31 @@
         section: "rpc_artifacts"
         option: initialized
         value: true
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Set the rpc-openstack variables
+      set_fact:
+        rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_artifacts'] }}"
+
+    - name: Set the rpc-artifact variables
+      set_fact:
+        py_artifact_enabled: "{{ rpc_openstack['py_artifact_enabled'] }}"
+      when:
+        - rpc_openstack['py_artifact_enabled'] is defined
+        - py_artifact_enabled is undefined
+
+    - name: Set the rpc-artifact variables
+      set_fact:
+        apt_artifact_enabled: "{{ rpc_openstack['apt_artifact_enabled'] }}"
+      when:
+        - rpc_openstack['apt_artifact_enabled'] is defined
+        - apt_artifact_enabled is undefined
 
     - name: Check for artifacts (wheels)
       uri:
@@ -73,7 +98,7 @@
 
     - name: Notify the Deployer
       debug:
-        msg: |
+        msg: >-
           ********************* NOTICE! *********************
           At this time there is no good way to override the repo-build process
           so that we can stash our python wheels into the repo container at build
@@ -129,3 +154,6 @@
       with_items:
         - { option: "py_artifact_enabled", value: "{{ py_artifact_enabled }}" }
         - { option: "py_artifact_found", value: "{{ py_artifact_found }}" }
+
+  tags:
+    - rpc

--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -1,0 +1,133 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Check for RPC-OpenStack product_release variable
+  hosts: localhost
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  connection: local
+  user: root
+  gather_facts: true
+  pre_tasks:
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Ensure local facts directory exists
+      file:
+        dest: "/etc/ansible/facts.d"
+        state: directory
+        group: "root"
+        owner: "root"
+        mode:  "0755"
+        recurse: no
+
+    - name: initialize local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_product"
+        option: initialized
+        value: true
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Set the rpc-openstack variables
+      set_fact:
+        rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
+
+    - name: Set the rpc-release variables
+      set_fact:
+        rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
+      when:
+        - rpc_openstack['rpc_product_release'] is defined
+        - rpc_product_release is undefined or
+          rpc_product_release == 'undefined'
+
+  tasks:
+    - name: Check for product_release variable
+      fail:
+        msg: >-
+          RPC product [{{ rpc_product_release }}] is unknown. Available options
+          are {{ rpc_product_releases.keys() }}. Set the environment variable
+          RPC_PRODUCT_RELEASE to the product release required or use the
+          ansible override [rpc_product_release] when running this play.
+      when:
+        - rpc_product_release is undefined or
+          rpc_product_release == 'undefined' or
+          not rpc_product_releases[rpc_product_release] is defined
+
+    - name: Set OpenStack-Ansible release option
+      set_fact:
+        osa_release: "{{ rpc_product_releases[rpc_product_release]['osa_release'] }}"
+        osa_force_clone: true
+      when:
+        - osa_release is undefined
+
+    - name: Set the product release
+      lineinfile:
+        dest: /etc/openstack_deploy/group_vars/all/release.yml
+        state: present
+        regexp: "^{{ item.key }}:"
+        line: '{{ item.key }}: "{{ item.value }}"'
+      with_dict: "{{ rpc_product_releases[rpc_product_release] }}"
+
+    - name: Clone / Checkout OpenStack-Ansible
+      git:
+        repo: "https://git.openstack.org/openstack/openstack-ansible"
+        dest: "/opt/openstack-ansible"
+        version: "{{ osa_release }}"
+        force: "{{ osa_force_clone | default(false) }}"
+
+    - name: Galaxy install the RPC-OpenStack roles
+      command: |
+        ansible-galaxy install \
+          --role-file={{ playbook_dir }}/../ansible-role-{{ rpc_product_release }}-requirements.yml \
+          --roles-path=/etc/ansible/roles \
+          --force
+      tags:
+        - skip_ansible_lint
+
+    - name: Galaxy install the OpenStack-Ansible roles
+      command: |
+        ansible-galaxy install \
+          --role-file=/opt/openstack-ansible/ansible-role-requirements.yml \
+          --roles-path=/etc/ansible/roles \
+          --force
+      tags:
+        - skip_ansible_lint
+
+  post_tasks:
+    - name: Set product release local fact
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_product"
+        option: "rpc_product_release"
+        value: "{{ rpc_product_release }}"
+
+  vars:
+    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') | default('undefined', true) }}"
+
+  vars_files:
+    - vars/rpc-release.yml
+
+  tags:
+    - rpc

--- a/playbooks/elasticsearch.yml
+++ b/playbooks/elasticsearch.yml
@@ -17,16 +17,24 @@
   hosts: elasticsearch_all
   environment: "{{ deployment_environment_variables | default({}) }}"
   pre_tasks:
+    - name: Debian - Add Elasticsearch repository key
+      become: yes
+      apt_key:
+        url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+        state: "present"
+
     - name: Create ElasticSearch data directory on host
       file:
-        path: "/openstack/{{ container_name }}/var/lib/elasticsearch"
+        dest: "/openstack/{{ container_name }}/var/lib/elasticsearch"
         state: directory
         group: "root"
         owner: "root"
         mode:  "0755"
         recurse: no
       delegate_to: "{{ physical_host }}"
-      when: not (is_metal | bool)
+      when:
+        - not (is_metal | bool)
+
     - name: ElasticSearch extra lxc config
       lxc_container:
         name: "{{ container_name }}"
@@ -36,24 +44,30 @@
           - "lxc.mount.entry=/openstack/{{ container_name }}/var/lib/elasticsearch var/lib/elasticsearch none bind 0 0"
           - "lxc.aa_profile=unconfined"
       delegate_to: "{{ physical_host }}"
-      when: not (is_metal | bool)
+      when:
+        - not (is_metal | bool)
       tags:
         - elasticsearch-pre-install
+
     - name: Flush net cache
       command: /usr/local/bin/lxc-system-manage flush-net-cache
       delegate_to: "{{ physical_host }}"
-      when: not (is_metal | bool)
+      when:
+        - not (is_metal | bool)
       tags:
         - elasticsearch-pre-install
+
     - name: Wait for container ssh
       wait_for:
         port: "22"
         delay: 5
         host: "{{ container_address }}"
       delegate_to: "{{ physical_host }}"
-      when: not (is_metal | bool)
+      when:
+        - not (is_metal | bool)
       tags:
         - elasticsearch-pre-install
+
   roles:
     - role: "elasticsearch"
       tags:
@@ -61,3 +75,6 @@
 
   vars:
     is_metal: "{{ properties.is_metal | default(False) }}"
+
+  tags:
+    - rpc

--- a/playbooks/filebeat.yml
+++ b/playbooks/filebeat.yml
@@ -17,5 +17,15 @@
   hosts: all
   environment: "{{ deployment_environment_variables | default({}) }}"
   max_fail_percentage: 20
+  pre_tasks:
+    - name: Debian - Add Elasticsearch repository key
+      become: yes
+      apt_key:
+        url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+        state: "present"
+
   roles:
     - role: "filebeat"
+
+  tags:
+    - rpc

--- a/playbooks/get-maas.yml
+++ b/playbooks/get-maas.yml
@@ -31,5 +31,7 @@
       copy:
         src: "/opt/rpc-maas/tests/user_master_vars.yml"
         dest: "/etc/openstack_deploy/user_rpcm_variables_defaults.yml"
+
   tags:
     - maas
+    - rpc

--- a/playbooks/kibana.yml
+++ b/playbooks/kibana.yml
@@ -13,8 +13,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE(cloudnull): The Kibana role has a dependent call to the haproxy_server
+#                  role. This change ensures the SSL keys are are set as
+#                  variables which allows the role to be deployment agnostic.
+- name: Cache Haproxy certificates
+  hosts: haproxy_all[0]
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  pre_tasks:
+    - name: Store ssl cert
+      slurp:
+        src: "{{ haproxy_ssl_cert }}"
+      register: _haproxy_ssl_cert
+    - name: Store ssl key
+      slurp:
+        src: "{{ haproxy_ssl_key }}"
+      register: _haproxy_ssl_key
+    - name: Register a fact for the cert and key
+      set_fact:
+        haproxy_ssl_cert_fact: "{{ _haproxy_ssl_cert.content }}"
+        haproxy_ssl_key_fact: "{{ _haproxy_ssl_key.content }}"
+
+  vars:
+    haproxy_ssl_cert: /etc/ssl/certs/haproxy.cert
+    haproxy_ssl_key: /etc/ssl/private/haproxy.key
+
+  tags:
+    - rpc
+
 - name: Setup Kibana host
   hosts: kibana_all
   environment: "{{ deployment_environment_variables | default({}) }}"
+  pre_tasks:
+    - name: Debian - Add Elasticsearch repository key
+      become: yes
+      apt_key:
+        url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+        state: "present"
+
   roles:
     - role: "kibana"
+
+  tags:
+    - rpc

--- a/playbooks/logstash.yml
+++ b/playbooks/logstash.yml
@@ -16,7 +16,18 @@
 - name: Setup Logstash host
   hosts: logstash_all
   environment: "{{ deployment_environment_variables | default({}) }}"
-  vars:
-    - elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}"
+  pre_tasks:
+    - name: Debian - Add Elasticsearch repository key
+      become: yes
+      apt_key:
+        url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+        state: "present"
+
   roles:
     - role: "logstash"
+
+  vars:
+    - elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]]['container_address'] }}"
+
+  tags:
+    - rpc

--- a/playbooks/openstack-flavor-setup.yml
+++ b/playbooks/openstack-flavor-setup.yml
@@ -15,6 +15,7 @@
 
 - name: OpenStack flavor setup
   hosts: utility_all[0]
+  environment: "{{ deployment_environment_variables | default({}) }}"
   user: root
   tasks:
     - name: Install shade
@@ -40,5 +41,9 @@
       with_items: "{{ openstack_vm_flavors }}"
 
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   vars_files:
     - vars/openstack-service-config.yml
+
+  tags:
+    - rpc

--- a/playbooks/openstack-image-setup.yml
+++ b/playbooks/openstack-image-setup.yml
@@ -15,6 +15,7 @@
 
 - name: OpenStack image setup
   hosts: utility_all[0]
+  environment: "{{ deployment_environment_variables | default({}) }}"
   user: root
   tasks:
     - name: Install shade
@@ -47,10 +48,12 @@
 
     - name: Clean up temp file
       file:
-        path: "/var/backup/os_image_{{ item.name }}"
+        dest: "/var/backup/os_image_{{ item.name }}"
         state: absent
       with_items: "{{ openstack_images }}"
 
-  environment: "{{ deployment_environment_variables | default({}) }}"
   vars_files:
     - vars/openstack-service-config.yml
+
+  tags:
+    - rpc

--- a/playbooks/rpc-support.yml
+++ b/playbooks/rpc-support.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, Rackspace US, Inc.
+# Copyright 2014-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The release tag to use
-# Note that this is set here so that the openstack_release override in
-# "osa_defaults" is able to use it.
-rpc_release: "undefined"
-
-# TODO(evrardjp): Move this to group_vars/all/release.yml when possible
-#                 The release tag to use for the repo and venvs
-#                 This can't be overriden because OSA is using group_vars.
-openstack_release: "{{ rpc_release }}"
-
-# Set the release of the maas
-maas_release: "undefined"
+- name: Setup openstack-ops module
+  hosts: all
+  gather_facts: yes
+  roles:
+    - role: "rcbops_openstack-ops"

--- a/playbooks/site-logging.yml
+++ b/playbooks/site-logging.yml
@@ -15,6 +15,6 @@
 
 - include: elasticsearch.yml
 - include: logstash.yml
-- include: kibana.yml
 - include: filebeat.yml
+- include: kibana.yml
 - include: get-maas.yml

--- a/playbooks/site-openstack.yml
+++ b/playbooks/site-openstack.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, Rackspace US, Inc.
+# Copyright 2017, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The release tag to use
-# Note that this is set here so that the openstack_release override in
-# "osa_defaults" is able to use it.
-rpc_release: "undefined"
-
-# TODO(evrardjp): Move this to group_vars/all/release.yml when possible
-#                 The release tag to use for the repo and venvs
-#                 This can't be overriden because OSA is using group_vars.
-openstack_release: "{{ rpc_release }}"
-
-# Set the release of the maas
-maas_release: "undefined"
+- include: openstack-image-setup.yml
+- include: openstack-flavor-setup.yml

--- a/playbooks/site-release.yml
+++ b/playbooks/site-release.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The release tag to use
-# Note that this is set here so that the openstack_release override in
-# "osa_defaults" is able to use it.
-rpc_release: "undefined"
-
-# TODO(evrardjp): Move this to group_vars/all/release.yml when possible
-#                 The release tag to use for the repo and venvs
-#                 This can't be overriden because OSA is using group_vars.
-openstack_release: "{{ rpc_release }}"
-
-# Set the release of the maas
-maas_release: "undefined"
+- include: configure-release.yml

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: site-logging.yml
+- include: site-release.yml
 - include: site-artifacts.yml
-- include: openstack-image-setup.yml
-- include: openstack-flavor-setup.yml
+- include: site-logging.yml
+- include: site-openstack.yml

--- a/playbooks/stage-python-artifacts.yml
+++ b/playbooks/stage-python-artifacts.yml
@@ -22,18 +22,15 @@
         name: "{{ staging_host | default(hostvars[groups['repo_all'][0]]['physical_host']) }}"
         groups: staging_hosts
 
+  tags:
+    - rpc
+
 
 
 - name: Stage the git and python artifacts
   hosts: staging_hosts
   user: root
   environment: "{{ deployment_environment_variables | default({}) }}"
-  vars:
-    aria_input_file: "/tmp/python_artifact_list.txt"
-    http_proxy_env: "{{ lookup('env', 'http_proxy') | default('not_set', true) }}"
-    https_proxy_env: "{{ lookup('env', 'https_proxy') | default('not_set', true) }}"
-    https_validate_certs: yes
-
   tasks:
     - name: Set the staging path
       set_fact:
@@ -159,7 +156,7 @@
 
     - name: Staging folders setup
       file:
-        path: "{{ item }}"
+        dest: "{{ item }}"
         state: "directory"
       with_items:
         - "{{ staging_path }}/git-archives/{{ rpc_release }}"
@@ -253,3 +250,12 @@
         - item['ansible_job_id'] is defined
       tags:
         - git
+
+  vars:
+    aria_input_file: "/tmp/python_artifact_list.txt"
+    http_proxy_env: "{{ lookup('env', 'http_proxy') | default('not_set', true) }}"
+    https_proxy_env: "{{ lookup('env', 'https_proxy') | default('not_set', true) }}"
+    https_validate_certs: yes
+
+  tags:
+    - rpc

--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -1,0 +1,17 @@
+rpc_product_releases:
+  master:
+    maas_release: master
+    osa_release: master
+    rpc_release: master
+  newton:
+    maas_release: 1.3.1
+    osa_release: 03ef2e15742c6bd8404b784b06de6506ab750638
+    rpc_release: r14.5.0
+  ocata:
+    maas_release: 1.3.1
+    osa_release: stable/ocata
+    rpc_release: r15.0.0
+  pike:
+    maas_release: 1.3.1
+    osa_release: stable/pike
+    rpc_release: r16.0.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,32 +18,16 @@ set -euv
 set -o pipefail
 
 ## Vars ----------------------------------------------------------------------
-export DEPLOY_AIO=${DEPLOY_AIO:-false}
-
 # NOTE(cloudnull): See comment further down, but this should be removed later.
 export MARKER="/tmp/gate-check-commit.complete"
 
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
 ## Functions -----------------------------------------------------------------
+source "${SCRIPT_PATH}/functions.sh"
+
 function exit_notice {
-  echo -e "\n**System prepared for Installation**
-To configure the installation please refer to the upstream OpenStack-Ansible
-documentation regarding basic [system setup]
-(https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/configure.html).
-
-Prior to running the playbooks ensure your system(s) are using the latest
-artifacts. To ensure all hosts have the same artifacts run the RPC-OpenStack
-playbook \`site-artifacts.yml\`.
-
-Once the deploy configuration has been completed please refer to the
-OpenStack-Ansible documentation regarding [running the playbooks]
-(https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/run-playbooks.html).
-
-Upon completion of the deployment run \`scripts/deploy-rpco.sh\` script to
-apply the RPC-OpenStack value added services; you may also run the playbooks
-\`playbooks/site-logging.yml\` to accomplish much of the same things.
-"
+  cat "${SCRIPT_PATH}/../README.md"
 }
 
 function basic_install {
@@ -95,7 +79,6 @@ if [ "${DEPLOY_AIO}" != false ]; then
     touch ${MARKER}
   else
     echo "An AIO has already been created, remove \"${MARKER}\" to run again."
-    exit_notice
   fi
 
   # Deploy RPC-OpenStack.

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -14,17 +14,38 @@
 # limitations under the License.
 
 ## Vars ----------------------------------------------------------------------
+# Set the DEPLOY_ variables to true to enable these services
+export DEPLOY_AIO=${DEPLOY_AIO:-false}
+export DEPLOY_MAAS=${DEPLOY_MAAS:-false}
+export DEPLOY_TELEGRAF=${DEPLOY_TELEGRAF:-false}
+export DEPLOY_INFLUX=${DEPLOY_INFLUX:-false}
 
-# OSA SHA
-export OSA_RELEASE="${OSA_RELEASE:-b79e7f36abeb054e888b4f6ea75219b5fb3b03b9}"
-export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+# To send data to the influxdb server, we need to deploy and configure
+#  telegraf. By default, telegraf will use log_hosts (rsyslog hosts) to
+#  define its influxdb servers. These playbooks need maas-get to have run
+#  previously.
+# Set the following variables when when deploying maas with influx to log
+#  to our upstream influx server.
+export INFLUX_IP="${INFLUX_IP:-127.0.0.1}"
+export INFLUX_PORT="${INFLUX_PORT:-8086}"
 
-# Gating
-export BUILD_TAG=${BUILD_TAG:-}
-export INFLUX_IP=${INFLUX_IP:-}
-export INFLUX_PORT=${INFLUX_PORT:-"8086"}
+# Set the build tag to create a unique ID within influxdb
+export BUILD_TAG="${BUILD_TAG:-testing}"
+
+# RPC-OpenStack product release, this variable is used in the config playbooks.
+export RPC_PRODUCT_RELEASE="${RPC_PRODUCT_RELEASE:-pike}"
+
+# OSA release
+if [ -z ${OSA_RELEASE+x} ]; then
+  if [[ "${RPC_PRODUCT_RELEASE}" != "master" ]]; then
+    export OSA_RELEASE="stable/${RPC_PRODUCT_RELEASE}"
+  else
+    export OSA_RELEASE="master"
+  fi
+fi
 
 # Other
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
 export RPC_RELEASE="$(awk '/rpc_release/ { print $2; }' ${BASE_DIR}/etc/openstack_deploy/group_vars/all/release.yml | sed s'/"//'g)"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,10 +18,10 @@ set -euv
 set -o pipefail
 
 ## Vars ----------------------------------------------------------------------
-export OSA_RELEASE="${OSA_RELEASE:-stable/pike}"
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
 ## Functions -----------------------------------------------------------------
+source "${SCRIPT_PATH}/functions.sh"
 
 ## Main ----------------------------------------------------------------------
 
@@ -66,8 +66,7 @@ pushd /opt/openstack-ansible
   bash -c "scripts/bootstrap-ansible.sh"
 popd
 
-# Get RPC Ansible roles.
-ansible-playbook /opt/openstack-ansible/tests/get-ansible-role-requirements.yml \
-                 -i /opt/openstack-ansible/tests/test-inventory.ini \
-                 -e role_file="${SCRIPT_PATH}/../ansible-role-requirements.yml" \
-                 -vvv
+# Setup the basic release
+pushd "${SCRIPT_PATH}/../playbooks"
+  ansible-playbook -i 'localhost,' site-release.yml
+popd

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = bindep,docs,linters,functional
+envlist = bindep,docs,linters
 sitepackages = True
 
 
@@ -24,13 +24,15 @@ setenv =
     WORKING_DIR={toxinidir}
     # bug#1682108
     PYTHONPATH={envsitepackagesdir}
+    # RPC product release name
+    RPC_PRODUCT_RELEASE={env:RPC_PRODUCT_RELEASE:pike}
     ### OSA specific call back files
     # Set the checkout to any supported tag, branch, or sha.
     # NOTE(cloudnull): This should be set to "master" as soon the gate is capable of
     #                  setting this option.
-    OSA_RELEASE=stable/pike
+    OSA_RELEASE={env:OSA_RELEASE:stable/pike}
     OSA_TEST_RELEASE=stable/pike
-    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_RELEASE:master}
+    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_ROLE_REQUIREMENTS=https://git.openstack.org/cgit/openstack/openstack-ansible/plain/ansible-role-requirements.yml?h={env:OSA_RELEASE:master}
 basepython = python2.7
@@ -121,10 +123,10 @@ deps =
     -r{env:OSA_TEST_DEPS}
 commands =
     bash -c "wget {env:OSA_ROLE_REQUIREMENTS} -O {toxinidir}/tests/common/osa-ansible-role-requirements.yml"
-    ansible-galaxy install --role-file={toxinidir}/ansible-role-requirements.yml \
+    ansible-galaxy install --role-file={toxinidir}/tests/common/osa-ansible-role-requirements.yml \
                            --roles-path={homedir}/.ansible/roles \
                            --force
-    ansible-galaxy install --role-file={toxinidir}/tests/common/osa-ansible-role-requirements.yml \
+    ansible-galaxy install --role-file={toxinidir}/ansible-role-{env:RPC_PRODUCT_RELEASE:pike}-requirements.yml \
                            --roles-path={homedir}/.ansible/roles \
                            --force
 


### PR DESCRIPTION
Change path to dest to support older ansible and enhance the playbooks
such that they're able to deloy any certified release of RPC-OpenStack.
Documentation has been updated showing how a deployer can consume
RPC-OpenStack README.md using any RPC-OpenStack product release.

RPC-OpenStack role release files have been added using the OpenStack
named releases corresponding to the RPC-OpenStack product releases.

Many of the RPC-OpenStack specific playbooks have been updated for
readability.

The dependency gating script was updated to modity the release file
using python YAML instead of bash. This makes updating the release
versions simpler and more predictable.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3080](https://rpc-openstack.atlassian.net/browse/RO-3080)