### PR TITLE
[master-rc] Update rpc-maas

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -12,6 +12,6 @@ rpc_product_releases:
     osa_release: stable/ocata
     rpc_release: r15.0.0
   pike:
-    maas_release: 1.5.0
+    maas_release: 1.6.0
     osa_release: 826636b994b7e3ab797c227eed10e39a62f19f43
     rpc_release: r16.0.0


### PR DESCRIPTION
This changes the RPC-MaaS version from 1.5.0 to 1.6.0 to fix
MaaS checks/alarm failures.

(cherry picked from commit 79c7bf61035ee09fbbc893579a466925db163c80)

Issue: [RO-3888](https://rpc-openstack.atlassian.net/browse/RO-3888)