### PR TITLE
RO-2932 Remove RabbitMQ ulimit override

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -16,11 +16,6 @@
 # Nova config overrides
 nova_console_type: novnc
 
-# RabbitMQ overrides
-# NOTE(mhayden): Remove this override once the OpenStack-Ansible SHA is bumped
-# to include: https://review.openstack.org/#/c/500054/
-rabbitmq_ulimit: 65535
-
 # Set RabbitMQ message replication count to 2
 # The desired setting would be {{ (groups.rabbitmq|length /2 +1)|round(0,'floor') |int }}
 # but can't be used due to https://github.com/ansible/ansible/issues/9362


### PR DESCRIPTION
There is no need to carry the `rabbitmq_ulimit` override since it
matches the upstream value in OpenStack-Ansible.

Upstream patches:

  https://review.openstack.org/#/q/8f32edae0902bb7173b44c71398673510bd5b6cc

Issue: [RO-3856](https://rpc-openstack.atlassian.net/browse/RO-3856)