### PR TITLE
RO-3303 Use python artifacts in AIO tests

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,18 +56,14 @@ if [ "${DEPLOY_AIO}" != false ]; then
     ## Run the basic installation script
     basic_install
 
-    # Force the AIO to use artifacts
-    # NOTE(cloudnull): This disables container/py artifacts for now. The
-    #                  RPC-OpenStack container/py artifacts are failing
-    #                  while the upstream container/py builds of similart
-    #                  sizes, packages, and distros is not showing the same
-    #                  issues. We need to spend some time debugging how the
-    #                  sources are built and how we can better construct and
-    #                  consume them.
+    # Implement the artifact configuration
+
+    # NOTE(odyssey4me):
+    # Re-enable container artifacts once
+    # RO-3316 has been resolved.
     openstack-ansible -i 'localhost,' \
                       -e 'apt_target_group=localhost' \
                       -e 'container_artifact_enabled=false' \
-                      -e 'py_artifact_enabled=false' \
                       "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
 
     # Install OpenStack-Ansible


### PR DESCRIPTION
With the artifact build problems resolved, and the various
issues relating to python artifact usage also resolved, we
can now revert to using the artifacts by default for AIO
builds.

Issue: [RO-3303](https://rpc-openstack.atlassian.net/browse/RO-3303)