### PR TITLE
[RO-3273] Disable other artifacts if apt is disabled

### DIFF
--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -82,6 +82,18 @@
       tags:
         - always
 
+    - name: Disable other artifacts if apt is disabled
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_artifacts"
+        option: "{{ item.option }}"
+        value: "{{ item.value }}"
+      with_items:
+        - { option: "container_artifact_enabled", value: false }
+        - { option: "py_artifact_enabled", value: false }
+      when:
+        - not apt_artifact_enabled | bool
+
   tasks:
     - name: Sync artifact files (all)
       copy:


### PR DESCRIPTION
If the apt artifacts are disabled we should automatically disable all
other artifacts. According to RE this needs to be done because the
local libs for python artifacts and containers could cause systemic
conflicts when the base APT artifacts are not being used.

Issue: [RO-3274](https://rpc-openstack.atlassian.net/secure/RapidBoard.jspa?rapidView=76&selectedIssue=RO-3273)

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3273](https://rpc-openstack.atlassian.net/browse/RO-3273)