### PR TITLE
[RO-3498] Bump Elasticsearch Version

### DIFF
--- a/etc/openstack_deploy/group_vars/all/elasticsearch.yml
+++ b/etc/openstack_deploy/group_vars/all/elasticsearch.yml
@@ -6,7 +6,7 @@
 # role then attempts to render these datasets, and will fail if it cannot resolve
 # a variable. Putting these variables in here ensures the repo_build
 # role can interpolate the variables correctly.
-elasticsearch_version: 5.5.0
+elasticsearch_version: 5.6.5
 elasticsearch_reindex_version: 1.7.5
 
 es_instance_name: "openstack"


### PR DESCRIPTION
The Elasticsearch version needs to be updated in order to match the
version of Kibana that is in the upstream repos.

Issue: [RO-3498](https://rpc-openstack.atlassian.net/browse/RO-3498)