### PR TITLE
RE-36 Thaw adjustments

### DIFF
--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -17,7 +17,7 @@ cp /opt/root_ssh_backup/.ssh/known_hosts /root/.ssh ||:
 ssh-keyscan localhost >> /root/.ssh/known_hosts
 
 
-cd /opt/rpc-openstack/openstack-ansible/playbooks/
+cd /opt/openstack-ansible/playbooks/
 
 # Use implicit fact gathering to ensure the fact cache is ignored,
 # and facts are always gathered. This important we rely on the public


### PR DESCRIPTION
This commit makes some minor adjustments to assist with the master
(pike) thaw process.

It appears that the thaw process was not updated when openstack-ansible
was moved out of the rpc-openstack tree.

Issue: [RE-36](https://rpc-openstack.atlassian.net/browse/RE-36)