### PR TITLE
RLM-322 Change openstack_hosts role to rpc one

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -16,4 +16,4 @@
 - name: openstack_hosts
   scm: git
   src: https://github.com/rcbops/openstack-ansible-openstack_hosts
-  version: ce249ec4386d013d76b617f009a93a408f76619e 
+  version: 235ec6f0fc5570e7c657b243bcf4208cc2c7739c

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -10,3 +10,7 @@
   scm: git
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
+- name: openstack_hosts
+  scm: git
+  src: https://github.com/rcbops/openstack-ansible-openstack_hosts
+  version: ce249ec4386d013d76b617f009a93a408f76619e 

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -10,6 +10,9 @@
   scm: git
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
+# Created for JIRA RLM-322
+# Frank: this is a forked ansible role for removing
+# hardcoded period mark from hostname template.
 - name: openstack_hosts
   scm: git
   src: https://github.com/rcbops/openstack-ansible-openstack_hosts


### PR DESCRIPTION
Link the rpc openstack_hosts role which is removed period mark from
templates/openstack-host-hostfile-setup.sh.j2