### PR TITLE
RO-3268 Use apt artifacts for bootstrap-ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ openstack-ansible site-artifacts.yml -e 'apt_artifact_enabled=false' -e 'contain
 
 These variables can be set on the CLI or within the `user_variables.yml` file.
 
+When bootstrapping ansible using the `install.sh` script, if apt artifacts
+are found to be available for the current release, the deployment host will
+be configured to use them prior to executing the ansible bootstrap script.
+This is to ensure that the only packages installed by that script are those
+that from the apt artifact repository for the release. In order to disable
+this functionality the bash environment variable `HOST_SOURCES_REWRITE` needs
+to be set to anything other than `yes` before executing `install.sh`. Eg:
+
+``` shell
+export HOST_SOURCES_REWRITE="no"
+./scripts/install.sh
+```
+
 #### Optional | Setting the OpenStack-Ansible release
 
 It is possible to set the OSA release outside of the predefined "stable" release

--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -151,20 +151,6 @@
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
-    - name: Remove extra sources
-      lineinfile:
-        dest: /etc/apt/sources.list
-        state: absent
-        regexp: "{{ item }}"
-      with_items:
-        - "^deb-src"
-        - "-backports"
-        - "-security"
-        - "-updates"
-      when:
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
-
     - name: Update apt-cache
       apt:
         update_cache: yes

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -44,10 +44,11 @@ if [ -z ${OSA_RELEASE+x} ]; then
   fi
 fi
 
-# Other
+# Vars used for bootstrapping artifact configurations
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+export HOST_SOURCES_REWRITE=${HOST_SOURCES_REWRITE:-"yes"}
+export HOST_UBUNTU_REPO=${HOST_UBUNTU_REPO:-"http://mirror.rackspace.com/ubuntu"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
-export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
 
 # Read the OS information
 for rc_file in openstack-release os-release lsb-release redhat-release; do
@@ -55,3 +56,70 @@ for rc_file in openstack-release os-release lsb-release redhat-release; do
     source "/etc/${rc_file}"
   fi
 done
+
+## Functions -----------------------------------------------------------------
+
+# Sourced from https://stackoverflow.com/a/21189044
+# Modified to remove the unnecessary prefix option,
+# and to please bashate.
+function parse_yaml {
+   s='[[:space:]]*'
+   w='[a-zA-Z0-9_]*'
+   fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s=\"%s\"\n", vn, $2, $3);
+      }
+   }'
+}
+
+function apt_artifacts_available {
+
+  CHECK_URL="${HOST_RCBOPS_REPO}/apt-mirror/integrated/dists/${RPC_RELEASE}-${DISTRIB_CODENAME}"
+
+  if curl --output /dev/null --silent --head --fail ${CHECK_URL}; then
+    return 0
+  else
+    return 1
+  fi
+
+}
+
+function configure_apt_sources {
+
+  # Backup the original sources file
+  if [[ ! -f "/etc/apt/sources.list.original" ]]; then
+    cp /etc/apt/sources.list /etc/apt/sources.list.original
+  fi
+
+  # Replace the existing apt sources with the artifacted sources.
+
+  sed -i '/^deb-src /d' /etc/apt/sources.list
+  sed -i '/-backports /d' /etc/apt/sources.list
+  sed -i '/-security /d' /etc/apt/sources.list
+  sed -i '/-updates /d' /etc/apt/sources.list
+
+  # Add the RPC-O apt repo source
+  echo "deb ${HOST_RCBOPS_REPO}/apt-mirror/integrated/ ${RPC_RELEASE}-${DISTRIB_CODENAME} main" \
+    > /etc/apt/sources.list.d/rpco.list
+
+  # Install the RPC-O apt repo key
+  curl --silent --fail ${HOST_RCBOPS_REPO}/apt-mirror/rcbops-release-signing-key.asc | apt-key add -
+
+}
+
+## Main ----------------------------------------------------------------------
+
+# To avoid needing to install python on the host, we use a bash
+# function here to extract the rpc_release value for the series
+# being installed. This is needed to be able to figure out whether
+# apt artifacts are available for the release and to set them up
+# prior to installing any packages.
+export RPC_RELEASE=$(parse_yaml ${BASE_DIR}/playbooks/vars/rpc-release.yml | grep "rpc_product_releases_${RPC_PRODUCT_RELEASE}_rpc_release" | cut -d= -f 2 | tr -d '"')

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,19 @@ rsync -av \
       "${SCRIPT_PATH}/../etc/openstack_deploy/" \
       /etc/openstack_deploy/
 
+# The deployment host must only have the base Ubuntu repository configured.
+# All updates (security and otherwise) must come from the RPC-O apt artifacting.
+#
+# This is being done via bash because Ansible is not bootstrapped yet, and the
+# apt artifacts used for bootstrapping Ansible must also come from the RPC-O
+# artifact repo.
+#
+# This has the ability to be disabled for the purpose of reusing the
+# bootstrap-ansible script for putting together the apt artifacts.
+if [[ "${HOST_SOURCES_REWRITE}" == 'yes' ]] && apt_artifacts_available; then
+  configure_apt_sources
+fi
+
 # Pre-boostrap ansible so that we have the option to run RPC-OpenStack playbooks
 #  if we need during the pre-installation setup.
 #  We give it an a-r-r file which does not exist as we'd prefer not to have


### PR DESCRIPTION
When install.sh runs it uses the bootstrap-ansible script from
OSA to install packages which are needed on the deployment host.
If the apt artifacts are not used for this, the host may end up
with packages which are newer than those available in the apt
artifacts and this will result in a failure later in the build.

This patch ensures that the availability of apt packages is
checked, and if they are available it uses them. There is also
an environment variable to override this behaviour as may be
necessary (for example, this is necessary when preparing the apt
artifacts).

The 'Remove extra sources' task in configure-apt-sources.yml is
removed as the task 'Replace the apt sources file with our content'
lays down a replaced file and the remove task therefore is always
a no-op.

Issue: [RO-3268](https://rpc-openstack.atlassian.net/browse/RO-3268)