### PR TITLE
RLM-322 Change openstack_hosts role to rpc one

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -10,3 +10,10 @@
   scm: git
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
+# Created for JIRA RLM-322
+# Frank: this is a forked ansible role for removing
+# hardcoded period mark from hostname template.
+- name: openstack_hosts
+  scm: git
+  src: https://github.com/rcbops/openstack-ansible-openstack_hosts
+  version: 235ec6f0fc5570e7c657b243bcf4208cc2c7739c


### PR DESCRIPTION
Cherry-picks change from Newton to Newton-RC to fix issues with openstack_domains during leapfrogs.

* Change openstack_hosts role to rpc one

Link the rpc openstack_hosts role which is removed period mark from
templates/openstack-host-hostfile-setup.sh.j2

* Add commoent to role requirement change

Link JIRA card number and brief the purpose of the change.

* Replace SHA1 with udpated stable/Newton

Since newton PR on rpc openstack_hosts role is merged.

Issue: [RLM-322](https://rpc-openstack.atlassian.net/browse/RLM-322)