### PR TITLE
Update multi-release to the latest stable versions

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -4,11 +4,11 @@ rpc_product_releases:
     osa_release: master
     rpc_release: master
   newton:
-    maas_release: 1.3.1
-    osa_release: 03ef2e15742c6bd8404b784b06de6506ab750638
-    rpc_release: r14.5.0
+    maas_release: 1.4.0
+    osa_release: 32230e8cd982367940a9b68f65f1e73d6f14d2c4
+    rpc_release: r14.6.0
   ocata:
-    maas_release: 1.3.1
+    maas_release: 1.4.0
     osa_release: stable/ocata
     rpc_release: r15.0.0
   pike:


### PR DESCRIPTION
RPC r14.6.0 was just released and rev'd forward OSA and MaaS for our
stable product. This change updates our multi-release capabilities to
match what we presently have in stable.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
