### PR TITLE
RO-3937 Add ironic/nova to EOL repo list

### DIFF
--- a/scripts/artifacts-building/containers/build-process.sh
+++ b/scripts/artifacts-building/containers/build-process.sh
@@ -131,10 +131,10 @@ if ! python_artifacts_available; then
     # which no longer exists.
     # We implement the override here to cater for PR tests
     # only.
-    eol_repo_list="cinder glance heat horizon keystone magnum_dashboard"
+    eol_repo_list="cinder glance heat horizon ironic keystone magnum_dashboard"
     eol_repo_list="${eol_repo_list} neutron neutron_dynamic_routing"
     eol_repo_list="${eol_repo_list} neutron_fwaas neutron_lbaas"
-    eol_repo_list="${eol_repo_list} neutron_vpnaas swift"
+    eol_repo_list="${eol_repo_list} neutron_vpnaas nova swift"
     for svc in ${eol_repo_list}; do
       echo "${svc}_git_install_branch: newton-eol" >> ${OA_OVERRIDES}
     done


### PR DESCRIPTION
Both ironic and nova have deleted the stable/newton branch
and need to now make use of the EOL tags. When building
the containers without the python artifacts we use developer
mode for the role execution, so we need to set the correct
var to ensure the EOL tag is used.

Issue: [RO-3937](https://rpc-openstack.atlassian.net/browse/RO-3937)