### PR TITLE
Add tasks to revert artifacts if they're disabled

### DIFF
--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -131,103 +131,117 @@
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
-    - name: Sync artifact files (all)
-      copy:
-        src: "{{ item }}"
-        dest: "/etc/openstack_deploy/{{ item | basename }}"
-      with_items:
-        - files/user_rpcm_variables.yml
-      run_once: true
-      delegate_to: localhost
+    - name: Deploy apt artifacts
+      block:
+        - name: Backup the original sources list
+          command: "cp /etc/apt/sources.list /etc/apt/sources.list.original"
+          args:
+            creates: "/etc/apt/sources.list.original"
+
+        - name: Sync artifact files (all)
+          copy:
+            src: "{{ item }}"
+            dest: "/etc/openstack_deploy/group_vars/all/{{ item | basename }}"
+          with_items: "{{ artifact_apt_group_files }}"
+          run_once: true
+          delegate_to: localhost
+
+        - name: Determine the existing Ubuntu repo configuration
+          shell: 'sed "s/^[ \t]*//" /etc/apt/sources.list | grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)"'
+          register: _ubuntu_repo
+          changed_when: false
+          delegate_to: "{{ physical_host | default(omit) }}"
+          when:
+            - host_ubuntu_repo is not defined
+
+        - name: Set host_ubuntu_repo fact
+          set_fact:
+            host_ubuntu_repo: "{{ _ubuntu_repo.stdout_lines[0] }}"
+          when:
+            - host_ubuntu_repo is not defined
+            - _ubuntu_repo.stdout_lines is defined
+
+        - name: Replace the apt sources file with our content
+          copy:
+            content: |
+              # Base repository
+              deb {{ host_ubuntu_repo }} {{ ansible_distribution_release }} main universe
+            dest: "/etc/apt/sources.list"
+            backup: yes
+          register: apt_sources_configure
+
+        - name: Create the rpco apt sources file
+          copy:
+            content: |
+              # RPC-OpenStack repository
+              deb {{ rpco_mirror_base_url }}/apt-mirror/integrated/ {{ rpc_release }}-{{ ansible_distribution_release }} main
+            dest: "/etc/apt/sources.list.d/rpco.list"
+            backup: yes
+          register: apt_sources_configure_rpco
+
+        - name: Add rpco keys
+          apt_key:
+            url: "{{ rpco_mirror_base_url }}/apt-mirror/rcbops-release-signing-key.asc"
+            state: "present"
+          register: add_keys
+          until: add_keys | success
+          retries: 5
+          delay: 2
+
+        - name: Remove extra sources
+          lineinfile:
+            dest: /etc/apt/sources.list
+            state: absent
+            regexp: "{{ item }}"
+          with_items:
+            - "^deb-src"
+            - "-backports"
+            - "-security"
+            - "-updates"
       when:
         - apt_artifact_found | bool
         - apt_artifact_enabled | bool
 
-    - name: Determine the existing Ubuntu repo configuration
-      shell: 'sed "s/^[ \t]*//" /etc/apt/sources.list | grep -oP "^deb \K(\[?.*\]?.*ubuntu\S*\/?)(?= {{ ansible_distribution_release }} main)"'
-      register: _ubuntu_repo
-      changed_when: false
-      delegate_to: "{{ physical_host | default(omit) }}"
-      when:
-        - host_ubuntu_repo is not defined
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
+    - name: Revert apt artifacts
+      block:
+        - name: Remove artifact group vars (all)
+          file:
+            dest: "/etc/openstack_deploy/group_vars/all/{{ item | basename }}"
+            state: absent
+          with_items: "{{ artifact_apt_group_files }}"
+          run_once: true
+          delegate_to: localhost
 
-    - name: Set host_ubuntu_repo fact
-      set_fact:
-        host_ubuntu_repo: "{{ _ubuntu_repo.stdout_lines[0] }}"
-      when:
-        - host_ubuntu_repo is not defined
-        - _ubuntu_repo.stdout_lines is defined
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
+        - name: Check for original sources file
+          stat:
+            path: "/etc/apt/sources.list.original"
+          register: ogs
 
-    - name: Backup the original sources file
-      copy:
-        src: /etc/apt/sources.list
-        dest: /etc/apt/sources.list.original
-        remote_src: yes
-        force: no
+        - name: Remove the modified sources file
+          file:
+            dest: "/etc/apt/sources.list"
+            state: absent
+          register: remove_sources
+          when:
+            - ogs.stat.exists | bool
 
-    - name: Replace the apt sources file with our content (artifact 'strict' mode)
-      copy:
-        content: |
-          # Base repository
-          deb {{ host_ubuntu_repo }} {{ ansible_distribution_release }} main universe
-        dest: "/etc/apt/sources.list"
-        backup: yes
-      register: apt_sources_configure
-      when:
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
-        - apt_artifact_mode == "strict"
+        - name: Restore the original sources list and remove rpco.list
+          command: "mv /etc/apt/sources.list.original /etc/apt/sources.list"
+          args:
+            creates: "/etc/apt/sources.list"
+          when:
+            - remove_sources | changed
 
-    # Set rpco_apt_sources_restore_source to 'local' to have the
-    # original apt sources file from the deploy host be pushed out
-    # to all hosts and containers.
-    - name: Restore the original sources file (artifact 'loose' mode)
-      copy:
-        src: /etc/apt/sources.list.original
-        dest: /etc/apt/sources.list
-        remote_src: "{{ rpco_apt_sources_restore_source | default('remote') == 'remote' }}"
-        force: yes
-      register: apt_sources_restore
+        - name: Remove rpco sources file
+          file:
+            dest: "/etc/apt/sources.list.d/rpco.list"
+            state: absent
       when:
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
-        - apt_artifact_mode != "strict"
-
-    - name: Create the rpco apt sources file
-      copy:
-        content: |
-          # RPC-OpenStack repository
-          deb {{ rpco_mirror_base_url }}/apt-mirror/integrated/ {{ rpc_release }}-{{ ansible_distribution_release }} main
-        dest: "/etc/apt/sources.list.d/rpco.list"
-        backup: yes
-      register: apt_sources_configure_rpco
-      when:
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
-
-    - name: Add rpco keys
-      apt_key:
-        url: "{{ rpco_mirror_base_url }}/apt-mirror/rcbops-release-signing-key.asc"
-        state: "present"
-      register: add_keys
-      until: add_keys | success
-      retries: 5
-      delay: 2
-      when:
-        - apt_artifact_found | bool
-        - apt_artifact_enabled | bool
+        - not apt_artifact_enabled | bool
 
     - name: Update apt-cache
       apt:
         update_cache: yes
-      when:
-        - apt_artifact_enabled | bool
-        - apt_artifact_found | bool
-        - apt_sources_configure | changed or apt_sources_configure_rpco | changed or apt_sources_restore | changed
 
   post_tasks:
     - name: Set artifact local fact
@@ -246,6 +260,8 @@
 
   vars:
     ansible_python_interpreter: "/usr/bin/python"
-
+    artifact_apt_group_files:
+      - files/apt.yml
+      - files/maas.yml
   tags:
     - rpc

--- a/playbooks/configure-container-sources.yml
+++ b/playbooks/configure-container-sources.yml
@@ -95,8 +95,7 @@
       copy:
         src: "{{ item }}"
         dest: "/etc/openstack_deploy/group_vars/all/{{ item | basename }}"
-      with_items:
-        - files/lxc.yml
+      with_items: "{{ artifact_container_group_all_files }}"
       when:
         - container_artifact_found | bool
         - container_artifact_enabled | bool
@@ -105,25 +104,26 @@
       copy:
         src: "{{ item }}"
         dest: "/etc/openstack_deploy/group_vars/{{ item | basename }}"
-      with_items:
-        - "files/cinder_all.yml"
-        - "files/glance_all.yml"
-        - "files/heat_all.yml"
-        - "files/horizon_all.yml"
-        - "files/ironic_all.yml"
-        - "files/keystone_all.yml"
-        - "files/kibana_all.yml"
-        - "files/logstash_all.yml"
-        - "files/memcached_all.yml"
-        - "files/neutron_all.yml"
-        - "files/nova_all.yml"
-        - "files/repo_all.yml"
-        - "files/rsyslog_all.yml"
-        - "files/swift_all.yml"
-        - "files/utility_all.yml"
+      with_items: "{{ artifact_container_group_files }}"
       when:
         - container_artifact_found | bool
         - container_artifact_enabled | bool
+
+    - name: Remove artifact files (all)
+      file:
+        dest: "/etc/openstack_deploy/group_vars/all/{{ item | basename }}"
+        state: absent
+      with_items: "{{ artifact_container_group_all_files }}"
+      when:
+        - not apt_artifact_enabled | bool
+
+    - name: Remove artifact files
+      file:
+        dest: "/etc/openstack_deploy/group_vars/{{ item | basename }}"
+        state: absent
+      with_items: "{{ artifact_container_group_files }}"
+      when:
+        - not apt_artifact_enabled | bool
 
   post_tasks:
     - name: Set artifact local fact
@@ -139,6 +139,25 @@
   vars:
     ansible_python_interpreter: "/usr/bin/python"
     container_search_string: ".*{{ ansible_distribution_release }};.*{{ rpc_release }};"
+    container_search_string: ".*{{ ansible_distribution_release }};.*{{ rpc_release }};"
+    artifact_container_group_files:
+      - "files/cinder_all.yml"
+      - "files/glance_all.yml"
+      - "files/heat_all.yml"
+      - "files/horizon_all.yml"
+      - "files/ironic_all.yml"
+      - "files/keystone_all.yml"
+      - "files/kibana_all.yml"
+      - "files/logstash_all.yml"
+      - "files/memcached_all.yml"
+      - "files/neutron_all.yml"
+      - "files/nova_all.yml"
+      - "files/repo_all.yml"
+      - "files/rsyslog_all.yml"
+      - "files/swift_all.yml"
+      - "files/utility_all.yml"
+    artifact_container_group_all_files:
+      - "files/lxc.yml"
 
   tags:
     - rpc

--- a/playbooks/configure-python-sources.yml
+++ b/playbooks/configure-python-sources.yml
@@ -18,7 +18,7 @@
   environment: "{{ deployment_environment_variables | default({}) }}"
   connection: local
   user: root
-  tasks:
+  pre_tasks:
     - name: Ensure local facts directory exists
       file:
         dest: "/etc/ansible/facts.d"
@@ -84,6 +84,21 @@
       when:
         - py_artifact_enabled is undefined
 
+    - name: Set the rpc-release variables
+      set_fact:
+        rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
+      when:
+        - rpc_openstack['rpc_product_release'] is defined
+        - rpc_product_release is undefined or
+          rpc_product_release == 'undefined'
+
+    - name: Set OpenStack-Ansible release option
+      set_fact:
+        osa_release: "{{ rpc_product_releases[rpc_product_release]['osa_release'] }}"
+      when:
+        - osa_release is undefined
+
+  tasks:
     - name: Check if artifacts are enabled but not found
       fail:
         msg: |
@@ -118,6 +133,14 @@
         - py_artifact_found | bool
         - py_artifact_enabled | bool
 
+    - name: Backup the original repo-build playbook
+      command: "cp /opt/openstack-ansible/playbooks/repo-build.yml /opt/repo-build.yml.original.{{ osa_release }}"
+      args:
+        creates: "/opt/repo-build.yml.original.{{ osa_release }}"
+      when:
+        - py_artifact_found | bool
+        - py_artifact_enabled | bool
+
     - name: Link "repo-build.yml" to "stage-python-artifacts.yml"
       file:
         src: "{{ playbook_dir }}/stage-python-artifacts.yml"
@@ -128,6 +151,32 @@
         - py_artifact_found | bool
         - py_artifact_enabled | bool
 
+    - name: Revert py artifacts
+      block:
+        - name: Check for original repo build playbook
+          stat:
+            path: "/opt/repo-build.yml.original.{{ osa_release }}"
+          register: ogrbp
+
+        - name: Remove artifact files (all)
+          file:
+            dest: "/opt/openstack-ansible/playbooks/repo-build.yml"
+            state: absent
+          register: link_remove
+          when:
+            - ogrbp.stat.exists | bool
+
+        - name: Restore the original repo-build playbook
+          command: "mv /opt/repo-build.yml.original.{{ osa_release }} /opt/openstack-ansible/playbooks/repo-build.yml"
+          args:
+            creates: "/opt/openstack-ansible/playbooks/repo-build.yml"
+          when:
+            - link_remove | changed
+            - ogrbp.stat.exists | bool
+      when:
+        - not py_artifact_enabled | bool
+
+  post_tasks:
     - name: Set artifact local fact
       ini_file:
         dest: "/etc/ansible/facts.d/rpc_openstack.fact"
@@ -140,6 +189,10 @@
 
   vars:
     ansible_python_interpreter: "/usr/bin/python"
+    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') | default('undefined', true) }}"
+
+  vars_files:
+    - vars/rpc-release.yml
 
   tags:
     - rpc


### PR DESCRIPTION
Presently if artifacts are enabled there's no way to automate their
removal. This change adds tasks to backup files we modify and to
restore the backs (original) files should a deployer chose to disable
the artifacts.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
Signed-off-by: Matthew Thode <mthode@mthode.org>