### PR TITLE
Notify users & protect the rpcm var file

### DIFF
--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -135,6 +135,7 @@
       copy:
         src: "{{ item }}"
         dest: "/etc/openstack_deploy/{{ item | basename }}"
+        mode: "0444"
       with_items:
         - files/user_rpcm_variables.yml
       run_once: true

--- a/playbooks/files/user_rpcm_variables.yml
+++ b/playbooks/files/user_rpcm_variables.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# NOTICE! ANY CHANGE IN THIS FILE WILL BE REMOVED DURING A PLAYBOOK RUN.
+# PLEASE PLACE MAAS OVERRIDES IN A USER CONTROLLED VARIABLE FILE.
+
+
 # Apt artifact repo configuration
 # The rest of the apt artifact repo configuration is held in
 # group_vars/all/apt.yml but due to the way that the rpc-maas


### PR DESCRIPTION
While we expect users to largely ignore this file in deployments,
especially given the fact that it's only used it when artifacts are
enabled, we have the ability to protect the file and notify operators
that this file should not be written to. This change sets the mode of
the user variable files we put into place to 0444 which will, by
default, make the file read only. This change also adds a comment to the
top of the file notifying users that any change written to the rpcm
variable file will be undone should the playbooks be executed.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3440](https://rpc-openstack.atlassian.net/browse/RO-3440)