### PR TITLE
RLM-3856 Set artifact variables in script

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -111,10 +111,12 @@ env | grep RE_ | sed 's/^/export /' > /opt/rpc-openstack/RE_ENV
 
 # check if we're using artifacts or not
 if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
+  export RPC_APT_ARTIFACT_ENABLED=no
   echo "export RPC_APT_ARTIFACT_ENABLED=no" >> /opt/rpc-openstack/RE_ENV
   ${MNAIO_SSH} "apt-get -qq update; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade"
 elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   # Set the apt artifact mode
+  export RPC_APT_ARTIFACT_MODE=loose
   echo "export RPC_APT_ARTIFACT_MODE=loose" >> /opt/rpc-openstack/RE_ENV
   ${MNAIO_SSH} "apt-get -qq update; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade"
 fi


### PR DESCRIPTION
Artifact variables were getting set in the ENV file
but not inside the script so that when the deploy-infra1.sh
file was generated, it was actually getting the artifact
defaults instead of the overrides.  This ensures those
variables are set so that the generated deploy-infra1.sh
has the proper values.

Issue: [RLM-3856](https://rpc-openstack.atlassian.net/browse/RLM-3856)