### PR TITLE
RO-3485 Do not delete user_variables.yml

### DIFF
--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -191,7 +191,6 @@
         - "user_rpcm_variables_defaults.yml"
         - "user_rpco_user_variables_defaults.yml"
         - "user_rpco_variables_defaults.yml"
-        - "user_variables.yml"
 
     - name: Set product release local fact
       ini_file:


### PR DESCRIPTION
During the initial configuration the initial sample user_variables.yml
file from /opt/openstack-ansible is copied into /etc/openstack_deploy
and then deleted a few tasks later. This would appear to be unintentional
behaviour, especially given that once the tooling is used for upgrades
it will remove any existing overrides implemented by the deployer.

Issue: [RO-3485](https://rpc-openstack.atlassian.net/browse/RO-3485)