### PR TITLE
RE-1214 Use an appropriately sized data disk

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,9 +35,11 @@ cd ${OA_DIR}
 
 # bootstrap the AIO
 if [[ "${DEPLOY_AIO}" == "yes" ]]; then
- # Determine the largest secondary disk device available for repartitioning
-  DATA_DISK_DEVICE=$(lsblk -brndo NAME,TYPE,RO,SIZE | \
-                     awk '/d[b-z]+ disk 0/{ if ($4>m){m=$4; d=$1}}; END{print d}')
+  # Get minimum disk size
+  DATA_DISK_MIN_SIZE="$((1024**3 * $(awk '/bootstrap_host_data_disk_min_size/{print $2}' "${OA_DIR}/tests/roles/bootstrap-host/defaults/main.yml") ))"
+
+  # Determine the largest secondary disk device that meets the minimum size
+  DATA_DISK_DEVICE=$(lsblk -brndo NAME,TYPE,RO,SIZE | awk '/d[b-z]+ disk 0/{ if ($4>m && $4>='$DATA_DISK_MIN_SIZE'){m=$4; d=$1}}; END{print d}')
 
   # Only set the secondary disk device option if there is one
   if [ -n "${DATA_DISK_DEVICE}" ]; then


### PR DESCRIPTION
Currently we choose the largest available disk as the data disk, however
this may be too small to be useful. This patch checks disqualifies disks
that are smaller than the minimum.

This ensures that disks which may be used for swap or other purposes by
the cloud provider are not considered a data disk.

Issue: [RE-1214](https://rpc-openstack.atlassian.net/browse/RE-1214)