### PR TITLE
RLM-316 Update gating artifact option setting

### DIFF
--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -33,12 +33,6 @@ source ${BASE_DIR}/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 
-if [[ "${RE_JOB_ACTION}" == "deploy_no_artifacts" ]]; then
-  export DEPLOY_ARTIFACTING="no"
-  apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
-fi
-
 # Set the appropriate scenario variables
 if [[ "${RE_JOB_SCENARIO}" == "ceph" ]]; then
   export DEPLOY_CEPH="yes"
@@ -47,8 +41,16 @@ elif [[ "${RE_JOB_SCENARIO}" == "ironic" ]]; then
   export DEPLOY_IRONIC="yes"
 fi
 
-if [[ ${RE_JOB_IMAGE} =~ loose$ ]]; then
+if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
+  # Set the env var to disable artifact usage
+  export DEPLOY_ARTIFACTING="no"
 
+  # Upgrade to the absolute latest
+  # available packages.
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+
+elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   # Set the apt artifact mode
   export RPCO_APT_ARTIFACTS_MODE="loose"
 


### PR DESCRIPTION
In [1] the names for the jobs were normalised to ensure more
consistency.

This updates the script to ensure that the new values are
properly interpreted.

The package upgrade consistently uses 'upgrade' instead
of 'dist-upgrade' as using the latter requires a reboot
to make all core OS packages upgraded active. A reboot
cannot be facilitated through this script and upgrading
the extra packages is unnecessary given the frequent image
updates anyway.

[1] https://github.com/rcbops/rpc-gating/pull/586

Issue: [RLM-316](https://rpc-openstack.atlassian.net/browse/RLM-316)
  