### PR TITLE
RE-1241 Change rpc_release to r16.0.0

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -14,4 +14,4 @@ rpc_product_releases:
   pike:
     maas_release: 1.5.0
     osa_release: 6591c4a3d5991b60c480534c025ea7d394ac9991
-    rpc_release: r16.0.0-beta.1
+    rpc_release: r16.0.0


### PR DESCRIPTION
In order to prepare for the r16.0.0 release candidate,
the version of RPC-O is being set to the intended
release. This will ensure that all artifacts are
updated over the course of the next few weeks until
the RC is set.

Issue: [RE-1241](https://rpc-openstack.atlassian.net/browse/RE-1241)