### PR TITLE
RE-35 Snapshot Support

### DIFF
--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -58,3 +58,41 @@ if which lxc-ls &> /dev/null; then
 fi
 
 echo "#### END LOG COLLECTION ###"
+
+extract_rpc_release(){
+  awk '/rpc_release/{print $2}' | tr -d '"'
+}
+
+# Only enable snapshot when triggered by a commit push.
+# This is to enable image updates whenever a PR is merged, but not before
+if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
+  echo "### BEGIN SNAPSHOT PREP ###"
+  mkdir -p /gating/thaw
+
+  # /opt/rpc-openstack may be a symlink to $WORKSPACE/rpc-openstack
+  # However $WORKSPACE will be wiped prior to the snapshot being taken
+  # so will not be present in instances created from the snapshot.
+  # In order to ensure /opt/rpc-openstack is present in the snapshot
+  # We check if its a link if it is, unlink it and create a full copy.
+  pushd /opt
+  target="$(readlink -f rpc-openstack)"
+  if [[ -n "$target" ]]; then
+      echo "/opt/rpc-openstack is linked into $WORKSPACE/rpc-openstack which"
+      echo "will be wiped prior to creating a snapshot."
+      echo "Removing symlink and copying $WORKSPACE/rpc-openstack to /opt."
+      rm rpc-openstack
+      cp -ar $target rpc-openstack
+  fi
+
+  # /root/.ssh is cleared on thaw. We need to store the keys that were there.
+  mkdir -p /opt/root_ssh_backup
+  cp -vr /root/.ssh /opt/root_ssh_backup
+
+  ln -s /opt/rpc-openstack/gating/thaw/run /gating/thaw/run
+
+  rpc_release="$(extract_rpc_release </opt/rpc-openstack/group_vars/all/release.yml)"
+  distro="$(lsb_release --codename --short)"
+
+  echo "rpc_${rpc_release}_${distro}" > /gating/thaw/image_name
+  echo "### END SNAPSHOT PREP ###"
+fi

--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -10,6 +10,21 @@ echo "+-------------------- ENV VARS --------------------+"
 env
 echo "+-------------------- ENV VARS --------------------+"
 
+## Vars ----------------------------------------------------------------------
+
+export DEPLOY_AIO="true"
+# These vars are set by the CI environment, but are given defaults
+# here to cater for situations where someone is executing the test
+# outside of the CI environment.
+export RE_JOB_NAME="${RE_JOB_NAME:-}"
+export RE_JOB_IMAGE="${RE_JOB_IMAGE:-}"
+export RE_JOB_SCENARIO="${RE_JOB_SCENARIO:-swift}"
+export RE_JOB_ACTION="${RE_JOB_ACTION:-deploy}"
+export RE_JOB_FLAVOR="${RE_JOB_FLAVOR:-}"
+export RE_JOB_TRIGGER="${RE_JOB_TRIGGER:-USER}"
+export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
+export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
+
 ## Main ----------------------------------------------------------------------
 
 if [ $RE_JOB_ACTION == "tox-test" ]; then

--- a/gating/thaw/haproxycheck.yml
+++ b/gating/thaw/haproxycheck.yml
@@ -1,0 +1,37 @@
+- name: Check HAProxy status after reconfiguration
+  hosts: localhost
+  tasks:
+  - name: Check state of haproxy backends
+    shell: |
+      set -xeu
+      # Check haproxy backends excluding elasticsearch
+      # TODO: Fix elk in thaw process.
+      # Haproxy prints the stats iteration so if the line is "1" its ignored
+      # Lines where the first field is hash are comments and are ignored
+      # Field 6 is srv_op_state, and 2 is fully up.
+
+      # http://cbonte.github.io/haproxy-dconv/1.7/management.html#9.3-show%20servers%20state
+
+      echo "Checking HAProxy status"
+      set -o pipefail
+
+      for i in {1..30}
+      do
+        echo "show servers state" |nc -U /var/run/haproxy.stat > haproxy.stat
+        awk '$2 !~ "elastic" && $0 != "1" && $1 != "#" && $6 != "2" {print $0}' \
+          < haproxy.stat  \
+          |tee haproxy.down
+        if [[ $(wc -l < haproxy.down) == 1 ]]
+        then
+          echo "HAProxy healthchecks passing."
+          exit 0
+        else
+          echo "At least one HAProxy backend is down, sleeping for 60s before"
+          echo "rechecking."
+          sleep 60
+        fi
+      done
+      print "HAProxy backends failed to come up in time"
+      exit 1
+    args:
+      executable: /bin/bash

--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -1,0 +1,28 @@
+#!/bin/bash -xeu
+
+# Thaw Script
+
+# This script is executed when an instance is created from a snapshot of
+# an RPCO deployment. It should fix things that are broken by the switch
+# to a difference instance (eg IPs, hostname)
+
+
+# Need to ensure SSH config is ok before running ansible
+mkdir -p /root/.ssh
+cat /opt/root_ssh_backup/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+cat /opt/root_ssh_backup/.ssh/authorized_keys >> /root/.ssh/authorized_keys
+cp /opt/root_ssh_backup/.ssh/id_rsa /root/.ssh
+cp /opt/root_ssh_backup/.ssh/id_rsa.pub /root/.ssh
+cp /opt/root_ssh_backup/.ssh/known_hosts /root/.ssh ||:
+ssh-keyscan localhost >> /root/.ssh/known_hosts
+
+
+cd /opt/rpc-openstack/openstack-ansible/playbooks/
+
+# Use implicit fact gathering to ensure the fact cache is ignored,
+# and facts are always gathered. This important we rely on the public
+# IP fact being up to date.
+export ANSIBLE_GATHERING=implicit
+openstack-ansible -v /opt/rpc-openstack/gating/thaw/thaw.yml
+openstack-ansible -t haproxy_server-config haproxy-install.yml
+openstack-ansible -v /opt/rpc-openstack/gating/thaw/haproxycheck.yml

--- a/gating/thaw/thaw.yml
+++ b/gating/thaw/thaw.yml
@@ -1,0 +1,66 @@
+- name: Initialise network interfaces
+  hosts: localhost
+  tasks:
+  - name: Add source line to interfaces file
+    lineinfile:
+      dest: /etc/network/interfaces
+      regexp: ''
+      insertafter: EOF
+      line: 'source /etc/network/interfaces.d/*.cfg'
+
+  - name: Enable additional interfaces
+    shell: |
+      awk '/iface/{print $2}' /etc/network/interfaces.d/*\
+        |while read iface; do ifup $iface; done
+
+# Split into a new play so that fact gathering runs after all the interfaces
+# are up.
+- name: Post Network Thaw Tasks
+  hosts: localhost
+  tasks:
+  - name: Check for cinder loop image
+    stat:
+      path: /openstack/cinder.img
+      get_md5: false
+      get_checksum: false
+    register: cinder_img
+
+  - name: Setup Cinder LVM loop
+    shell: |
+      set -xeu
+      losetup -f /openstack/cinder.img
+    args:
+      executable: /bin/bash
+    when: cinder_img.stat.exists|bool
+
+  - name: Show new public IP
+    debug:
+      var: ansible_default_ipv4.address
+
+  - name: Fix up Public IP
+    replace:
+      dest: /etc/openstack_deploy/openstack_user_config.yml
+      regexp: "external_lb_vip_address:.*"
+      replace: "external_lb_vip_address: {{ ansible_default_ipv4.address }}"
+      backup: yes
+
+  - name: Fix up keystone_service
+    replace:
+      dest: /etc/haproxy/conf.d/keystone_service
+      regexp: "bind.*"
+      replace: "bind {{ ansible_default_ipv4.address }}:5000"
+
+  - name: List stopped containers
+    shell: |
+      lxc-ls -f | awk '/STOPPED.*openstack/{print $1}'
+    register: stopped_containers
+
+  - name: Start stopped containers
+    shell: |
+      lxc-start -d -n {{ item }}
+    with_items: "{{ stopped_containers.stdout_lines }}"
+
+  - name: Restart haproxy
+    service:
+      name: haproxy
+      state: restarted


### PR DESCRIPTION
This commit adds support to RPCO for saving a snapshot of a build
and reusing it later.

There are two parts:
1) Pre-Snapshot preparation: This is done at the end of a build to
prepare an instance for snapshotting. This is added to the post
hook of the pre_merge_test hook (which is also used for post merge).
RE_JOB_TRIGGER is used to determine the cause of the build, if the
cause is PUSH, then snapshot prep is enabled. Snapshot prep writes
the name of the image to be created to a file, the existence of that
file signals to rpc-gating that an image should be saved.

2) Thaw: These are tasks performed on a new instance created from
a snapshot. The thaw hook is /gating/thaw/run relative to the
instance's rootfs. The thaw hook is implemented in
rpc-openstack/gating/thaw/run. Pre snapshot prep ensures that script
is linked to /gating/thaw/run. The thaw hook fixes known issues
with openstack after moving to a different host, it is a shell
script that uses two playbooks, in the same directory.

Issue: [RE-35](https://rpc-openstack.atlassian.net/browse/RE-35)