### PR TITLE
RO-3068 override ceph_stable_repo param

### DIFF
--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -45,6 +45,9 @@ fetch_directory: /etc/openstack_deploy/ceph_fetch
 ceph_stable: true
 # Specify ceph release name
 ceph_stable_release: hammer
+# Override stable_repo URI. Current pin of ansible-ceph-common has invalid URI.
+# https://github.com/ceph/ansible-ceph-common/blob/033a5e54b97903750586efce67f3fe8ba968bf4/defaults/main.yml#L70
+ceph_stable_repo: "https://download.ceph.com/debian-{{ ceph_stable_release }}"
 # Enable OpenStack support inside the ceph-ansible playbooks
 openstack_config: true
 # Use raw journal devices

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -88,6 +88,7 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
       sed -i 's/is_metal: true/is_metal: false/' /etc/openstack_deploy/env.d/ceph.yml
       sed -i "s/journal_size:.*/journal_size: 1024/" $RPCD_VARS
       sed -i "s/raw_multi_journal:.*/raw_multi_journal: false/" $RPCD_VARS
+      sed -i "s/glance_default_store:.*/glance_default_store: rbd/" /etc/openstack_deploy/user_variables.yml
       add_config ceph
     else
       if [[ "$DEPLOY_SWIFT" == "yes" ]]; then


### PR DESCRIPTION
This commit adds a value for `ceph_stable_repo` ansible variable in
order to override the one provided by the
[ansible-ceph-common](https://github.com/ceph/ansible-ceph-common).

The Ceph ansible installation parameters are derived from the
upstream [ansible-ceph-common](https://github.com/ceph/ansible-ceph-common)
repository. The current submodule SHA pinned to the kilo branch of
the rpc-openstack repository is 033a5e54b97903750586efce67f3fe8ba968bf4.

The [value](https://github.com/ceph/ansible-ceph-common/blob/033a5e54b97903750586efce67f3fe8ba968bf4/defaults/main.yml#L70)
for the `ceph_stable_repo` is defined as a URI that is no longer
compatible with the online Ceph repository. The SHA of the
ansible-ceph-common repository has been orphaned from all current
branches of that repo.

The [change set](https://github.com/ceph/ansible-ceph-common/compare/033a5e54b97903750586efce67f3fe8ba968bf45...28abaa4871ea50d9ecbd2dc291e746b4415dea73)
introduced by the SHA in the master branch that updates
this variable would introduce a broader set of changes than is desirable
for the rpc-openstack repository. Therefore, this commit simply overrides
the value with one defined in the rpcd/etc/openstack_deploy/user_extras_variables.yml
file.

Issue: [RO-3068](https://rpc-openstack.atlassian.net/browse/RO-3068)