### PR TITLE
RLM-1104 Install cryptography after mnaio bootstrap (#2776)

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -93,12 +93,17 @@ pushd /opt/openstack-ansible-ops/multi-node-aio
   # By default the MNAIO deploys metering services, so we override
   # osa_enable_meter to prevent those services from being deployed.
   sed -i 's/osa_enable_meter: true/osa_enable_meter: false/' playbooks/group_vars/all.yml
-  # bump up cryptography version to avoid exception detailed in RLM-1104
-  pip install cryptography==1.5 --upgrade
 popd
 
 # build the multi node aio
 pushd /opt/openstack-ansible-ops/multi-node-aio
+  # normally we can run ./build.sh by itself but gating environment requires
+  # this hack for now, have to set up env before updating cryptography
+  # run bootstrap first to set environment up
+  ./bootstrap.sh
+  # bump up cryptography version to avoid exception detailed in RLM-1104
+  pip install cryptography==1.5 --upgrade
+  # build the mnaio normally
   ./build.sh
 popd
 echo "Multi Node AIO setup completed..."
@@ -112,13 +117,13 @@ if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
   ${MNAIO_SSH} "apt-get -qq update; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade"
 elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   # Set the apt artifact mode
-  echo "export RPC_APT_ARTIFACT_MODE=loose >> /opt/rpc-openstack/RE_ENV
+  echo "export RPC_APT_ARTIFACT_MODE=loose" >> /opt/rpc-openstack/RE_ENV
   ${MNAIO_SSH} "apt-get -qq update; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade"
 fi
 
 # Set the appropriate scenario variables
 if [[ "${RE_JOB_SCENARIO}" == "ceph" ]]; then
-  echo "export DEPLOY_CEPH=yes >> /opt/rpc-openstack/RE_ENV
+  echo "export DEPLOY_CEPH=yes" >> /opt/rpc-openstack/RE_ENV
   echo "export DEPLOY_SWIFT=no" >> /opt/rpc-openstack/RE_ENV
 elif [[ "${RE_JOB_SCENARIO}" == "ironic" ]]; then
   echo "export DEPLOY_IRONIC=yes" >> /opt/rpc-openstack/RE_ENV


### PR DESCRIPTION
In order to work around issues from the gating env,
we have to upgrade cryptography but it needs to be
done after running the bootstrap from build.sh so
dependencies like gcc are already in place.

Once installed, we should be able to run build.sh as
normal.

(cherry picked from commit cb380c3acfe2ab2ba70343ce21ced9f4915de598)

Issue: [RLM-1104](https://rpc-openstack.atlassian.net/browse/RLM-1104)

Issue: [RO-3727](https://rpc-openstack.atlassian.net/browse/RO-3727)