### PR TITLE
RE-1267 Ensure host has python/python-yaml

### DIFF
--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -28,6 +28,15 @@ elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 fi
 
+# In order to get the value for rpc_release, we need to use
+# a python script, so we need to make sure that python and
+# the python yaml library are installed. If not, the value
+# for rpc_release cannot be read and the check for the value
+# will result in a null return, causing all artifacts to be
+# disabled.
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-yaml
+
 # When a PR contains a change to rpc_release, there may not
 # be any artifacts for the new release version. If this is
 # the case then we need to disable the artifact usage. In

--- a/playbooks/files/apt.yml
+++ b/playbooks/files/apt.yml
@@ -83,9 +83,8 @@ user_external_repos_list:
   - "{{ rpco_apt_repo }}"
 
 # Elasticsearch
-elasticsearch_apt_repos:
-  - "{{ rpco_apt_repo }}"
-elasticsearch_apt_keys: "{{ rpco_apt_gpg_keys }}"
+es_apt_key: "{{ rpco_gpg_key_location }}{{ rpco_gpg_key_name }}"
+es_apt_url: "{{ rpco_mirror_apt_deb_line }}"
 
 # Filebeat
 filebeat_apt_gpg_keys: "{{ rpco_apt_gpg_keys }}"


### PR DESCRIPTION
In order to get the value for rpc_release, we need to use
a python script, so we need to make sure that python and
the python yaml library are installed. If not, the value
for rpc_release cannot be read and the check for the value
will result in a null return, causing all artifacts to be
disabled.

Also, when deploying RPC-O master using strict mode for
artifacts, the upstream elasticsearch repo is used instead
of the apt artifacts repo. This patch implements the correct
overrides to resolve this issue.

Issue: [RE-1267](https://rpc-openstack.atlassian.net/browse/RE-1267)

Issue: [RO-3624](https://rpc-openstack.atlassian.net/browse/RO-3624)