### PR TITLE
[RO-3268] Bootstrap rpco without breaking artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stab
 To configure the installation please refer to the upstream OpenStack-Ansible
 documentation regarding basic [system setup](https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/configure.html).
 
+##### Artifact Setup
+
 Prior to running the OpenStack-Ansible playbooks ensure your system(s) are using
-the latest artifacts. To ensure all hosts have the same artifacts run the
-RPC-OpenStack playbook `site-artifacts.yml`.
+the latest artifacts. To ensure all hosts have are using the same artifacted
+release, run the `site-artifacts.yml` playbook.
 
 ``` shell
 cd /opt/rpc-openstack
@@ -80,10 +82,7 @@ export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stab
 openstack-ansible site-artifacts.yml
 ```
 
-Once the deploy configuration has been completed please refer to the
-OpenStack-Ansible documentation regarding [running the playbooks](https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/run-playbooks.html).
-
-#### Optional | Disable Artifacts
+###### Optional | Disable Artifacts
 
 It is possible to disable parts of the artifact deployment system RPC-OpenStack
 provides. To disable the artifact components any of the following variables
@@ -99,23 +98,41 @@ respective artifacts are found. These settings are stored in the local fact file
 reset the state of artifacts, this file can be removed or modified as needed.
 
 ``` shell
-openstack-ansible site-artifacts.yml -e 'apt_artifact_enabled=false' -e 'container_artifact_enabled=false' -e 'py_artifact_enabled=false'
+openstack-ansible site-artifacts.yml -e 'apt_artifact_enabled=false' \
+                                     -e 'container_artifact_enabled=false' \
+                                     -e 'py_artifact_enabled=false'
 ```
 
-These variables can be set on the CLI or within the `user_variables.yml` file.
+##### OpenStack-Ansible Installation
 
-#### Optional | Setting the OpenStack-Ansible release
+OpenStack-Ansible will need to be installed. While you can simply run the
+`bootstrap-ansible.sh` script provided by the OpenStack-Ansible community
+you may also run the `openstack-ansible-install.yml` playbook which was
+created for convenience and will maintain impotency.
+
+``` shell
+cd /opt/rpc-openstack
+export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stable product will be used
+openstack-ansible openstack-ansible-install.yml
+```
+
+###### Optional | Setting the OpenStack-Ansible release
 
 It is possible to set the OSA release outside of the predefined "stable" release
 curated by the RPC-OpenStack product. To set the release define the Ansible
 variable `osa_release` to a SHA, Branch, or Tag and run the `site-release.yml`
-playbook.
+and `openstack-ansible-install.yml` playbooks to install the correct version.
 
 ``` shell
-openstack-ansible site-release.yml -e 'osa_release=master'
+openstack-ansible site-release.yml openstack-ansible-install.yml -e 'osa_release=master'
 ```
 
-This option can be set on the CLI or within the `user_variables.yml` file.
+##### Running the playbooks
+
+Once the deploy configuration has been completed please refer to the
+OpenStack-Ansible documentation regarding [running the playbooks](https://docs.openstack.org/project-deploy-guide/openstack-ansible/pike/run-playbooks.html).
+
+----
 
 #### Deploy the Rackspace Value Added Services
 
@@ -136,6 +153,8 @@ cd /opt/rpc-openstack
 openstack-ansible site-openstack.yml
 ```
 
+----
+
 ### Perform an Intra-Series Product Upgrade
 
 To run a basic system upgrade set the `${RPC_PRODUCT_RELEASE}` option, re-run
@@ -147,6 +166,7 @@ cd /opt/rpc-openstack
 export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stable product will be used
 ./scripts/deploy.sh
 openstack-ansible site-artifacts.yml
+openstack-ansible openstack-ansible-install.yml
 ```
 
 Once basic system configuration has completed, [run through the upgrade process](https://docs.openstack.org/openstack-ansible/pike/user/minor-upgrade.html)
@@ -163,6 +183,7 @@ cd /opt/rpc-openstack
 export RPC_PRODUCT_RELEASE="master"  # This needs to be set to the new product
 ./scripts/deploy.sh
 openstack-ansible site-artifacts.yml
+openstack-ansible openstack-ansible-install.yml
 ```
 
 Once the deployment is ready either [run the major upgrade script](https://docs.openstack.org/openstack-ansible/pike/user/script-upgrade.html)

--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -183,5 +183,8 @@
         - { option: "apt_artifact_enabled", value: "{{ apt_artifact_enabled }}" }
         - { option: "apt_artifact_found", value: "{{ apt_artifact_found }}" }
 
+  vars:
+    ansible_python_interpreter: "/usr/bin/python"
+
   tags:
     - rpc

--- a/playbooks/configure-container-sources.yml
+++ b/playbooks/configure-container-sources.yml
@@ -19,8 +19,6 @@
   connection: local
   user: root
   gather_facts: true
-  vars:
-    container_search_string: ".*{{ ansible_distribution_release }};.*{{ rpc_release }};"
   pre_tasks:
     - name: Ensure local facts directory exists
       file:
@@ -131,6 +129,10 @@
       with_items:
         - { option: "container_artifact_enabled", value: "{{ container_artifact_enabled }}" }
         - { option: "container_artifact_found", value: "{{ container_artifact_found }}" }
+
+  vars:
+    ansible_python_interpreter: "/usr/bin/python"
+    container_search_string: ".*{{ ansible_distribution_release }};.*{{ rpc_release }};"
 
   tags:
     - rpc

--- a/playbooks/configure-python-sources.yml
+++ b/playbooks/configure-python-sources.yml
@@ -155,5 +155,8 @@
         - { option: "py_artifact_enabled", value: "{{ py_artifact_enabled }}" }
         - { option: "py_artifact_found", value: "{{ py_artifact_found }}" }
 
+  vars:
+    ansible_python_interpreter: "/usr/bin/python"
+
   tags:
     - rpc

--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -63,6 +63,31 @@
           rpc_product_release == 'undefined'
 
   tasks:
+    - name: Ensure root has a .ssh directory
+      file:
+        path: /root/.ssh
+        state: directory
+        owner: root
+        group: root
+        mode: "0700"
+
+    - name: Create ssh key pair for root
+      user:
+        name: root
+        generate_ssh_key: yes
+        ssh_key_bits: 2048
+        ssh_key_file: /root/.ssh/id_rsa
+
+    - name: Store id_rsa.pub
+      slurp:
+        src: "/root/.ssh/id_rsa.pub"
+      register: _root_id_rsa_pub
+
+    - name: Ensure root can ssh to localhost
+      authorized_key:
+        user: "root"
+        key: "{{ _root_id_rsa_pub.content | b64decode }}"
+
     - name: Check for product_release variable
       fail:
         msg: >-
@@ -82,13 +107,10 @@
       when:
         - osa_release is undefined
 
-    - name: Set the product release
-      lineinfile:
-        dest: /etc/openstack_deploy/group_vars/all/release.yml
-        state: present
-        regexp: "^{{ item.key }}:"
-        line: '{{ item.key }}: "{{ item.value }}"'
-      with_dict: "{{ rpc_product_releases[rpc_product_release] }}"
+    - name: Set the rpc-product bootstrapped variables
+      set_fact:
+        rpc_product_bootstrapped: "{{ rpc_openstack['rpc_product_bootstrapped'] | default('undefined') }}"
+        rpc_product_new_bootstrap: "rpc-{{ rpc_product_release }}-{{ osa_release }}"
 
     - name: Clone / Checkout OpenStack-Ansible
       git:
@@ -97,21 +119,49 @@
         version: "{{ osa_release }}"
         force: "{{ osa_force_clone | default(false) }}"
 
+    - name: Copy basic files into place
+      command: "cp -Rv /opt/openstack-ansible/etc/openstack_deploy /etc/openstack_deploy"
+      args:
+        creates: /etc/openstack_deploy
+
+    - name: Sync configuration for RPC-OpenStack files
+      shell: |
+        rsync -av \
+              --exclude '*.bak' \
+              "{{ playbook_dir }}/../etc/openstack_deploy/" \
+              /etc/openstack_deploy/
+      when:
+        - rpc_product_bootstrapped != rpc_product_new_bootstrap
+      tags:
+        - skip_ansible_lint
+
+    - name: Set the product release
+      lineinfile:
+        dest: /etc/openstack_deploy/group_vars/all/release.yml
+        state: present
+        regexp: "^{{ item.key }}:"
+        line: '{{ item.key }}: "{{ item.value }}"'
+      with_dict: "{{ rpc_product_releases[rpc_product_release] }}"
+
     - name: Galaxy install the RPC-OpenStack roles
       command: |
-        ansible-galaxy install \
+        /opt/rpc-ansible/bin/ansible-galaxy install \
           --role-file={{ playbook_dir }}/../ansible-role-{{ rpc_product_release }}-requirements.yml \
           --roles-path=/etc/ansible/roles \
           --force
+      when:
+        - rpc_product_bootstrapped != rpc_product_new_bootstrap
       tags:
         - skip_ansible_lint
 
     - name: Galaxy install the OpenStack-Ansible roles
       command: |
-        ansible-galaxy install \
+        /opt/rpc-ansible/bin/ansible-galaxy install \
           --role-file=/opt/openstack-ansible/ansible-role-requirements.yml \
           --roles-path=/etc/ansible/roles \
           --force
+      when:
+        - rpc_product_bootstrapped != rpc_product_new_bootstrap
       tags:
         - skip_ansible_lint
 
@@ -120,10 +170,14 @@
       ini_file:
         dest: "/etc/ansible/facts.d/rpc_openstack.fact"
         section: "rpc_product"
-        option: "rpc_product_release"
-        value: "{{ rpc_product_release }}"
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - { option: "rpc_product_release", value: "{{ rpc_product_release }}" }
+        - { option: "rpc_product_bootstrapped", value: "{{ rpc_product_new_bootstrap }}" }
 
   vars:
+    ansible_python_interpreter: "/usr/bin/python"
     rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') | default('undefined', true) }}"
 
   vars_files:

--- a/playbooks/openstack-ansible-install.yml
+++ b/playbooks/openstack-ansible-install.yml
@@ -1,0 +1,97 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install OpenStack-Ansible
+  hosts: localhost
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  connection: local
+  user: root
+  gather_facts: true
+  pre_tasks:
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Ensure local facts directory exists
+      file:
+        dest: "/etc/ansible/facts.d"
+        state: directory
+        group: "root"
+        owner: "root"
+        mode:  "0755"
+        recurse: no
+
+    - name: initialize local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_product"
+        option: initialized
+        value: true
+
+    - name: Set the rpc-openstack variables
+      set_fact:
+        rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
+
+    - name: Set the rpc-release variables
+      set_fact:
+        rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
+      when:
+        - rpc_openstack['rpc_product_release'] is defined
+        - rpc_product_release is undefined or
+          rpc_product_release == 'undefined'
+
+    - name: Set OpenStack-Ansible release option
+      set_fact:
+        osa_release: "{{ rpc_product_releases[rpc_product_release]['osa_release'] }}"
+      when:
+        - osa_release is undefined
+
+    - name: Set the rpc-product bootstrapped variables
+      set_fact:
+        osa_bootstrapped: "{{ rpc_openstack['osa_bootstrapped'] | default('undefined') }}"
+        osa_new_bootstrap: "osa-{{ rpc_product_release }}-{{ osa_release }}"
+
+  tasks:
+    - name: Install the OpenStack-Ansible
+      shell: |
+        ANSIBLE_ROLE_FILE='/tmp/does-not-exist' ./scripts/bootstrap-ansible.sh
+      args:
+        chdir: "/opt/openstack-ansible"
+      when:
+        - osa_bootstrapped != osa_new_bootstrap
+      tags:
+        - skip_ansible_lint
+
+  post_tasks:
+    - name: Set product release local fact
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_product"
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - { option: "osa_bootstrapped", value: "{{ osa_new_bootstrap }}" }
+
+  vars:
+    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') | default('undefined', true) }}"
+
+  vars_files:
+    - vars/rpc-release.yml
+
+  tags:
+    - rpc

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -65,10 +65,13 @@ if [ "${DEPLOY_AIO}" != false ]; then
     #                  sources are built and how we can better construct and
     #                  consume them.
     openstack-ansible -i 'localhost,' \
-                      -e apt_target_group=localhost \
+                      -e 'apt_target_group=localhost' \
                       -e 'container_artifact_enabled=false' \
                       -e 'py_artifact_enabled=false' \
-                      ${SCRIPT_PATH}/../playbooks/site-artifacts.yml
+                      "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
+
+    # Install OpenStack-Ansible
+    openstack-ansible "${SCRIPT_PATH}/../playbooks/openstack-ansible-install.yml"
 
     ## Create the AIO
     pushd /opt/openstack-ansible

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -44,14 +44,19 @@ if [ -z ${OSA_RELEASE+x} ]; then
   fi
 fi
 
-# Other
-export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
-export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
-export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
-
 # Read the OS information
 for rc_file in openstack-release os-release lsb-release redhat-release; do
   if [[ -f "/etc/${rc_file}" ]]; then
     source "/etc/${rc_file}"
   fi
 done
+
+# Other
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+export HOST_RCBOPS_DOMAIN="rpc-repo.rackspace.com"
+export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://${HOST_RCBOPS_DOMAIN}"}
+export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
+export RPC_OS="${ID}-${VERSION_ID}-x86_64"
+export RPC_ANSIBLE_VERSION="2.3.2.0"
+export RPC_ANSIBLE="${HOST_RCBOPS_REPO}/pools/${RPC_OS}/ansible/ansible-${RPC_ANSIBLE_VERSION}-py2-none-any.whl"
+export RPC_LINKS="${HOST_RCBOPS_REPO}/links"

--- a/scripts/openstack-ansible-wrapper.sh
+++ b/scripts/openstack-ansible-wrapper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+export ANSIBLE_ACTION_PLUGINS="/etc/ansible/roles/plugins/action"
+export ANSIBLE_CALLBACK_PLUGINS="/etc/ansible/roles/plugins/callback"
+export ANSIBLE_CALLBACK_WHITELIST="profile_tasks"
+export ANSIBLE_FILTER_PLUGINS="/etc/ansible/roles/plugins/filter"
+export ANSIBLE_HOST_KEY_CHECKING="False"
+export ANSIBLE_INVENTORY="localhost,"
+export ANSIBLE_LIBRARY="/etc/ansible/roles/plugins/library"
+export ANSIBLE_LOOKUP_PLUGINS="/etc/ansible/roles/plugins/lookup"
+export ANSIBLE_TEST_PLUGINS="/etc/ansible/roles/plugins/test"
+export ANSIBLE_VARS_PLUGINS="/etc/ansible/roles/plugins/vars_plugins"
+(/opt/rpc-ansible/bin/ansible-playbook $@) && exit 0


### PR DESCRIPTION
Because APT artifacts can not be used at kick time it's possible that
the basic installation of OSA can bring an environment ahead of our
current artifacted release. This change makes it possible for APT
artifacts to be present when bootstrapping the environment. When a
deployer runs a basic installation of RPC-OpenStack they have the choice
to enable or disable artifacts however if they chose to enable them all
package installations should come from our artifacted repo assuming
they're available.

This change ensures only the minimum requirements are installed on the system
prior to setting up the release and configuring our artifacted solutions.
To keep everything as idempotent as possible and to ensure we're using
playbooks to configure the deployment, the initial install will create an
*rpc-ansible* virtual environment in "/opt" using a cached version of ansible
from [ rpc-repo.rackspace.com ]. This simple ansible installation runs only
the required playbooks to get the deployment online. Once OSA has been
bootstrapped all future interactions can be run through the
`openstack-ansible` cli tool. 

Non-Idempotent commands in scripts were have been moved into
playbooks where possible. Modules have replaced most of the
functions and if no suitable module was available the command module
was used but in the most idempotent way possible by leveraging local
facts.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3268](https://rpc-openstack.atlassian.net/browse/RO-3268)