### PR TITLE
RE-1267 Update rpc_release to r16.0.0-beta.1

### DIFF
--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -28,6 +28,21 @@ elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 fi
 
+# When a PR contains a change to rpc_release, there may not
+# be any artifacts for the new release version. If this is
+# the case then we need to disable the artifact usage. In
+# order to figure out whether there are artifacts available,
+# we need to source the functions so that we have the right
+# variables available to use.
+source $(dirname ${0})/../../scripts/functions.sh
+
+# Check for available artifacts and disable artifact usage
+# if they are not available.
+CHECK_URL="${HOST_RCBOPS_REPO}/apt-mirror/integrated/dists/${RPC_RELEASE}-${DISTRIB_CODENAME}"
+if ! curl --output /dev/null --silent --head --fail ${CHECK_URL}; then
+  export RPC_APT_ARTIFACT_ENABLED="no"
+fi
+
 ## Functions -----------------------------------------------------------------
 
 ## Main ----------------------------------------------------------------------

--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -14,4 +14,4 @@ rpc_product_releases:
   pike:
     maas_release: 1.5.0
     osa_release: 4cde8f86aaea1fde7c43016f661119879068a133
-    rpc_release: r16.0.0-alpha.1
+    rpc_release: r16.0.0-beta.1


### PR DESCRIPTION
In order to prepare a beta release for broader testing,
the version is being updated. This will be the last
release before the release candidate.

When doing a PR for a new release, the artifacts do not yet exist
and therefore cannot be used. This PR implements a check in
the PR script which disables artifacting if it detects that no apt
artifacts are available for the given rpc_release.

Issue: [RE-1267](https://rpc-openstack.atlassian.net/browse/RE-1267)