### PR TITLE
Revert "RE-1308 Fix openSUSE image URL"

### DIFF
--- a/playbooks/vars/openstack-service-config.yml
+++ b/playbooks/vars/openstack-service-config.yml
@@ -91,7 +91,7 @@ openstack_images:
       img_config_drive: "optional"
   - name: OpenSuse Leap 42.3
     format: qcow2
-    url: http://download.opensuse.org/repositories/Cloud:/Images:/Leap_42.3/images/openSUSE-Leap-42.3-OpenStack.x86_64
+    url: http://download.opensuse.org/repositories/Cloud:/Images:/Leap_42.3/images/openSUSE-Leap-42.3-OpenStack.x86_64.qcow2
     properties:
       hw_scsi_model: "virtio-scsi"
       hw_disk_bus: "scsi"


### PR DESCRIPTION
This reverts commit db32927e5bfa0deba569082bdc329cec5f59976f.

The URL has reverted to its previous form causing a failure when trying
to download the image.

Issue: [RE-1308](https://rpc-openstack.atlassian.net/browse/RE-1308)