### PR TITLE
[RO-3244] Specify a-r-r file and product release

### DIFF
--- a/gating/generate_release_notes/generate_commit_diff_notes.sh
+++ b/gating/generate_release_notes/generate_commit_diff_notes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
+source "scripts/functions.sh"
 
-rpc-differ --debug -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file diff_notes.rst
+rpc-differ --debug -rp ${RPC_PRODUCT_RELEASE} -rr "ansible-role-${RPC_PRODUCT_RELEASE}-requirements.yml" -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file diff_notes.rst
 pandoc --from rst --to markdown_github < diff_notes.rst > diff_notes.md

--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,8 +8,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-RUN pip install rpc_differ==0.3.1 reno==2.5.1
-RUN pip install git+https://github.com/major/osa_differ@0.3.3
+RUN pip install osa_differ==0.3.4 rpc_differ==0.3.3 reno==2.5.1
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
rpc-differ now supports additional options:

- allowing to specify an ansible-role-requirements file
other than ansible-role-requirements.yml
- allowing to specify the major rpc-o release series

 This commit updates the release notes script to make use of both of
those, and fixes the broken release job.

Issue: [RO-3244](https://rpc-openstack.atlassian.net/browse/RO-3244)