### PR TITLE
RO-3315 Only download the OSA roles once

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,7 +75,7 @@ if [ "${DEPLOY_AIO}" != false ]; then
 
     ## Create the AIO
     pushd /opt/openstack-ansible
-      bash -c "scripts/gate-check-commit.sh"
+      bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"
     popd
 
     ## Drop the AIO marker file.


### PR DESCRIPTION
When deploying an AIO for testing it executes deploy.sh -> install.sh,
which bootstraps the ansible roles. Then deploy.sh executes
gate-check-commit.sh from OSA, which downloads the roles again using
git, whereas the deployment already has all the roles downloaded via
ansible-galaxy.

This patch makes gate-checkcommit not do any role bootstrapping so that
we only bootstrap the roles once.

Issue: [RO-3315](https://rpc-openstack.atlassian.net/browse/RO-3315)