### PR TITLE
RLM-316 Make artifact options consistent with pike

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ DEPLOY_RPC         | yes                                | Deploy the RPCO specif
 BOOTSTRAP_OPTS     |                                    | Any options used for the bootstrap process           | Only used if DEPLOY_AIO=yes
 FORKS              | `grep -c ^processor /proc/cpuinfo` | Number of forks Ansible may use                      | May have issues if FORKS > SSHD's MaxSessions. Adjust accordingly
 ANSIBLE_PARAMETERS |                                    | Additional paramters passed to Ansible               |
-RPCO_APT_ARTIFACTS_MODE | strict                        | Set the behaviour for the use of the apt artifacts   | Set to 'loose' to leave existing sources in place
+RPC_APT_ARTIFACT_MODE | strict                          | Set the behaviour for the use of the apt artifacts   | Set to 'loose' to leave existing sources in place
 
 All of the variables for deploy.sh are made available by sourcing the [functions.sh](https://github.com/rcbops/rpc-openstack/blob/master/scripts/functions.sh) script
 

--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -43,7 +43,7 @@ fi
 
 if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
   # Set the env var to disable artifact usage
-  export DEPLOY_ARTIFACTING="no"
+  export RPC_APT_ARTIFACT_ENABLED="no"
 
   # Upgrade to the absolute latest
   # available packages.
@@ -52,7 +52,7 @@ if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
 
 elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   # Set the apt artifact mode
-  export RPCO_APT_ARTIFACTS_MODE="loose"
+  export RPC_APT_ARTIFACT_MODE="loose"
 
   # Upgrade to the absolute latest
   # available packages.

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -22,7 +22,7 @@
         user_variables_overrides:
           ## Implement the appropriate override for the apt artifact
           ## deployment mode.
-          rpco_apt_artifacts_mode: "{{ lookup('env', 'RPCO_APT_ARTIFACTS_MODE') }}"
+          rpco_apt_artifacts_mode: "{{ lookup('env', 'RPC_APT_ARTIFACT_MODE') }}"
           ## Three vars below migrated from existing boostrap-aio task.
           apply_security_hardening: "{{ rpco_deploy_hardening }}"
           # Tempest is turned off to prevent the tests from running by default
@@ -222,7 +222,7 @@
   vars:
     bootstrap_host_apt_distribution_suffix_list: >-
       {{ ((lookup('env', 'RPCO_APT_ARTIFACTS_AVAILABLE') | bool) and
-          (lookup('env', 'RPCO_APT_ARTIFACTS_MODE') == 'strict'))
+          (lookup('env', 'RPC_APT_ARTIFACT_MODE') == 'strict'))
           | ternary([], ['updates', 'backports']) }}
     scenario: >-
       {%- if lookup('env', 'DEPLOY_IRONIC') | bool -%}

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -36,7 +36,6 @@ export DEPLOY_SUPPORT_ROLE=${DEPLOY_SUPPORT_ROLE:-"no"}
 export DEPLOY_HARDENING=${DEPLOY_HARDENING:-"yes"}
 export DEPLOY_RPC=${DEPLOY_RPC:-"yes"}
 export DEPLOY_ARA=${DEPLOY_ARA:-"no"}
-export DEPLOY_ARTIFACTING=${DEPLOY_ARTIFACTING:-"yes"}
 export DEPLOY_IRONIC=${DEPLOY_IRONIC:-"no"}
 export BOOTSTRAP_OPTS=${BOOTSTRAP_OPTS:-""}
 export UNAUTHENTICATED_APT=${UNAUTHENTICATED_APT:-no}
@@ -54,7 +53,8 @@ export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 export HOST_SOURCES_REWRITE=${HOST_SOURCES_REWRITE:-"yes"}
 export HOST_UBUNTU_REPO=${HOST_UBUNTU_REPO:-"http://mirror.rackspace.com/ubuntu"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
-export RPCO_APT_ARTIFACTS_MODE=${RPCO_APT_ARTIFACTS_MODE:-"strict"}
+export RPC_APT_ARTIFACT_ENABLED=${RPC_APT_ARTIFACT_ENABLED:-"yes"}
+export RPC_APT_ARTIFACT_MODE=${RPC_APT_ARTIFACT_MODE:-"strict"}
 
 # Derive the rpc_release version from the group vars
 export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
@@ -115,7 +115,7 @@ function copy_default_user_space_files {
 }
 
 function apt_artifacts_available {
-  [[ "${DEPLOY_ARTIFACTING}" != "yes" ]] && return 1
+  [[ "${RPC_APT_ARTIFACT_ENABLED}" != "yes" ]] && return 1
 
   CHECK_URL="${HOST_RCBOPS_REPO}/apt-mirror/integrated/dists/${RPC_RELEASE}-${DISTRIB_CODENAME}"
 
@@ -128,7 +128,7 @@ function apt_artifacts_available {
 }
 
 function git_artifacts_available {
-  [[ "${DEPLOY_ARTIFACTING}" != "yes" ]] && return 1
+  [[ "${RPC_APT_ARTIFACT_ENABLED}" != "yes" ]] && return 1
 
   CHECK_URL="${HOST_RCBOPS_REPO}/git-archives/${RPC_RELEASE}/requirements.checksum"
 
@@ -141,7 +141,7 @@ function git_artifacts_available {
 }
 
 function python_artifacts_available {
-  [[ "${DEPLOY_ARTIFACTING}" != "yes" ]] && return 1
+  [[ "${RPC_APT_ARTIFACT_ENABLED}" != "yes" ]] && return 1
 
   ARCH=$(uname -p)
   CHECK_URL="${HOST_RCBOPS_REPO}/os-releases/${RPC_RELEASE}/${ID}-${VERSION_ID}-${ARCH}/MANIFEST.in"
@@ -155,7 +155,7 @@ function python_artifacts_available {
 }
 
 function container_artifacts_available {
-  [[ "${DEPLOY_ARTIFACTING}" != "yes" ]] && return 1
+  [[ "${RPC_APT_ARTIFACT_ENABLED}" != "yes" ]] && return 1
 
   CHECK_URL="${HOST_RCBOPS_REPO}/meta/1.0/index-system"
 
@@ -169,7 +169,7 @@ function container_artifacts_available {
 
 function configure_apt_sources {
 
-  if [[ "${RPCO_APT_ARTIFACTS_MODE}" == "strict" ]]; then
+  if [[ "${RPC_APT_ARTIFACT_MODE}" == "strict" ]]; then
 
     # Backup the original sources file
     if [[ ! -f "/etc/apt/sources.list.original" ]]; then


### PR DESCRIPTION
In order to ease the transition for development, testing
and deployment between newton and pike the environment
variables are renamed to be the same as those used in
[1].

[1] https://github.com/rcbops/rpc-openstack/pull/2740

Issue: [RLM-316](https://rpc-openstack.atlassian.net/browse/RLM-316)