### PR TITLE
[RO-3190] Disable container/py artifacts

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,7 +73,18 @@ if [ "${DEPLOY_AIO}" != false ]; then
     basic_install
 
     # Force the AIO to use artifacts
-    openstack-ansible -i 'localhost,' -e apt_target_group=localhost ${SCRIPT_PATH}/../playbooks/site-artifacts.yml
+    # NOTE(cloudnull): This disables container/py artifacts for now. The
+    #                  RPC-OpenStack container/py artifacts are failing
+    #                  while the upstream container/py builds of similart
+    #                  sizes, packages, and distros is not showing the same
+    #                  issues. We need to spend some time debugging how the
+    #                  sources are built and how we can better construct and
+    #                  consume them.
+    openstack-ansible -i 'localhost,' \
+                      -e apt_target_group=localhost \
+                      -e 'container_artifact_enabled=false' \
+                      -e 'py_artifact_enabled=false' \
+                      ${SCRIPT_PATH}/../playbooks/site-artifacts.yml
 
     ## Create the AIO
     pushd /opt/openstack-ansible

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -16,7 +16,7 @@
 ## Vars ----------------------------------------------------------------------
 
 # OSA SHA
-export OSA_RELEASE="${OSA_RELEASE:-27fa064a0eb2c2b17c361e176abe06375f8dc55f}"
+export OSA_RELEASE="${OSA_RELEASE:-b79e7f36abeb054e888b4f6ea75219b5fb3b03b9}"
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 
 # Gating


### PR DESCRIPTION
This disables container/py artifacts for now. The RPC-OpenStack container
and py artifacts are failing import while the upstream container images
and builds of similart sizes, packages, and distros are not showing the
same issues. We need to spend some time debugging how the images are
built and how we can better construct / consume machine images.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
Issue: [RO-3190](https://rpc-openstack.atlassian.net/browse/RO-3190)