### PR TITLE
[WIP] [RO-3924] Add ironic as a SCENARIO option

### DIFF
--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -196,20 +196,18 @@
       set_fact:
         user_variables_overrides: "{{ user_variables_overrides|combine(scenario_user_variables_overrides_ironic)}}"
       when:
-        - SCENARIO is defined
-        - (SCENARIO == "ironic-multihypervisor" or SCENARIO == "ironic")
+        - SCENARIO is defined and "ironic" in SCENARIO
 
     - name: Set specific user variables for all scenarios but ironic
       set_fact:
         scenario_user_variables_overrides_non_ironic:
-          nova_virt_type: qemu
+          nova_virt_type: ironic
 
     - name: Add non-ironic scenario user vars to user_variables_overrides
       set_fact:
         user_variables_overrides: "{{ user_variables_overrides|combine(scenario_user_variables_overrides_non_ironic)}}"
       when:
-        - SCENARIO is defined
-        - (SCENARIO != "ironic-multihypervisor" or SCENARIO != "ironic")
+        - SCENARIO is defined and "ironic" not in SCENARIO
   vars:
     rpco_deploy_hardening: "{{ lookup('env', 'DEPLOY_HARDENING') }}"
     TRIGGER: "{{ lookup('env', 'TRIGGER')}}"

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -201,7 +201,7 @@
     - name: Set specific user variables for all scenarios but ironic
       set_fact:
         scenario_user_variables_overrides_non_ironic:
-          nova_virt_type: ironic
+          nova_virt_type: qemu
 
     - name: Add non-ironic scenario user vars to user_variables_overrides
       set_fact:

--- a/scripts/bootstrap-aio.yml
+++ b/scripts/bootstrap-aio.yml
@@ -197,7 +197,7 @@
         user_variables_overrides: "{{ user_variables_overrides|combine(scenario_user_variables_overrides_ironic)}}"
       when:
         - SCENARIO is defined
-        - SCENARIO == "ironic-multihypervisor"
+        - (SCENARIO == "ironic-multihypervisor" or SCENARIO == "ironic")
 
     - name: Set specific user variables for all scenarios but ironic
       set_fact:
@@ -209,7 +209,7 @@
         user_variables_overrides: "{{ user_variables_overrides|combine(scenario_user_variables_overrides_non_ironic)}}"
       when:
         - SCENARIO is defined
-        - SCENARIO != "ironic-multihypervisor"
+        - (SCENARIO != "ironic-multihypervisor" or SCENARIO != "ironic")
   vars:
     rpco_deploy_hardening: "{{ lookup('env', 'DEPLOY_HARDENING') }}"
     TRIGGER: "{{ lookup('env', 'TRIGGER')}}"


### PR DESCRIPTION
The nova_virt_type is being squashed because there is no check for
the standard ironic scenario.  This adds checks for the ironic
scenario.

Issue: [RO-3924](https://rpc-openstack.atlassian.net/browse/RO-3924)