### PR TITLE
RO-3239 Ensure that RPC_RELEASE is correct

### DIFF
--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -56,10 +56,6 @@ if which lxc-ls &> /dev/null; then
 fi
 echo "#### END LOG COLLECTION ###"
 
-extract_rpc_release(){
-  awk '/rpc_release/{print $2}' | tr -d '"'
-}
-
 # Only enable snapshot when triggered by a commit push.
 # This is to enable image updates whenever a PR is merged, but not before
 if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
@@ -87,9 +83,8 @@ if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
 
   ln -s /opt/rpc-openstack/gating/thaw/run /gating/thaw/run
 
-  rpc_release="$(extract_rpc_release </opt/rpc-openstack/group_vars/all/release.yml)"
   distro="$(lsb_release --codename --short)"
 
-  echo "rpc_${rpc_release}_${distro}" > /gating/thaw/image_name
+  echo "rpc_${RPC_RELEASE}_${distro}" > /gating/thaw/image_name
   echo "### END SNAPSHOT PREP ###"
 fi

--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -52,7 +52,7 @@ release_data_file="${WORKSPACE}/rc-release-data.yml"
 # new method
 if git cat-file -e ${new_file_to_fetch} 2>/dev/null; then
   git show ${new_file_to_fetch} > ${release_data_file}
-  export RC_BRANCH_VERSION=$(${GATING_PATH}/get-rpc_release.py ${release_data_file})
+  export RC_BRANCH_VERSION=$(${GATING_PATH}/../../scripts/get-rpc_release.py ${release_data_file})
 
 # old method
 elif git cat-file -e ${old_file_to_fetch} 2>/dev/null; then

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -47,7 +47,7 @@ fi
 # Other
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
-export RPC_RELEASE="$(awk '/rpc_release/ { print $2; }' ${BASE_DIR}/etc/openstack_deploy/group_vars/all/release.yml | sed s'/"//'g)"
+export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
 
 # Read the OS information
 for rc_file in openstack-release os-release lsb-release redhat-release; do

--- a/scripts/get-rpc_release.py
+++ b/scripts/get-rpc_release.py
@@ -17,13 +17,14 @@ import os
 import sys
 import yaml
 
-# Read the release file path from an environment variable
+# Read the release file path from a CLI parameter or environment variable.
 if len(sys.argv) > 1:
     release_file = sys.argv[1]
 else:
     release_file = os.environ['RELEASE_FILE']
 
-# Read the RPC release series name from an environment variable
+# Read the RPC release series name from a CLI parameter or environment
+# variable.
 if len(sys.argv) > 2:
     release_series = sys.argv[2]
 else:


### PR DESCRIPTION
With the implementation of c4132cd the use of the
release.yml file from group_vars is no longer an
appropriate way to derive the RPC_RELEASE version.

This patch ensures that the RPC_RELEASE version is
correctly derived using a small python script in
order to read the release mapping.

Given that the get-rpc_release script is now possibly
going to be used by humans, using argparse makes sense
to make it friendlier to use. This patch uses argparse
and adds some exception handling.

Issue: [RO-3239](https://rpc-openstack.atlassian.net/browse/RO-3239)