### PR TITLE
[RO-2746] Remove marker files from gate scripts

### DIFF
--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -19,8 +19,6 @@ set -euv
 set -o pipefail
 
 ## Vars ----------------------------------------------------------------------
-# NOTE(cloudnull): See comment further down, but this should be removed later.
-export MARKER="/tmp/deploy-rpc-commit.complete"
 
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
@@ -28,23 +26,6 @@ export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 source "${SCRIPT_PATH}/functions.sh"
 
 ## Main ----------------------------------------------------------------------
-
-# NOTE(cloudnull): Drop a marker after Deploying RPC-OpenStack and check for
-#                  it's existance. This is here because our CIT gating system
-#                  calls this script a mess of times with different
-#                  environment variables instead of leveraging a stable
-#                  interface and controlling the systems code paths within
-#                  a set of well known and understanable test scripts.
-#                  Because unwinding this within the CIT gate is impossible
-#                  at this time and there's no stable interface to consume
-#                  we check for and drop a marker file once the basic AIO
-#                  has been created. If the marker is found we skip trying to
-#                  build everything again.
-# NOTE(cloudnull): Remove this when we have a sane test interface.
-if [ "${DEPLOY_AIO}" != false ] && [[ -f "${MARKER}" ]]; then
-  echo "RPC-O has already been deployed, remove \"${MARKER}\" to run again."
-  exit 0
-fi
 
 # Generate the scretes required for the deployment.
 if [[ ! -f "/etc/openstack_deploy/user_rpco_secrets.yml" ]]; then
@@ -84,6 +65,3 @@ pushd /opt/rpc-maas/playbooks
     openstack-ansible site.yml
   fi
 popd
-
-## Drop the RPC-OpenStack marker file.
-touch ${MARKER}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,8 +18,6 @@ set -euv
 set -o pipefail
 
 ## Vars ----------------------------------------------------------------------
-# NOTE(cloudnull): See comment further down, but this should be removed later.
-export MARKER="/tmp/gate-check-commit.complete"
 
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
@@ -39,46 +37,30 @@ function basic_install {
 
 # Setup OpenStack
 if [ "${DEPLOY_AIO}" != false ]; then
-  # Run the AIO job.
-  # NOTE(cloudnull): Drop a marker after building an AIO and check for it's
-  #                  existance. This is here because our CIT gating system
-  #                  calls this script a mess of times with different
-  #                  environment variables instead of leveraging a stable
-  #                  interface and controlling the systems code paths within
-  #                  a set of well known and understanable test scripts.
-  #                  Because unwinding this within the CIT gate is impossible
-  #                  at this time and there's no stable interface to consume
-  #                  we check for and drop a marker file once the basic AIO
-  #                  has been created. If the marker is found we skip trying to
-  #                  build everything again.
-  # NOTE(cloudnull): Remove this when we have a sane test interface.
-  if [[ ! -f "${MARKER}" ]]; then
-    ## Run the basic installation script
-    basic_install
+  ## Run the basic installation script
+  basic_install
 
-    # Implement the artifact configuration
+  # Force the AIO to use artifacts
+  # NOTE(cloudnull): This disables container/py artifacts for now. The
+  #                  RPC-OpenStack container/py artifacts are failing
+  #                  while the upstream container/py builds of similart
+  #                  sizes, packages, and distros is not showing the same
+  #                  issues. We need to spend some time debugging how the
+  #                  sources are built and how we can better construct and
+  #                  consume them.
+  openstack-ansible -i 'localhost,' \
+                    -e 'apt_target_group=localhost' \
+                    -e 'container_artifact_enabled=false' \
+                    -e 'py_artifact_enabled=false' \
+                    "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
 
-    # NOTE(odyssey4me):
-    # Re-enable container artifacts once
-    # RO-3316 has been resolved.
-    openstack-ansible -i 'localhost,' \
-                      -e 'apt_target_group=localhost' \
-                      -e 'container_artifact_enabled=false' \
-                      "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
+  # Install OpenStack-Ansible
+  openstack-ansible "${SCRIPT_PATH}/../playbooks/openstack-ansible-install.yml"
 
-    # Install OpenStack-Ansible
-    openstack-ansible "${SCRIPT_PATH}/../playbooks/openstack-ansible-install.yml"
-
-    ## Create the AIO
-    pushd /opt/openstack-ansible
-      bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"
-    popd
-
-    ## Drop the AIO marker file.
-    touch ${MARKER}
-  else
-    echo "An AIO has already been created, remove \"${MARKER}\" to run again."
-  fi
+  ## Create the AIO
+  pushd /opt/openstack-ansible
+    bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"
+  popd
 
   # Deploy RPC-OpenStack.
   bash -c "${SCRIPT_PATH}/deploy-rpco.sh"


### PR DESCRIPTION
The marker files were added to the gate tests because the CIT gating
system was repeatedly calling `deploy.sh`. With the merge of RLM-895[0]
this is no longer required. This PR removes the markers that are no
longer relevant.

[0] https://rpc-openstack.atlassian.net/browse/RLM-895

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3270](https://rpc-openstack.atlassian.net/browse/RO-3270)
