### PR TITLE
RO-3267 Only copy yml files for openstack_deploy

### DIFF
--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -120,16 +120,25 @@
         force: "{{ osa_force_clone | default(false) }}"
 
     - name: Copy basic files into place
-      command: "cp -Rv /opt/openstack-ansible/etc/openstack_deploy /etc/openstack_deploy"
+      shell: |
+        rsync -av \
+              --include='*.yml' --include='*/' --exclude='*' \
+              "/opt/openstack-ansible/etc/openstack_deploy/" \
+              /etc/openstack_deploy/
       args:
+        executable: /bin/bash
         creates: /etc/openstack_deploy
+      tags:
+        - skip_ansible_lint
 
     - name: Sync configuration for RPC-OpenStack files
       shell: |
         rsync -av \
-              --exclude '*.bak' \
+              --include='*.yml' --include='*/' --exclude='*' \
               "{{ playbook_dir }}/../etc/openstack_deploy/" \
               /etc/openstack_deploy/
+      args:
+        executable: /bin/bash
       when:
         - rpc_product_bootstrapped != rpc_product_new_bootstrap
       tags:

--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -27,9 +27,9 @@ source "${SCRIPT_PATH}/functions.sh"
 
 ## Main ----------------------------------------------------------------------
 
-# Generate the scretes required for the deployment.
+# Generate the secrets required for the deployment.
 if [[ ! -f "/etc/openstack_deploy/user_rpco_secrets.yml" ]]; then
-  cp /etc/openstack_deploy/user_rpco_secrets.yml.example /etc/openstack_deploy/user_rpco_secrets.yml
+  cp ${SCRIPT_PATH}/../etc/openstack_deploy/user_rpco_secrets.yml.example /etc/openstack_deploy/user_rpco_secrets.yml
 fi
 
 for file_name in user_secrets.yml user_rpco_secrets.yml; do
@@ -54,12 +54,12 @@ pushd /opt/rpc-maas/playbooks
       # Set the rpc_maas vars.
       if [[ ! -f "/etc/openstack_deploy/user_rpco_maas_variables.yml" ]]; then
         envsubst < \
-          /etc/openstack_deploy/user_rpco_maas_variables.yml.example > \
+          ${SCRIPT_PATH}/../etc/openstack_deploy/user_rpco_maas_variables.yml.example > \
           /etc/openstack_deploy/user_rpco_maas_variables.yml
       fi
 
       # If influx port and IP are set enable the variable
-      sed -i 's|^# influx_telegraf_targets|influx_telegraf_targets|g' /etc/openstack_deploy/user_rpc_maas_variables.yml
+      sed -i 's|^# influx_telegraf_targets|influx_telegraf_targets|g' /etc/openstack_deploy/user_rpco_maas_variables.yml
     fi
     # Run the rpc-maas setup process
     openstack-ansible site.yml


### PR DESCRIPTION
Instead of copying *all* the files, resulting in
/etc/openstack_deploy being filled with a bunch of
example files and CI-related config files, we only
copy over the *.yml files as they're required and
useful.

Issue: [RO-3267](https://rpc-openstack.atlassian.net/browse/RO-3267)