### PR TITLE
RO-3973 Override MariaDB repo configuration

### DIFF
--- a/etc/openstack_deploy/group_vars/all/mariadb.yml
+++ b/etc/openstack_deploy/group_vars/all/mariadb.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO(odyssey4me):
+# Remove this once the more specific version pins in OSA
+# are in the SHA we use, or a longer term solution is
+# available in OSA.
+#
+# ref:
+# https://rpc-openstack.atlassian.net/browse/RO-3973
+#
+galera_repo_url: https://downloads.mariadb.com/MariaDB/mariadb-10.1.30/repo/ubuntu
+galera_client_repo_url:  "{{ galera_repo_url }}"

--- a/playbooks/configure-apt-sources.yml
+++ b/playbooks/configure-apt-sources.yml
@@ -118,6 +118,16 @@
         - not apt_artifact_enabled | bool
 
   tasks:
+    - name: Remove MariaDB repo overrides if apt artifacts enabled
+      file:
+        path: "/etc/openstack_deploy/group_vars/all/mariadb.yml"
+        state: "absent"
+      run_once: true
+      delegate_to: localhost
+      when:
+        - apt_artifact_found | bool
+        - apt_artifact_enabled | bool
+
     - name: Sync artifact files (all)
       copy:
         src: "{{ item }}"


### PR DESCRIPTION
MariaDB released new packages yesterday which breaks MariaDB
clustering for multi-node deployments. This breaks non-artifacted
builds which use MariaDB 10.1.

As a workaround until an upstream fix is implemented, we
override the defaults set in OSA to ensure that we use the
last known good version of MariaDB.

As these settings are unnecessary when using apt artifacts,
the overrides are removed if apt artifacts are enabled so
that only the apt artifacts repo is used.

(cherry picked from commit ef222dee5e0e477b31cd28c63c3686e5e361c3be)

Issue: [RO-3973](https://rpc-openstack.atlassian.net/browse/RO-3973)