### PR TITLE
[RO-3272] Cleanup legacy user variable files

### DIFF
--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -166,6 +166,25 @@
         - skip_ansible_lint
 
   post_tasks:
+    - name: Remove legacy user variable files
+      file:
+        dest: "/etc/openstack_deploy/{{ item }}"
+        state: absent
+      with_items:
+        - "user_extras_variables.yml"
+        - "user_liberty_vars.yml"
+        - "user_master_vars.yml"
+        - "user_newton_vars.yml"
+        - "user_osa_variables_defaults.yml"
+        - "user_osa_varibles_defaults.yml"
+        - "user_rpc_maas_variables.yml"
+        - "user_rpcm_default_variables.yml"
+        - "user_rpcm_variables_defaults.yml"
+        - "user_rpcm_variables.yml"
+        - "user_rpco_user_variables_defaults.yml"
+        - "user_rpco_variables_defaults.yml"
+        - "user_variables.yml"
+
     - name: Set product release local fact
       ini_file:
         dest: "/etc/ansible/facts.d/rpc_openstack.fact"


### PR DESCRIPTION
This change removes legacy user variable files that may have been
created on the system over the life of the deployment. This change will
remove all of the legacy user variable files on disk which contained
"defaults" options already set within OSA and RPC-O group variables or
contained within the roles. All of the overrides implemented by RPC-O
will remain in the "override" files which will ensure anything
implemented by the deployer remains intact.

** This change does not validate options in variable files. All options
   in the override variable files are the responsibility of the
   deployer.

** This change is looking for and removing legacy variable files going
   as far back as liberty as it's very probable that these erroneous
   files will still exist, especially if the deployment has been leap
   upgraded.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

[RO-3272](https://rpc-openstack.atlassian.net/browse/RO-3272)

Issue: [RO-3272](https://rpc-openstack.atlassian.net/browse/RO-3272)