### PR TITLE
RO-3316 Enable container image usage

### DIFF
--- a/playbooks/configure-container-sources.yml
+++ b/playbooks/configure-container-sources.yml
@@ -43,12 +43,6 @@
       tags:
         - always
 
-    # TODO(odyssey4me):
-    # Remove this task once RO-3316 is resolved.
-    - name: Disable the use of container artifacts
-      set_fact:
-        container_artifact_enabled: no
-
     - name: Set the rpc-openstack variables
       set_fact:
         rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_artifacts'] }}"


### PR DESCRIPTION
With the containers builds fixed, they are now producing single
stream xz archives which are usable by machinectl when importing.

Without using the container images we would have to implement [1]
to downgrade any packages installed upstream in lxc-ci which are
not available in our apt repository, so it is better to re-enable
the use of container artifacts where this is done in CI rather
than in deployments.

[1] https://github.com/rcbops/rpc-artifacts/blob/b00e8059d6c969b176e5a5942a4034d57978433e/user_rcbops_artifacts_building.yml#L57-L96

Issue: [RO-3316](https://rpc-openstack.atlassian.net/browse/RO-3316)