### PR TITLE
RE-1199 Cater for alpha/beta release versions

### DIFF
--- a/gating/update_dependencies/get-rpc_release.py
+++ b/gating/update_dependencies/get-rpc_release.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import yaml
+
+# Read the release file path from an environment variable
+if len(sys.argv) > 1:
+    release_file = sys.argv[1]
+else:
+    release_file = os.environ['RELEASE_FILE']
+
+# Read the RPC release series name from an environment variable
+if len(sys.argv) > 2:
+    release_series = sys.argv[2]
+else:
+    release_series = os.environ['RPC_PRODUCT_RELEASE']
+
+# Read the file contents
+with open(release_file) as f:
+    release_file_content = yaml.safe_load(f.read())
+
+# Read the series-specific data
+release_data = release_file_content['rpc_product_releases'][release_series]
+
+# Get the current rpc_release version
+rpc_release = release_data['rpc_release']
+
+# Print out the rpc_release value
+print(rpc_release)

--- a/gating/update_dependencies/release-update.py
+++ b/gating/update_dependencies/release-update.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import os
+import semver
+import yaml
+
+# Read the release file path from an environment variable
+release_file = os.environ['RELEASE_FILE']
+
+# Read the RPC release series name from an environment variable
+release_series = os.environ['RPC_PRODUCT_RELEASE']
+
+# Read the maas_release to set from an an environment variable
+maas_release = os.environ['MAAS_TAG']
+
+# Read the osa_release to set from an environment variable
+osa_release = os.environ['OSA_SHA']
+
+# Read the rpc_rc_release version from an environment variable
+rpc_rc_release = os.environ['RC_BRANCH_VERSION']
+
+# Read the file contents
+with open(release_file) as f:
+    release_file_content = yaml.safe_load(f.read())
+
+# Read the series-specific data
+release_data = release_file_content['rpc_product_releases'][release_series]
+
+# Get the current rpc_release version
+rpc_release = release_data['rpc_release']
+
+# Validate that the version complies with the RPC-O
+# version naming standards.
+# ref: https://rpc-openstack.atlassian.net/browse/RE-1199
+#
+# This is important for all PR's to ensure that we're
+# changing the version to something matching the right
+# standard.
+
+release_naming_standard = re.compile(
+    "^r[0-9]+.[0-9]+.[0-9]+(-(alpha|beta).[0-9]+)?$")
+
+assert release_naming_standard.match(rpc_release), (
+    "The rpc_release value of %s does not comply with the release naming"
+    " standard. Please correct it!" % rpc_release)
+
+# Extract the SemVer-compliant portion of the version (no 'r' prefix)
+rpc_release_semver = re.sub('^r', '', rpc_release)
+
+# If the rpc_rc_release and rpc_release versions match,
+# then we need to increment the value of rpc_release.
+if rpc_rc_release == rpc_release:
+
+    # If the current version is a prerelease version,
+    # then increment the prerelease.
+    rpc_release_parts = semver.parse(rpc_release_semver)
+    if rpc_release_parts['prerelease'] is not None:
+        rpc_release_semver_new = semver.bump_prerelease(rpc_release_semver)
+
+    # Otherwise, this is a standard release and we
+    # just need to do a minor version increment.
+    else:
+        rpc_release_semver_new = semver.bump_minor(rpc_release_semver)
+
+    # Now add the 'r' prefix back on for the final version
+    rpc_release = "r" + rpc_release_semver_new
+
+# Adjust the maas release
+release_data['maas_release'] = maas_release
+
+# Adjust the OSA SHA
+release_data['osa_release'] = osa_release
+
+# Adjust the RPC release version
+release_data['rpc_release'] = rpc_release
+
+# Write the file
+with open(release_file, 'w') as f:
+    f.write(
+        yaml.safe_dump(
+            release_file_content, default_flow_style=False, width=1000))
+
+# Output the details for debugging purposes
+print('Product release set: [%s]' % release_data)

--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -3,9 +3,14 @@
 export GATING_PATH="$(readlink -f $(dirname ${0}))"
 source "${GATING_PATH}/../../scripts/functions.sh"
 
+# Install the semver library to manipulate the
+# rpc_release version strings
+pip install semver==2.7.9
+
 ## Update OSA SHA to head of stable/pike
 # These var must be set per branch of RPC-Openstack
 rpco_branch="${BRANCH:-master}" # BRANCH injected by Jenkins.
+rc_branch="${rpco_branch}-rc"
 
 # Env vars injected by Jenkins:
 WORKSPACE="${WORKSPACE:-/opt}"
@@ -22,7 +27,7 @@ osa_dir="${WORKSPACE}/openstack-ansible"
 git clone "https://github.com/openstack/openstack-ansible" "${osa_dir}"
 pushd "${osa_dir}"
   git checkout "${OSA_RELEASE}"
-  osa_sha="$(git log -n 1 --format=%H)"
+  export OSA_SHA="$(git log -n 1 --format=%H)"
 popd
 
 ## Update rpc-maas to latest tag
@@ -32,63 +37,28 @@ pushd "${rpc_maas_dir}"
   # the maas repo includes old tags eg v9.x.x and 9.x.x when the version
   #  at the time of writing is 1.x.x. All tags that include a character
   #  or that start with 9 or 10 are filtered out.
-  latest_maas_tag="$(git tag -l |grep -v '[a-zA-Z]\|^\(9\.\|10\.\)' |sort -n |tail -n 1)"
+  export MAAS_TAG="$(git tag -l |grep -v '[a-zA-Z]\|^\(9\.\|10\.\)' |sort -n |tail -n 1)"
 popd
 
-# Write to the rpc-release file
-python <<EOC
-import yaml
-release_file = "${GATING_PATH}/../../playbooks/vars/rpc-release.yml"
-with open(release_file) as f:
-  x = yaml.safe_load(f.read())
-release_data = x['rpc_product_releases']["${RPC_PRODUCT_RELEASE}"]
-release_data['maas_release'] = "${latest_maas_tag}"
-release_data['osa_release'] = "${osa_sha}"
-with open(release_file, 'w') as f:
-  f.write(yaml.safe_dump(x, default_flow_style=False, width=1000))
-print('Product release set: [%s]' % release_data)
-EOC
+## Check what version is set in the RC branch
 
-# can't use derive-artifact-version.sh as that hardcodes the rpc repo path
-extract_rpc_release(){
-  awk '/^rpc_release/{print $2}' | tr -d '"'
-}
+# We can only use this method once this file exists in the RC branch, so
+# we have to implement the new method and a fall back to the old method.
 
-update_rpc_release(){
-  rc_branch_version="$(git show origin/${rc_branch}:etc/openstack_deploy/group_vars/all/release.yml \
-                      | extract_rpc_release)"
-  echo "rpc_release version from rc-branch (${rc_branch}): ${rc_branch_version}"
+new_file_to_fetch="origin/${rc_branch}:playbooks/vars/rpc-release.yml"
+old_file_to_fetch="origin/${rc_branch}:etc/openstack_deploy/group_vars/all/release.yml"
+release_data_file="${WORKSPACE}/rc-release-data.yml"
 
-  current_branch_version="$(extract_rpc_release < etc/openstack_deploy/group_vars/all/release.yml)"
-  echo "rpc_release version from current branch (${rpco_branch}): ${current_branch_version}"
+# new method
+if git cat-file -e ${new_file_to_fetch} 2>/dev/null; then
+  git show ${new_file_to_fetch} > ${release_data_file}
+  export RC_BRANCH_VERSION=$(${GATING_PATH}/get-rpc_release.py ${release_data_file})
 
-  # Extract the required version info
-  major_version="$( echo ${rc_branch_version} | cut -d. -f1 )"
-  minor_version="$( echo ${rc_branch_version} | cut -d. -f2 )"
-  patch_version="$( echo ${rc_branch_version} | cut -d. -f3 )"
+# old method
+elif git cat-file -e ${old_file_to_fetch} 2>/dev/null; then
+  git show ${old_file_to_fetch} > ${release_data_file}
+  export RC_BRANCH_VERSION=$(awk '/^rpc_release/{print $2}' ${release_data_file} | tr -d '"')
 
-  # increment the minor version
-  minor_version="$(( minor_version + 1 ))"
-
-  incremented_version="${major_version}.${minor_version}.${patch_version}"
-  echo "Incremented rpc_release version: ${incremented_version}"
-
-  sed -i "s/${current_branch_version}/${incremented_version}/" \
-    etc/openstack_deploy/group_vars/all/release.yml
-}
-
-# Update rpc_release. The mainline branch should always be one version
-# ahead of the rc branch, as the next rc branch will be cut from mainline
-# post release.
-
-# This update script will only ever run against a mainline branch, as
-# dependencies should not change once an RC branch has been cut.
-
-# Get RC branch version
-rc_branch="${rpco_branch}-rc"
-git fetch origin
-if git show "origin/${rc_branch}"; then
-  update_rpc_release
 else
   echo "RC branch ${rc_branch} not found, skipping rpc_release version bump.
 If there is no RC branch then the mainline branch is considered unreleased
@@ -96,3 +66,7 @@ and therefore the rpc_release value is left alone. It is still important
 for the dependencies to be updated regularly though, so that part continues
 to be done."
 fi
+
+# Execute the update of all the data
+export RELEASE_FILE="${GATING_PATH}/../../playbooks/vars/rpc-release.yml"
+${GATING_PATH}/release-update.py

--- a/playbooks/openstack-flavor-setup.yml
+++ b/playbooks/openstack-flavor-setup.yml
@@ -40,8 +40,6 @@
         ephemeral: "{{ item.ephemeral }}"
       with_items: "{{ openstack_vm_flavors }}"
 
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
   vars_files:
     - vars/openstack-service-config.yml
 

--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -14,4 +14,4 @@ rpc_product_releases:
   pike:
     maas_release: 1.3.1
     osa_release: stable/pike
-    rpc_release: r16.0.0
+    rpc_release: r16.0.0-alpha.1


### PR DESCRIPTION
The dependency update script also handles the automated update of
rpc_release when it is appropriate to do so. Currently it only
does minor version increments. There is no way to cater to alpha
or beta releases.

Also, the dependency update script is currently not working correctly.
With the implementation of c4132cd the dependency update script was
adjusted to update playbooks/vars/rpc-release.yml but it did not remove
the adjustments to etc/openstack_deploy/group_vars/all/release.yml. The
resulting PR's from the changes are therefore malformed.

This patch implements changes to the script in order to cater for
alpha/beta releases according to the rpc_release naming scheme in
RE-1199. It will auto-increment both pre-release and minor versions
depending on the current value of rpc_release. This gives us more
flexibility to cater to releasing internally before doing customer
facing releases.

Issue: [RE-1199](https://rpc-openstack.atlassian.net/browse/RE-1199)