### PR TITLE
Add elasticsearch_major_version

### DIFF
--- a/etc/openstack_deploy/group_vars/all/elasticsearch.yml
+++ b/etc/openstack_deploy/group_vars/all/elasticsearch.yml
@@ -6,7 +6,8 @@
 # role then attempts to render these datasets, and will fail if it cannot resolve
 # a variable. Putting these variables in here ensures the repo_build
 # role can interpolate the variables correctly.
-elasticsearch_version: 5.6.5
+elasticsearch_version: 5.6.7
+elasticsearch_major_version: 5.x
 elasticsearch_reindex_version: 1.7.5
 
 es_instance_name: "openstack"
@@ -19,6 +20,7 @@ es_heap_size: 1g
 es_api_host: "{{ container_address }}"
 es_api_port: "{{ elasticsearch_http_port }}"
 es_version: "{{ elasticsearch_version }}"
+es_major_version: "{{ elasticsearch_major_version }}"
 
 es_config:
   node.name: "{{ container_name }}"


### PR DESCRIPTION
The updated ansible role from elastic.co does checking on the
es_major_version, we need to set it to the correct major version in
order to pull from the appropriate repository.

Fixes: RO-3952

Issue: [RO-3952](https://rpc-openstack.atlassian.net/browse/RO-3952)