### PR TITLE
RO-3729 Source functions correctly in post_deploy

### DIFF
--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -14,7 +14,7 @@ export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 
 ## Functions -----------------------------------------------------------------
-source ../../scripts/functions.sh
+source $(dirname ${0})/../../scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 


### PR DESCRIPTION
The functions currently fail to source due to the wrong path.

(cherry picked from commit fd43b10c31a553e04350556c43341c690c7c4758)

Issue: [RO-3729](https://rpc-openstack.atlassian.net/browse/RO-3729)