### PR TITLE
RLM-316 Implement strict/loose artifact options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ export RPC_PRODUCT_RELEASE="pike"  # This is optional, if unset the current stab
 openstack-ansible site-artifacts.yml
 ```
 
+###### Optional | Enable 'loose' mode for apt artifacts
+
+It is possible to set the apt artifact implementation to be done in 'loose'
+mode which leaves the existing apt sources in place when doing the deployment.
+This ensures that if packages are already installed on the target hosts which
+are newer than those available in the RPC-O artifacts, the apt install process
+will leave them in place. This helps with initial deployments to allow a
+transition from an unmanaged environment, to a 'loose' managed environment
+and later it can be switched to a 'strict' managed environment which only
+uses the artifacts which were used in testing.
+
+``` shell
+cd /opt/rpc-openstack
+openstack-ansible site-artifacts.yml -e 'apt_artifact_mode="loose"'
+```
+
 ###### Optional | Disable Artifacts
 
 It is possible to disable parts of the artifact deployment system RPC-OpenStack

--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -9,12 +9,21 @@ set -o pipefail
 
 export DEPLOY_AIO="true"
 
-# Set the apt artifact mode appropriately
-if [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
-  export RPCO_APT_ARTIFACTS_MODE="loose"
+if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
+  # Set the env var to disable artifact usage
+  export RPC_APT_ARTIFACT_ENABLED="no"
 
-  # Upgrade all packages to test the absolute
-  # latest packages when testing this mode.
+  # Upgrade to the absolute latest
+  # available packages.
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+
+elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
+  # Set the apt artifact mode
+  export RPC_APT_ARTIFACT_MODE="loose"
+
+  # Upgrade to the absolute latest
+  # available packages.
   apt-get update
   DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 fi

--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -9,6 +9,16 @@ set -o pipefail
 
 export DEPLOY_AIO="true"
 
+# Set the apt artifact mode appropriately
+if [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
+  export RPCO_APT_ARTIFACTS_MODE="loose"
+
+  # Upgrade all packages to test the absolute
+  # latest packages when testing this mode.
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+fi
+
 ## Functions -----------------------------------------------------------------
 
 ## Main ----------------------------------------------------------------------

--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -28,7 +28,7 @@
         mode:  "0755"
         recurse: no
 
-    - name: initialize local facts
+    - name: Initialize local facts
       ini_file:
         dest: "/etc/ansible/facts.d/rpc_openstack.fact"
         section: "rpc_artifacts"
@@ -46,12 +46,19 @@
       set_fact:
         rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_artifacts'] }}"
 
-    - name: Set the rpc-artifact variables
+    - name: Set apt_artifact_enabled (based on previous settings)
       set_fact:
         apt_artifact_enabled: "{{ rpc_openstack['apt_artifact_enabled'] }}"
       when:
         - rpc_openstack['apt_artifact_enabled'] is defined
         - apt_artifact_enabled is undefined
+
+    - name: Set apt_artifact_mode (based on previous settings)
+      set_fact:
+        apt_artifact_mode: "{{ rpc_openstack['apt_artifact_mode'] }}"
+      when:
+        - rpc_openstack['apt_artifact_mode'] is defined
+        - apt_artifact_mode is undefined
 
     - name: Check for artifacts
       uri:
@@ -60,15 +67,21 @@
       failed_when: false
       register: check_artifacts
 
-    - name: Set artifacts found
+    - name: Set apt_artifact_found
       set_fact:
         apt_artifact_found: "{{ check_artifacts.status == 200 }}"
 
-    - name: Set artifacts enabled
+    - name: Set apt_artifact_enabled (based on whether they exist)
       set_fact:
         apt_artifact_enabled: "{{ apt_artifact_found | bool }}"
       when:
         - apt_artifact_enabled is undefined
+
+    - name: Set apt_artifact_mode default value
+      set_fact:
+        apt_artifact_mode: "strict"
+      when:
+        - apt_artifact_mode is undefined
 
     - name: Check if artifacts are enabled but not found
       fail:
@@ -79,6 +92,17 @@
       when:
         - apt_artifact_enabled | bool
         - not apt_artifact_found | bool
+      tags:
+        - always
+
+    - name: Check if artifact mode is set incorrectly
+      fail:
+        msg: |
+          The apt artifact mode is set to the invalid value of '{{ apt_artifact_mode }}'.
+          The deployment has halted. Valid values are 'strict' or 'loose'.
+      when:
+        - apt_artifact_enabled | bool
+        - apt_artifact_mode not in ['strict', 'loose']
       tags:
         - always
 
@@ -138,7 +162,14 @@
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
-    - name: Replace the apt sources file with our content
+    - name: Backup the original sources file
+      copy:
+        src: /etc/apt/sources.list
+        dest: /etc/apt/sources.list.original
+        remote_src: yes
+        force: no
+
+    - name: Replace the apt sources file with our content (artifact 'strict' mode)
       copy:
         content: |
           # Base repository
@@ -149,6 +180,22 @@
       when:
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
+        - apt_artifact_mode == "strict"
+
+    # Set rpco_apt_sources_restore_source to 'local' to have the
+    # original apt sources file from the deploy host be pushed out
+    # to all hosts and containers.
+    - name: Restore the original sources file (artifact 'loose' mode)
+      copy:
+        src: /etc/apt/sources.list.original
+        dest: /etc/apt/sources.list
+        remote_src: "{{ rpco_apt_sources_restore_source | default('remote') == 'remote' }}"
+        force: yes
+      register: apt_sources_restore
+      when:
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
+        - apt_artifact_mode != "strict"
 
     - name: Create the rpco apt sources file
       copy:
@@ -174,26 +221,13 @@
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
-    - name: Remove extra sources
-      lineinfile:
-        dest: /etc/apt/sources.list
-        state: absent
-        regexp: "{{ item }}"
-      with_items:
-        - "^deb-src"
-        - "-backports"
-        - "-security"
-        - "-updates"
-      when:
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
-
     - name: Update apt-cache
       apt:
         update_cache: yes
       when:
-        - (apt_artifact_found | bool) and (apt_sources_configure | changed or apt_sources_configure_rpco | changed)
         - apt_artifact_enabled | bool
+        - apt_artifact_found | bool
+        - apt_sources_configure | changed or apt_sources_configure_rpco | changed or apt_sources_restore | changed
 
   post_tasks:
     - name: Set artifact local fact
@@ -203,8 +237,12 @@
         option: "{{ item.option }}"
         value: "{{ item.value }}"
       with_items:
-        - { option: "apt_artifact_enabled", value: "{{ apt_artifact_enabled }}" }
-        - { option: "apt_artifact_found", value: "{{ apt_artifact_found }}" }
+        - option: "apt_artifact_enabled"
+          value: "{{ apt_artifact_enabled }}"
+        - option: "apt_artifact_found"
+          value: "{{ apt_artifact_found }}"
+        - option: "apt_artifact_mode"
+          value: "{{ apt_artifact_mode }}"
 
   vars:
     ansible_python_interpreter: "/usr/bin/python"

--- a/playbooks/files/bootstrap-aio-opts.yml
+++ b/playbooks/files/bootstrap-aio-opts.yml
@@ -1,0 +1,29 @@
+---
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apt_artifact_enabled: "{{ ansible_local['rpc_openstack']['rpc_artifacts']['apt_artifact_enabled'] }}"
+apt_artifact_mode: "{{ ansible_local['rpc_openstack']['rpc_artifacts']['apt_artifact_mode'] }}"
+
+# When apt artifacts are enabled and in strict mode,
+# we want the bootstrap to remove the extra ubuntu
+# sources from /etc/apt/sources.list as all the Ubuntu
+# updates/backports/security packages required are
+# included in the apt artifact repo.
+bootstrap_host_apt_distribution_suffix_list: "{{ (apt_artifact_enabled | bool and apt_artifact_mode == 'strict') | ternary([], ['updates', 'backports']) }}"
+
+# When apt artifacts are enabled, we do not want UCA to be
+# used as the UCA content is included in the apt artifact
+# repo.
+uca_enable: "{{ (apt_artifact_enabled | bool) | ternary(False, True) }}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,11 +47,15 @@ if [ "${DEPLOY_AIO}" != false ]; then
   # RO-3316 has been resolved.
   openstack-ansible -i 'localhost,' \
                     -e 'apt_target_group=localhost' \
+                    -e "apt_artifact_mode='${RPCO_APT_ARTIFACTS_MODE}'" \
                     -e 'container_artifact_enabled=false' \
                     "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
 
   # Install OpenStack-Ansible
   openstack-ansible "${SCRIPT_PATH}/../playbooks/openstack-ansible-install.yml"
+
+  # Set the AIO config bootstrap options to take apt artifacts into consideration
+  export ANSIBLE_PARAMETERS=-e@${SCRIPT_PATH}/../playbooks/files/bootstrap-aio-opts.yml
 
   ## Create the AIO
   pushd /opt/openstack-ansible

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,18 +40,14 @@ if [ "${DEPLOY_AIO}" != false ]; then
   ## Run the basic installation script
   basic_install
 
-  # Force the AIO to use artifacts
-  # NOTE(cloudnull): This disables container/py artifacts for now. The
-  #                  RPC-OpenStack container/py artifacts are failing
-  #                  while the upstream container/py builds of similart
-  #                  sizes, packages, and distros is not showing the same
-  #                  issues. We need to spend some time debugging how the
-  #                  sources are built and how we can better construct and
-  #                  consume them.
+  # Implement the artifact configuration
+
+  # NOTE(odyssey4me):
+  # Re-enable container artifacts once
+  # RO-3316 has been resolved.
   openstack-ansible -i 'localhost,' \
                     -e 'apt_target_group=localhost' \
                     -e 'container_artifact_enabled=false' \
-                    -e 'py_artifact_enabled=false' \
                     "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
 
   # Install OpenStack-Ansible

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,7 +47,8 @@ if [ "${DEPLOY_AIO}" != false ]; then
   # RO-3316 has been resolved.
   openstack-ansible -i 'localhost,' \
                     -e 'apt_target_group=localhost' \
-                    -e "apt_artifact_mode='${RPCO_APT_ARTIFACTS_MODE}'" \
+                    -e "apt_artifact_enabled='${RPC_APT_ARTIFACT_ENABLED}'" \
+                    -e "apt_artifact_mode='${RPC_APT_ARTIFACT_MODE}'" \
                     -e 'container_artifact_enabled=false' \
                     "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -55,6 +55,7 @@ done
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export HOST_RCBOPS_DOMAIN="rpc-repo.rackspace.com"
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://${HOST_RCBOPS_DOMAIN}"}
+export RPCO_APT_ARTIFACTS_MODE=${RPCO_APT_ARTIFACTS_MODE:-"strict"}
 export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
 export RPC_OS="${ID}-${VERSION_ID}-x86_64"
 export RPC_ANSIBLE_VERSION="2.3.2.0"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -55,7 +55,8 @@ done
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export HOST_RCBOPS_DOMAIN="rpc-repo.rackspace.com"
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://${HOST_RCBOPS_DOMAIN}"}
-export RPCO_APT_ARTIFACTS_MODE=${RPCO_APT_ARTIFACTS_MODE:-"strict"}
+export RPC_APT_ARTIFACT_ENABLED=${RPC_APT_ARTIFACT_ENABLED:-"yes"}
+export RPC_APT_ARTIFACT_MODE=${RPC_APT_ARTIFACT_MODE:-"strict"}
 export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
 export RPC_OS="${ID}-${VERSION_ID}-x86_64"
 export RPC_ANSIBLE_VERSION="2.3.2.0"


### PR DESCRIPTION
When deploying to a new environment it is often the case
that the base OS installed has packages which are newer
than those available in the apt artifacts.

To ease the initial installation and provide the ability
to transition to using the apt artifacts exclusively, an
option is made available to do a 'loose' mode for the apt
artifacts. This mode leaves the existing apt sources in
place, ensuring that we don't end up with apt returning
that packages are installed which are not available in
the sources configured as it does when in 'strict' mode.

The facility to switch between modes is also implemented
so that an initial implementation trying to use strict
mode can switch to loose mode and continue the deployment.

Note that various forms of pinning to the repository were
tried to try and prefer the RPC-O repository, but allow
other sources to be used. This only works when the pins
are equal.

The default behaviour for 'loose' mode will be to make
use of the latest available package from the already
installed sources and the RPC-O source. This will mean
that a deployment today will not be guaranteed to provide
the same result tomorrow.

Issue: [RLM-316](https://rpc-openstack.atlassian.net/browse/RLM-316)

Issue: [RLM-917](https://rpc-openstack.atlassian.net/browse/RLM-917)