### PR TITLE
[RLM-322]Nova hostname fix

### DIFF
--- a/rpcd/etc/openstack_deploy/user_osa_variables_overrides.yml
+++ b/rpcd/etc/openstack_deploy/user_osa_variables_overrides.yml
@@ -20,3 +20,6 @@
 
 # this variable is here because vars files need to have at least ONE variable defined.
 this_file_is_reserved_for_support: True
+nova_nova_conf_overrides:
+    DEFAULT:
+        host: "{{ inventory_hostname }}"


### PR DESCRIPTION
Since nova-compute would delete nova.compute.node due to hostname
updated, we fix nova to certain hostname to prevent this happening.