### PR TITLE
RO-3316 Enable container images for MNAIO tests

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -65,8 +65,6 @@ export INFRA_VM_SERVER_RAM=16384
 # artifact settings
 export RPC_APT_ARTIFACT_ENABLED="${RPC_APT_ARTIFACT_ENABLED:-yes}"
 export RPC_APT_ARTIFACT_MODE="${RPC_APT_ARTIFACT_MODE:-strict}"
-# RO-3316 - Disable container artifact usage
-export RPC_CONTAINER_ARTIFACT_ENABLED=false
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
@@ -161,7 +159,6 @@ ${MNAIO_SSH} <<EOC
                       -e 'apt_target_group=localhost' \
                       -e "apt_artifact_enabled='${RPC_APT_ARTIFACT_ENABLED}'" \
                       -e "apt_artifact_mode='${RPC_APT_ARTIFACT_MODE}'" \
-                      -e "container_artifact_enabled='${RPC_CONTAINER_ARTIFACT_ENABLED}'" \
                       site-artifacts.yml
     openstack-ansible openstack-ansible-install.yml
   popd


### PR DESCRIPTION
As discussed in [1] the container images should now
be used in build tests, rather than disabled. The
setting for the MNAIO tests was missed in [1] so
this patch resolves that.

[1] https://github.com/rcbops/rpc-openstack/pull/2797

(cherry picked from commit 94fee0467a75b8fedb75ae591994d2915f802990)

Issue: [RO-3316](https://rpc-openstack.atlassian.net/browse/RO-3316)