### PR TITLE
RLM-316 Implement strict/loose artifact options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ DEPLOY_RPC         | yes                                | Deploy the RPCO specif
 BOOTSTRAP_OPTS     |                                    | Any options used for the bootstrap process           | Only used if DEPLOY_AIO=yes
 FORKS              | `grep -c ^processor /proc/cpuinfo` | Number of forks Ansible may use                      | May have issues if FORKS > SSHD's MaxSessions. Adjust accordingly
 ANSIBLE_PARAMETERS |                                    | Additional paramters passed to Ansible               |
+RPCO_APT_ARTIFACTS_MODE | strict                        | Set the behaviour for the use of the apt artifacts   | Set to 'loose' to leave existing sources in place
 
 All of the variables for deploy.sh are made available by sourcing the [functions.sh](https://github.com/rcbops/rpc-openstack/blob/master/scripts/functions.sh) script
 

--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -41,6 +41,17 @@ elif [[ "${RE_JOB_SCENARIO}" == "ironic" ]]; then
   export DEPLOY_IRONIC="yes"
 fi
 
+if [[ ${RE_JOB_IMAGE} =~ loose$ ]]; then
+
+  # Set the apt artifact mode
+  export RPCO_APT_ARTIFACTS_MODE="loose"
+
+  # Upgrade to the absolute latest
+  # available packages.
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+fi
+
 # Run the deployment script
 cd ${BASE_DIR}
 source ${BASE_DIR}/scripts/deploy.sh

--- a/group_vars/all/apt.yml
+++ b/group_vars/all/apt.yml
@@ -122,3 +122,16 @@ hwraid_apt_repos:
     state: "present"
     filename: "hwraid"
 hwraid_apt_keys: "{{ rpco_apt_gpg_keys }}"
+
+# The apt artifact mode can be implemented in 'strict' or 'loose' mode.
+# Strict mode will replace the existing apt sources with a minimal set
+#  which guarantees that what is deployed is the same as that which was
+#  tested.
+# Loose mode will leave the existing apt sources in place, but set the
+#  preference to use RPC-O's apt sources ahead of other repositories.
+#  This may be useful for a new install where the packages installed
+#  are newer than those in the RPC-O's apt repository for the release
+#  being deployed.
+# This setting may be overridden by overriding it in the
+# /etc/openstack_deploy/user_*.yml files.
+rpco_apt_artifacts_mode: "strict"

--- a/rpcd/playbooks/configure-apt-sources.yml
+++ b/rpcd/playbooks/configure-apt-sources.yml
@@ -33,28 +33,49 @@
         - host_ubuntu_repo is not defined
         - _ubuntu_repo.stdout_lines is defined
 
-    - name: Replace the apt sources file with our content
+    - name: Backup the original sources file
+      copy:
+        src: /etc/apt/sources.list
+        dest: /etc/apt/sources.list.original
+        remote_src: yes
+        force: no
+
+    - name: Replace the apt sources file with our content (artifact 'strict' mode)
       template:
         src: configure-apt-sources.j2
         dest: "/etc/apt/sources.list"
         backup: yes
       register: apt_sources_configure
+      when:
+        - rpco_apt_artifacts_mode == "strict"
       tags:
         - always
+
+    # Set rpco_apt_sources_restore_source to 'local' to have the
+    # original apt sources file from the deploy host be pushed out
+    # to all hosts and containers.
+    - name: Restore the original sources file (artifact 'loose' mode)
+      copy:
+        src: /etc/apt/sources.list.original
+        dest: /etc/apt/sources.list
+        remote_src: "{{ rpco_apt_sources_restore_source | default('remote') == 'remote' }}"
+        force: yes
+      register: apt_sources_restore
+      when:
+        - rpco_apt_artifacts_mode != "strict"
 
     - name: Update apt-cache
       apt:
         update_cache: yes
       when:
-        - apt_sources_configure is defined
-        - apt_sources_configure | changed
+        - apt_sources_configure | changed or apt_sources_restore | changed
       tags:
         - always
 
   roles:
     # We execute the pip_install role here to ensure that all
-    # hosts have the correct rpco repo configured now that
-    # /etc/apt/sources.list has been changed to no longer
+    # hosts have the correct rpco repo and key configured now
+    # that /etc/apt/sources.list has been changed to no longer
     # include the updates repo.
     - role: "pip_install"
       pip_lock_to_internal_repo: False

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -20,6 +20,9 @@
     - name: Set user_variables_overrides fact
       set_fact:
         user_variables_overrides:
+          ## Implement the appropriate override for the apt artifact
+          ## deployment mode.
+          rpco_apt_artifacts_mode: "{{ lookup('env', 'RPCO_APT_ARTIFACTS_MODE') }}"
           ## Three vars below migrated from existing boostrap-aio task.
           apply_security_hardening: "{{ rpco_deploy_hardening }}"
           # Tempest is turned off to prevent the tests from running by default
@@ -39,7 +42,7 @@
           galera_innodb_buffer_pool_size: 16M
           galera_innodb_log_buffer_size: 4M
           galera_wsrep_provider_options:
-           - { option: "gcache.size", value: "4M" } 
+           - { option: "gcache.size", value: "4M" }
           ### Set workers for all services to optimise memory usage
           ceilometer_api_workers: 1
           ceilometer_collector_workers: 1
@@ -217,11 +220,19 @@
 - name: Execute the OSA AIO bootstrap
   include: "{{ lookup('env', 'OA_DIR') }}/tests/bootstrap-aio.yml"
   vars:
-    bootstrap_host_apt_distribution_suffix_list: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary([], ['updates', 'backports']) }}"
-    scenario: "{% if lookup('env', 'DEPLOY_IRONIC') == 'yes' %}ironic{% else %}{{ lookup('env', 'DEPLOY_CEPH') |bool |ternary('ceph','swift') }}{%endif%}"
+    bootstrap_host_apt_distribution_suffix_list: >-
+      {{ ((lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) and
+          (lookup('env', 'RPCO_APT_ARTIFACTS_MODE') == 'strict'))
+          | ternary([], ['updates', 'backports']) }}
+    scenario: >-
+      {%- if lookup('env', 'DEPLOY_IRONIC') | bool -%}
+      ironic
+      {%- else -%}
+      {{ (lookup('env', 'DEPLOY_CEPH') | bool) | ternary('ceph','swift') }}
+      {%- endif -%}
     bootstrap_host_user_variables_filename: "user_osa_variables_overrides.yml"
     bootstrap_host_user_secrets_filename: "user_osa_secrets.yml"
-    uca_enable: no
+    uca_enable: "{{ (lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) | ternary(False, True) }}"
     confd_overrides:
       swift:
         - name: cinder.yml.aio


### PR DESCRIPTION
When deploying to a new environment it is often the case
that the base OS installed has packages which are newer
than those available in the apt artifacts.

To ease the initial installation and provide the ability
to transition to using the apt artifacts exclusively, an
option is made available to do a 'loose' mode for the apt
artifacts. This mode leaves the existing apt sources in
place, ensuring that we don't end up with apt returning
that packages are installed which are not available in
the sources configured as it does when in 'strict' mode.

The facility to switch between modes is also implemented
so that an initial implementation trying to use strict
mode can switch to loose mode and continue the deployment.

Note that various forms of pinning to the repository were
tried to try and prefer the RPC-O repository, but allow
other sources to be used. This only works when the pins
are equal.

The default behaviour for 'loose' mode will be to make
use of the latest available package from the already
installed sources and the RPC-O source. This will mean
that a deployment today will not be guaranteed to provide
the same result tomorrow.

A little bit of tidying up to the AIO bootstrap has been
included in order to make it easier to read.

Jobs to test this as a periodic are implemented in
https://github.com/rcbops/rpc-gating/pull/575

Issue: [RLM-316](https://rpc-openstack.atlassian.net/browse/RLM-316)