### PR TITLE
[RO-3870] Disable artifacts & gate no|loose|strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,20 +98,23 @@ cd /opt/rpc-openstack
 openstack-ansible site-artifacts.yml -e 'apt_artifact_mode="loose"'
 ```
 
-###### Optional | Disable Artifacts
+###### Optional | Toggle Artifacts
 
-It is possible to disable parts of the artifact deployment system RPC-OpenStack
-provides. To disable the artifact components any of the following variables
-can be set to **false** when running the `site-artifacts.yml` playbook.
+It is possible to toggle parts of the artifact deployment system RPC-OpenStack
+provides. To toggle any of the artifact components the following variables
+can be set to **true** or **false** when running the `site-artifacts.yml`
+playbook. By default artifacting is disabled.
 
 * apt_artifact_enabled
 * container_artifact_enabled
 * py_artifact_enabled
 
-If these variables are unset, they will automatically flip to **true** when the
-respective artifacts are found. These settings are stored in the local fact file
-`/etc/ansible/facts.d/rpc_openstack.fact`. If a deployer needs to completely
-reset the state of artifacts, this file can be removed or modified as needed.
+If a deployer needs to forcibly modify or reset the state of artifacts,
+everything is stored as a local fact in the
+`/etc/ansible/facts.d/rpc_openstack.fact` file which can be removed or modified
+as needed.
+
+**Example Command to disable artifacts**
 
 ``` shell
 openstack-ansible site-artifacts.yml -e 'apt_artifact_enabled=false' \

--- a/gating/pre_merge_test/run_deploy.sh
+++ b/gating/pre_merge_test/run_deploy.sh
@@ -21,11 +21,17 @@ if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
 elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   # Set the apt artifact mode
   export RPC_APT_ARTIFACT_MODE="loose"
+  export RPC_APT_ARTIFACT_ENABLED="yes"
 
   # Upgrade to the absolute latest
   # available packages.
   apt-get update
   DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
+
+elif [[ ${RE_JOB_IMAGE} =~ strict_artifacts$ ]]; then
+  # Set the apt artifact mode
+  export RPC_APT_ARTIFACT_MODE="strict"
+  export RPC_APT_ARTIFACT_ENABLED="yes"
 fi
 
 # In order to get the value for rpc_release, we need to use

--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -111,14 +111,22 @@ env | grep RE_ | sed 's/^/export /' > /opt/rpc-openstack/RE_ENV
 
 # check if we're using artifacts or not
 if [[ ${RE_JOB_IMAGE} =~ no_artifacts$ ]]; then
-  export RPC_APT_ARTIFACT_ENABLED=no
+  export RPC_APT_ARTIFACT_ENABLED="no"
   echo "export RPC_APT_ARTIFACT_ENABLED=no" >> /opt/rpc-openstack/RE_ENV
   ${MNAIO_SSH} "apt-get -qq update; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade"
+
 elif [[ ${RE_JOB_IMAGE} =~ loose_artifacts$ ]]; then
   # Set the apt artifact mode
-  export RPC_APT_ARTIFACT_MODE=loose
+  export RPC_APT_ARTIFACT_MODE="loose"
   echo "export RPC_APT_ARTIFACT_MODE=loose" >> /opt/rpc-openstack/RE_ENV
   ${MNAIO_SSH} "apt-get -qq update; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade"
+
+elif [[ ${RE_JOB_IMAGE} =~ strict_artifacts$ ]]; then
+  # Set the apt artifact mode
+  export RPC_APT_ARTIFACT_MODE="strict"
+  echo "export RPC_APT_ARTIFACT_MODE=strict" >> /opt/rpc-openstack/RE_ENV
+  export RPC_APT_ARTIFACT_ENABLED="yes"
+  echo "export RPC_APT_ARTIFACT_ENABLED=yes" >> /opt/rpc-openstack/RE_ENV
 fi
 
 # Set the appropriate scenario variables

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -55,7 +55,7 @@ done
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export HOST_RCBOPS_DOMAIN="rpc-repo.rackspace.com"
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://${HOST_RCBOPS_DOMAIN}"}
-export RPC_APT_ARTIFACT_ENABLED=${RPC_APT_ARTIFACT_ENABLED:-"yes"}
+export RPC_APT_ARTIFACT_ENABLED=${RPC_APT_ARTIFACT_ENABLED:-"no"}
 export RPC_APT_ARTIFACT_MODE=${RPC_APT_ARTIFACT_MODE:-"strict"}
 export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
 export RPC_OS="${ID}-${VERSION_ID}-x86_64"


### PR DESCRIPTION
This change implements the change to react to gate images for
no|loose|strict artifacting. This also disables artifacting by default
for actual deployments.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3870](https://rpc-openstack.atlassian.net/browse/RO-3870)