### PR TITLE
RO-3952 Revert elasticsearch SHA update

### DIFF
--- a/ansible-role-pike-requirements.yml
+++ b/ansible-role-pike-requirements.yml
@@ -13,7 +13,7 @@
 - name: elasticsearch
   scm: git
   src: https://github.com/elastic/ansible-elasticsearch
-  version: d7a5af8c33c5adb3aeff5d9e2caba2e2f853cd4d
+  version: 7714c925e06e8538a09b6e9d8c1bd074813e9639
 - name: rcbops_openstack-ops
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops


### PR DESCRIPTION
The update of the elasticsearch role SHA introduced a breaking change.
This reverts the SHA to its previous value while a fix is prepared to
move the SHA on again.

Reverts the change introduced by https://github.com/rcbops/rpc-openstack/pull/2815

Issue: [RO-3952](https://rpc-openstack.atlassian.net/browse/RO-3952)