### PR TITLE
(ASC-144) Fix typo in run_system_tests

### DIFF
--- a/gating/pre_merge_test/run_system_tests.sh
+++ b/gating/pre_merge_test/run_system_tests.sh
@@ -10,6 +10,7 @@ set -o pipefail
 ## Variables -----------------------------------------------------------------
 
 RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
+export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 SYS_WORKING_DIR=$(mktemp  -d -t system_test_workingdir.XXXXXXXX)
 export SYS_VENV_NAME="${SYS_VENV_NAME:-venv-molecule}"
 SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
@@ -38,7 +39,7 @@ git submodule update --recursive
 ./execute_tests.sh
 
 # 3. Collect results from script
-tar -xf test_results.tar -C "${RE_HOOK_RESULTS_DIR}"
+tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
 
 # 4. Collect logs from script
 # Molecule does not produce logs outside of STDOUT


### PR DESCRIPTION
This commit corrects a typo on the `run_system_tests.sh` script where
the `RE_HOOK_RESULT_DIR` was erroneously identified as
`RE_HOOK_RESULTS_DIR`.

Issue: [ASC-144](https://rpc-openstack.atlassian.net/browse/ASC-144)