### PR TITLE
RO-3266 Only download the OSA roles once

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,8 +62,11 @@ rsync -av \
 
 # Pre-boostrap ansible so that we have the option to run RPC-OpenStack playbooks
 #  if we need during the pre-installation setup.
+#  We give it an a-r-r file which does not exist as we'd prefer not to have
+#  bootstrap-ansible download the roles using git for us. We will do that in
+#  playbooks/configure-release.yml instead using ansible-galaxy.
 pushd /opt/openstack-ansible
-  bash -c "scripts/bootstrap-ansible.sh"
+  bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/bootstrap-ansible.sh"
 popd
 
 # Setup the basic release


### PR DESCRIPTION
When executing install.sh it executes bootstrap-ansible.sh from OSA,
then executes site-release.yml -> configure-release.yml which replaces
the git-downloaded roles with ansible-galaxy downloaded roles.

This makes the deployment a little more fragile as either one of these
download methods may fail, causing the install script to fail.

This patch makes bootstrap-ansible not do any role boostrapping so that
our own tooling in configure-release.yml can do it instead. Given that
we use ansible-galaxy for the RPC roles, it appears to make sense to
use the same method for OSA roles too.

Issue: [RO-3266](https://rpc-openstack.atlassian.net/browse/RO-3266)