### PR TITLE
RLM-1136 Lookup RPC_APT_ARTIFACT_MODE env var

### DIFF
--- a/group_vars/all/apt.yml
+++ b/group_vars/all/apt.yml
@@ -134,4 +134,4 @@ hwraid_apt_keys: "{{ rpco_apt_gpg_keys }}"
 #  being deployed.
 # This setting may be overridden by overriding it in the
 # /etc/openstack_deploy/user_*.yml files.
-rpco_apt_artifacts_mode: "strict"
+rpco_apt_artifacts_mode: "{{ lookup('env', 'RPC_APT_ARTIFACT_MODE') | default('strict', true) }}"


### PR DESCRIPTION
AIO looks up the environment variable but doing a
non-AIO deploy does not.

Issue: [RLM-1136](https://rpc-openstack.atlassian.net/browse/RLM-1136)