### PR TITLE
RO-3283 Use rpc-differ 0.3.4 to fix unicode bug

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,7 +8,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-RUN pip install osa_differ==0.3.4 rpc_differ==0.3.3 reno==2.5.1
+RUN pip install osa_differ==0.3.4 rpc_differ==0.3.4 reno==2.5.1
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
In order to fix a bug which causes rpc-differ to fail
when unicode is used in release notes, we update the
version of rpc-differ used to the latest version which
no longer fails.

Issue: [RO-3283](https://rpc-openstack.atlassian.net/browse/RO-3283)