### PR TITLE
RE-1304 Add workaround for nova-novncproxy fail

### DIFF
--- a/releasenotes/notes/nova-novncproxy-restart-6aa641c97867e6ef.yaml
+++ b/releasenotes/notes/nova-novncproxy-restart-6aa641c97867e6ef.yaml
@@ -1,0 +1,17 @@
+---
+issues:
+  - |
+    For all newton releases up to r14.8.0 when executing the os-nova-install.yml
+    playbook the ``nova-novncproxy`` and ``nova-spicehtml5proxy`` services will
+    fail. The workaround to resolve this issue is to restart the services.
+
+    .. code-block:: shell-session
+
+      cd /opt/rpc-openstack/openstack-ansible/playbooks
+      # start the service again
+      # replace nova-novncproxy with nova-spicehtml5proxy when appropriate
+      ansible nova_console -m service -a 'name=nova-novncproxy state=restarted'
+      # set the appropriate facts to prevent the playbook trying
+      # to reload it again when the playbook is run again
+      ansible nova_console -m ini_file -a 'dest=/etc/ansible/facts.d/openstack_ansible.fact section=nova option=need_service_restart value=False'
+


### PR DESCRIPTION
For all newton releases up to r14.8.0 when executing the os-nova-install.yml
playbook the ``nova-novncproxy`` and ``nova-spicehtml5proxy`` services will
fail. The workaround to resolve this issue is to restart the services.

This patch adds a release note to communicate the known issue. The fix will
be brought into the r14.9.0 release as part of the upstream dependency
updates.

(cherry picked from commit e57b236fc064513b59d774fe8ecbdc947ef48dfb)

Issue: [RE-1304](https://rpc-openstack.atlassian.net/browse/RE-1304)