### PR TITLE
RO-3857 Add support for MNAIO log collection

### DIFF
--- a/gating/pre_merge_test/collect_logs.yml
+++ b/gating/pre_merge_test/collect_logs.yml
@@ -1,0 +1,147 @@
+- hosts: "{{ target_hosts }}"
+  gather_facts: false
+  tasks:
+    - name: Ensure artefacts directories exists
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ artifacts_dir }}/{{ inventory_hostname }}/host"
+        - "{{ artifacts_dir }}/{{ inventory_hostname }}/containers"
+      delegate_to: "localhost"
+
+    - name: Grab host data
+      command: >
+               rsync
+               --archive
+               --compress
+               --verbose
+               --relative
+               --rsh 'ssh -o StrictHostKeyChecking=no'
+               --ignore-missing-args
+               --safe-links
+               --no-perms
+               --no-owner
+               --no-group
+               {{ inventory_hostname }}:{{ item }}
+               {{ artifacts_dir }}/{{ inventory_hostname }}/host
+      with_items:
+        - "/openstack/log"
+        - "/etc"
+        - "/var/./log"
+      delegate_to: "localhost"
+      ignore_errors: true
+      tags:
+        - skip_ansible_lint
+
+    - name: List containers
+      command: "lxc-ls -1"
+      failed_when:
+        - containers.rc != 0
+        - containers.msg != '[Errno 2] No such file or directory'
+      changed_when: false
+      register: containers
+
+    - name: Get container PIDs
+      command: "lxc-info --name {{ item }} --no-humanize --pid"
+      with_items:
+        - "{{ containers.stdout_lines | default([]) }}"
+      register: container_pids
+
+    - name: Grab container data
+      command: >
+               rsync
+               --archive
+               --compress
+               --verbose
+               --rsh 'ssh -o StrictHostKeyChecking=no'
+               --ignore-missing-args
+               --safe-links
+               --no-perms
+               --no-owner
+               --no-group
+               {{ inventory_hostname }}:/proc/{{ item[0].stdout }}/root/{{ item[1] }}
+               {{ artifacts_dir }}/{{ inventory_hostname }}/containers/{{ item[0].item }}
+      when:
+        - containers.rc == 0
+        - item[0].stdout != ""
+      with_nested:
+        - "{{ container_pids.results }}"
+        -
+          - "etc"
+          - "var/log"
+      delegate_to: "localhost"
+      tags:
+        - skip_ansible_lint
+  vars:
+    artifacts_dir: "/tmp/artifacts"
+    target_hosts: "localhost"
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Ensure result directory exists
+      file:
+        path: "{{ result_dir }}"
+        state: directory
+
+    - name: Find tempest results file
+      find:
+        paths: "{{ artifacts_dir }}"
+        recurse: yes
+        patterns: "tempest_results*.xml"
+      register: results_files
+
+    - name: Copy tempest results to RE_HOOK_RESULT_DIR
+      copy:
+       src: "{{ item.path }}"
+       dest: "{{ result_dir }}/"
+      with_items: "{{ results_files.files }}"
+      when: results_files.matched > 0
+  vars:
+    result_dir: "/tmp/result"
+
+- hosts: "{{ target_hosts }}"
+  gather_facts: false
+  tasks:
+    - name: Find kibana-selenium screenshots
+      find:
+        paths: "/opt/kibana-selenium"
+        patterns: "*.png"
+      when: inventory_hostname in ["infra1", "localhost"]
+      register: kibana_selenium_screenshots
+
+    - name: Ensure kibana artefacts directory exists
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ artifacts_dir }}/{{ inventory_hostname }}/host/kibana"
+      delegate_to: "localhost"
+
+    - name: Copy kibana-selenium screenshots to RE_HOOK_ARTIFACTS_DIR
+      fetch:
+       src: "{{ item.path }}"
+       dest: "{{ artifacts_dir }}/kibana"
+       flat: yes
+      with_items: "{{ kibana_selenium_screenshots.files }}"
+      when: item is defined
+
+    - name: Find kibana-selenium results file
+      find:
+        paths: "/opt/kibana-selenium"
+        patterns: "nosetests.xml"
+      when: inventory_hostname in ["infra1", "localhost"]
+      register: kibana_selenium_results_file
+
+    - name: Copy kibana-selenium results to RE_HOOK_RESULT_DIR
+      fetch:
+       src: "{{ item.path }}"
+       dest: "{{ result_dir }}/"
+       flat: yes
+      with_items: "{{ kibana_selenium_results_file.files }}"
+      when: item is defined
+  vars:
+    artifacts_dir: "/tmp/artifacts"
+    result_dir: "/tmp/result"
+    target_hosts: "localhost"

--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -19,43 +19,23 @@ source ${BASE_DIR}/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 
-# Copy the tempest results to the job results folder
-mkdir -p ${RE_HOOK_RESULT_DIR}
-find /var/lib/lxc/*utility*/ -type f -name 'tempest_results.xml' -exec cp {} ${RE_HOOK_RESULT_DIR}/ \;
-find /opt/kibana-selenium -type f -name 'nosetests.xml' -exec cp {} ${RE_HOOK_RESULT_DIR}/ \;
-
-# Copy the job artifacts to the job artifacts folder
-export RSYNC_CMD="rsync --archive --safe-links --ignore-errors --quiet --no-perms --no-owner --no-group"
-export RSYNC_ETC_CMD="${RSYNC_CMD} --no-links --exclude selinux/"
-
 echo "#### BEGIN LOG COLLECTION ###"
-mkdir -vp \
-    "${RE_HOOK_ARTIFACT_DIR}/logs/host" \
-    "${RE_HOOK_ARTIFACT_DIR}/logs/openstack" \
-    "${RE_HOOK_ARTIFACT_DIR}/etc/host" \
-    "${RE_HOOK_ARTIFACT_DIR}/etc/openstack" \
-    "${RE_HOOK_ARTIFACT_DIR}/kibana"
 
-# Copy the kibana-selenium screen captures
-${RSYNC_CMD} /opt/kibana-selenium/*.png "${RE_HOOK_ARTIFACT_DIR}/kibana/" || true
+collect_logs_cmd="ansible-playbook"
+collect_logs_cmd+=" --ssh-common-args='-o StrictHostKeyChecking=no'"
+collect_logs_cmd+=" --extra-vars='artifacts_dir=${RE_HOOK_ARTIFACT_DIR}'"
+collect_logs_cmd+=" --extra-vars='result_dir=${RE_HOOK_RESULT_DIR}'"
 
-# Copy the host and container log files
-${RSYNC_CMD} /var/log/ "${RE_HOOK_ARTIFACT_DIR}/logs/host" || true
-if [ -d "/openstack/log" ]; then
-  ${RSYNC_CMD} /openstack/log/ "${RE_HOOK_ARTIFACT_DIR}/logs/openstack" || true
+if [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
+  collect_logs_cmd+=" --extra-vars='target_hosts=pxe_servers'"
+  collect_logs_cmd+=" --inventory='/opt/openstack-ansible-ops/multi-node-aio/playbooks/inventory/hosts'"
+else
+  collect_logs_cmd+=" --extra-vars='target_hosts=localhost'"
 fi
 
-# Copy the host /etc directory
-${RSYNC_ETC_CMD} /etc/ "${RE_HOOK_ARTIFACT_DIR}/etc/host/" || true
+collect_logs_cmd+=" $(dirname ${0})/collect_logs.yml"
 
-# Loop over each container and archive its /etc directory
-if which lxc-ls &> /dev/null; then
-  for CONTAINER_NAME in `lxc-ls -1`; do
-    CONTAINER_PID=$(lxc-info -p -n ${CONTAINER_NAME} | awk '{print $2}')
-    ETC_DIR="/proc/${CONTAINER_PID}/root/etc/"
-    ${RSYNC_ETC_CMD} ${ETC_DIR} "${RE_HOOK_ARTIFACT_DIR}/etc/openstack/${CONTAINER_NAME}/" || true
-  done
-fi
+eval $collect_logs_cmd || true
 
 echo "#### END LOG COLLECTION ###"
 


### PR DESCRIPTION
This change replaces the rsync commands used to gather logs and
configuration files on an AIO with a playbook that can be used on both
AIOs and MNAIOs. For an AIO the playbook targets localhost and for an
MNAIO the playbook uses the MNAIO inventory host file created by
openstack-ansible-ops.

This cherry pick has modifies `collect_logs.yml` to ensure the
Kibana/Selenium tests results are saved. The filename of the tempest
test results is also corrected.

(cherry picked from commit a35a446935d93d6dbffae3f5fa65344873f23bc7)

Issue: [RO-3857](https://rpc-openstack.atlassian.net/browse/RO-3857)