### PR TITLE
(ASC-144) Source MNAIO_SSH from an exported file

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -13,6 +13,7 @@ echo "+-------------------- ENV VARS --------------------+"
 ## Vars ----------------------------------------------------------------------
 
 export DEPLOY_AIO="true"
+export MNAIO_VAR_FILE="${MNAIO_VAR_FILE:-/tmp/mnaio_vars}"
 # These vars are set by the CI environment, but are given defaults
 # here to cater for situations where someone is executing the test
 # outside of the CI environment.
@@ -31,6 +32,7 @@ if [[ $RE_JOB_ACTION == "tox-test" ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_tox.sh)"
 elif [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_deploy_mnaio.sh)"
+  source "${MNAIO_VAR_FILE}"
 else
   bash -c "$(readlink -f $(dirname ${0})/run_deploy.sh)"
 fi

--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -72,6 +72,9 @@ export RPC_APT_ARTIFACT_MODE="${RPC_APT_ARTIFACT_MODE:-strict}"
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
+# place variable in file to be sourced by parent calling script 'run'
+export MNAIO_VAR_FILE="${MNAIO_VAR_FILE:-/tmp/mnaio_vars}"
+echo "export MNAIO_SSH=\"${MNAIO_SSH}\"" > "${MNAIO_VAR_FILE}"
 
 ## Main --------------------------------------------------------------------
 


### PR DESCRIPTION
This commit sources the `MNAIO_SSH` variable in the `run` script
from a file created by the `run_deploy_mnaio.sh`. This mechanism is
used to make the variable available to the parent shell in order to
pass it to the `run_system_tests.sh` script as expected.

Because the variable is created by a sub-shell to the one used by
the `run` command, exporting it does not make it available to the
parent shell. To get around this, the variable is stored to an
external file and sourced after the `run_deploy_mnaio.sh` script has
returned control to the parent.

Issue: [ASC-144](https://rpc-openstack.atlassian.net/browse/ASC-144)