### PR TITLE
RE-1287 Allow openstack_deploy as symlink

### DIFF
--- a/playbooks/get-maas.yml
+++ b/playbooks/get-maas.yml
@@ -23,10 +23,15 @@
         repo: "https://github.com/rcbops/rpc-maas"
         dest: "/opt/rpc-maas"
         version: "{{ maas_release }}"
-    - name: Ensure openstack_deploy exists
-      file:
-        dest: "/etc/openstack_deploy"
-        state: directory
+    - name: Stat /etc/openstack_deploy
+      stat:
+        path: "/etc/openstack_deploy"
+      register: stat_openstack_deploy
+    - name: Fail when /etc/openstack_deploy doesn't exist
+      fail:
+        msg: "/etc/openstack_deploy is required but doesn't exist"
+      when:
+        - not stat_openstack_deploy.stat.exists
     - name: Copy over base maas vars
       copy:
         src: "/opt/rpc-maas/tests/user_master_vars.yml"


### PR DESCRIPTION
Currently get-maas.yml checks that /etc/openstack_deploy is a directory,
whereas the check was intended to ensure that it exists (according to
the naming of the task.)

This patch uses the stat and fail modules to ensure that
openstack_deploy exists, without forcing it to be a particular type.

This is useful when you want to keep config in git, and symlink a dir
from that repo to /etc/openstack_deploy.

Issue: [RE-1287](https://rpc-openstack.atlassian.net/browse/RE-1287)