### PR TITLE
RO-3316 Disable container artifact usage

### DIFF
--- a/playbooks/configure-container-sources.yml
+++ b/playbooks/configure-container-sources.yml
@@ -43,6 +43,12 @@
       tags:
         - always
 
+    # TODO(odyssey4me):
+    # Remove this task once RO-3316 is resolved.
+    - name: Disable the use of container artifacts
+      set_fact:
+        container_artifact_enabled: no
+
     - name: Set the rpc-openstack variables
       set_fact:
         rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_artifacts'] }}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,15 +41,10 @@ if [ "${DEPLOY_AIO}" != false ]; then
   basic_install
 
   # Implement the artifact configuration
-
-  # NOTE(odyssey4me):
-  # Re-enable container artifacts once
-  # RO-3316 has been resolved.
   openstack-ansible -i 'localhost,' \
                     -e 'apt_target_group=localhost' \
                     -e "apt_artifact_enabled='${RPC_APT_ARTIFACT_ENABLED}'" \
                     -e "apt_artifact_mode='${RPC_APT_ARTIFACT_MODE}'" \
-                    -e 'container_artifact_enabled=false' \
                     "${SCRIPT_PATH}/../playbooks/site-artifacts.yml"
 
   # Install OpenStack-Ansible


### PR DESCRIPTION
As the resolution of the issue described in RO-3316 has
been designated to be solved after the pike release,
this patch disables container artifact usage for all
deployments rather than just for the AIO builds.

Issue: [RO-3316](https://rpc-openstack.atlassian.net/browse/RO-3316)