### PR TITLE
Set a package pin for the RPC-OpenStack repo

### DIFF
--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -165,11 +165,29 @@
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
+    - name: Remove apt preference file if artifacts are disbaled
+      file:
+        dest: "/etc/apt/preferences.d/rpc_openstack_pinned_packages.pref"
+        state: absent
+      when:
+        - not apt_artifact_enabled | bool
+
     - name: Update apt-cache
       apt:
         update_cache: yes
       when:
         - (apt_artifact_found | bool) and (apt_sources_configure | changed or apt_sources_configure_rpco | changed)
+        - apt_artifact_enabled | bool
+
+  roles:
+    - role: "apt_package_pinning"
+      apt_package_pinning_file_name: "rpc_openstack_pinned_packages.pref"
+      apt_pinned_packages:
+        - package: "*"
+          release: "{{ rpc_release }}-{{ ansible_distribution_release }}"
+          priority: "999"
+      when:
+        - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
   post_tasks:


### PR DESCRIPTION
While the RPC-OpenStack repo "should" be the only repository used within
an artifacted deployment there are times when "other" repositories may
be added to a deployment post build which could have adverse affects on
our artifacted builds when it comes to day to operations. This change
adds a package pin instructing apt to prefer packages from our repos.
This change implements a pin using the highest priorty possible without
also instructing the APT to downgrade packages by default. The pin will
only be implemented when apt package artifacts are enabled and found to
be available.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3263](https://rpc-openstack.atlassian.net/browse/RO-3263)