### PR TITLE
RE-36 Update freeze and thaw process

### DIFF
--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -83,8 +83,6 @@ if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
 
   ln -s /opt/rpc-openstack/gating/thaw/run /gating/thaw/run
 
-  distro="$(lsb_release --codename --short)"
-
-  echo "rpc_${RPC_RELEASE}_${distro}" > /gating/thaw/image_name
+  echo "rpc-${RPC_RELEASE}-${RE_JOB_IMAGE}-${RE_JOB_SCENARIO}" > /gating/thaw/image_name
   echo "### END SNAPSHOT PREP ###"
 fi

--- a/gating/thaw/thaw.yml
+++ b/gating/thaw/thaw.yml
@@ -50,15 +50,9 @@
       regexp: "bind.*"
       replace: "bind {{ ansible_default_ipv4.address }}:5000"
 
-  - name: List stopped containers
-    shell: |
-      lxc-ls -f | awk '/STOPPED.*openstack/{print $1}'
-    register: stopped_containers
-
   - name: Start stopped containers
     shell: |
-      lxc-start -d -n {{ item }}
-    with_items: "{{ stopped_containers.stdout_lines }}"
+      lxc-autostart --all
 
   - name: Restart haproxy
     service:


### PR DESCRIPTION
This commit updates gating/pre_merge_test/post_deploy.sh to include
the full gating-specified image name and scenario in the name used to
create the instance snapshot. This is necessary to differentiate the
different artifact modes and whether the scenario is swift, ironic, etc.

Additionally, we update gating/thaw/thaw.yml to use lxc-autostart to
containers so that the start order defined in each container's config
is honoured.

Issue: [RE-36](https://rpc-openstack.atlassian.net/browse/RE-36)