### PR TITLE
Do not pass --system-site-packages

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ fi
 #                  initial bootstrap purposes. While playbooks can be run using
 #                  this ansible release in the general sense, the OSA ansible
 #                  version will superseed this globally.
-virtualenv --system-site-packages /opt/rpc-ansible
+virtualenv /opt/rpc-ansible
 
 # Install a Ansible for RPC-OpenStack.
 install_ansible_wheel || install_ansible_source


### PR DESCRIPTION
Passing this flag allows the system to leak into the venv, this can cause
some problems particularly for compiled modules (openssl)
ERROR! Unexpected Exception: 'module' object has no attribute 'SSL_ST_INIT'