### PR TITLE
RO-3269 Remove ineffective pkg_locations override

### DIFF
--- a/etc/openstack_deploy/group_vars/all/rpc-o.yml
+++ b/etc/openstack_deploy/group_vars/all/rpc-o.yml
@@ -41,15 +41,3 @@ horizon_custom_uploads:
 # Use RPC python package index
 repo_build_pip_extra_indexes:
   - "https://rpc-repo.rackspace.com/pools"
-
-# TODO(evrardjp): Move this to group_vars/all/osa.yml when OSA has overridable
-#                 group vars AND pkg_locations becomes a group
-#                 var. Alternatively, we can remove this variable when all
-#                 our roles will be outside /opt/rpc-openstack/ This
-#                 var lists the locations for the package builder to look for
-#                 files that contain pip packages and git repos to build from
-pkg_locations:
-  - /opt/openstack-ansible
-  - /etc/ansible/roles
-  - /etc/openstack_deploy
-  - /opt/rpc-openstack/rpcd


### PR DESCRIPTION
The group_var to override the pkg_locations has no effect, resulting
in any values set there being ignored. It has no effect because OSA
Pike has this implemented as a playbook var, and that has a higher
precedence than a group_var.

The variation in the var from the upstream default is the addition of
the "/opt/rpc-openstack/rpcd" directory, which does not exist. Given
that we no longer have roles in-tree like we did with newton, this
override is necessary any more.

This patch therefore removes it.

Issue: [RO-3269](https://rpc-openstack.atlassian.net/browse/RO-3269)