### PR TITLE
RO-3303 Ensure a complete manifest file is built

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -13,5 +13,5 @@ rpc_product_releases:
     rpc_release: r15.0.0
   pike:
     maas_release: 1.4.0
-    osa_release: fce47edd056ba595d915e62ff9a26d2cf25b5534
+    osa_release: f458161e9ded90c39a7dfca5006078bb7aac8504
     rpc_release: r16.0.0-alpha.1


### PR DESCRIPTION
Due to a change in behaviour in Ansible 2.3, the manifest
file in the repo build process was incomplete. This brings
in the OSA SHA which resolves that.

Issue: [RO-3303](https://rpc-openstack.atlassian.net/browse/RO-3303)