### PR TITLE
[RLM-917] Add the ability to gate without artifacts

### DIFF
--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -33,6 +33,12 @@ source ${BASE_DIR}/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 
+if [[ "${RE_JOB_ACTION}" == "deploy_no_artifacts" ]]; then
+  export DEPLOY_ARTIFACTING="no"
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
+fi
+
 # Set the appropriate scenario variables
 if [[ "${RE_JOB_SCENARIO}" == "ceph" ]]; then
   export DEPLOY_CEPH="yes"


### PR DESCRIPTION
With PR rcbops/rpc-gating#584 the option to
gate without artifacts has been added. This provides rpc-openstack the
bility to understand this action and set the required options.

> While this option has been added to the gating purposes additional
  work will needed to be added to allow RPC-OpenStack Newton to deploy
  without artifacts. The DEPLOY_ARTIFACTING environment variable is AIO
  specific at this time.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RLM-917](https://rpc-openstack.atlassian.net/browse/RLM-917)