### PR TITLE
Add properties to the images we provide

### DIFF
--- a/playbooks/openstack-image-setup.yml
+++ b/playbooks/openstack-image-setup.yml
@@ -42,6 +42,7 @@
         name: "{{ item.name }}"
         filename: "/var/backup/os_image_{{ item.name }}"
         disk_format: "{{ item.format }}"
+        properties: "{{ item.properties | default(omit) }}"
       with_items: "{{ openstack_images }}"
 
     - name: Clean up temp file

--- a/playbooks/vars/openstack-service-config.yml
+++ b/playbooks/vars/openstack-service-config.yml
@@ -67,18 +67,58 @@ openstack_images:
   - name: CentOS 7
     format: qcow2
     url: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+    properties:
+      hw_scsi_model: "virtio-blk"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "qemu"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
   - name: Cirros-0.3.5
     format: qcow2
     url: http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
   - name: Debian 9
     format: qcow2
     url: http://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
+    properties:
+      hw_scsi_model: "virtio-blk"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "qemu"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
   - name: OpenSuse Leap 42.3
     format: qcow2
     url: http://download.opensuse.org/repositories/Cloud:/Images:/Leap_42.3/images/openSUSE-Leap-42.3-OpenStack.x86_64.qcow2
+    properties:
+      hw_scsi_model: "virtio-blk"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "qemu"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
   - name: Ubuntu 14.04 LTS
     format: qcow2
     url: http://uec-images.ubuntu.com/releases/14.04/release/ubuntu-14.04-server-cloudimg-amd64-disk1.img
+    properties:
+      hw_scsi_model: "virtio-blk"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "qemu"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
   - name: Ubuntu 16.04
     format: qcow2
     url: http://uec-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
+    properties:
+      hw_scsi_model: "virtio-blk"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "qemu"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"

--- a/releasenotes/notes/image-metadata-8d1562d924ffd7e5.yaml
+++ b/releasenotes/notes/image-metadata-8d1562d924ffd7e5.yaml
@@ -1,0 +1,21 @@
+---
+features:
+  - Image metadata has been added to boost base image performance for the Images
+    that we may provide to a customer deployment.
+  - The metadata option `hw_scsi_model` is being passed into the images we
+    provide by default and is set to **virtio_scsi**.  This option will
+    improve IO performance on our default images. While not required, it is
+    recommended that the **virtio_scsi** kernel module be loaded on the host for
+    this change to have a functional benifit.
+  - The metadata option `hw_vif_multiqueue_enabled` is being passed into the
+    images we provide by default and is set to **true**.  This option will
+    improve network performance on our default images when the guest OS has
+    "multi-queuing" enabled. If the guest OS can not automatically understand
+    "multi-queuing" enablment the user can run the following command to enable
+    it within the guest `ethtool -L ${NIC} combined ${CPU_CORES}`.
+  - The metadata option `hw_qemu_guest_agent` is being passsed into the images
+    we provide by default and is set to "yes". This option will attempt to
+    enable qemu guest agent which provides additional options to nova when
+    managing the instance. While not required, it is recommended that the
+    **virtio_net** kernel module be loaded on the host for this change to have a
+    functional benifit.


### PR DESCRIPTION
This change adds property flags to the image we provide which will
ensure all of the images for distros that may run customer workloads
are operating at the highest level of performance possible.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>