### PR TITLE
RO-2932 Remove unused run_tempest.yml

### DIFF
--- a/scripts/run_tempest.yml
+++ b/scripts/run_tempest.yml
@@ -1,1 +1,0 @@
-../playbooks/run_tempest.yml


### PR DESCRIPTION
This patch removes the unused `run_tempest.yml` playbook that is
no longer referenced in rpc-openstack and rpc-gating.

Issue: [RO-2932](https://rpc-openstack.atlassian.net/browse/RO-2932)