### PR TITLE
(ASC-144) Ensure RE_HOOK dirs exist for system test

### DIFF
--- a/gating/pre_merge_test/run_system_tests.sh
+++ b/gating/pre_merge_test/run_system_tests.sh
@@ -39,8 +39,10 @@ git submodule update --recursive
 ./execute_tests.sh
 
 # 3. Collect results from script
+mkdir -p "${RE_HOOK_RESULT_DIR}" || true      #ensure that result dir exists
 tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
 
 # 4. Collect logs from script
+mkdir -p "${RE_HOOK_ARTIFACT_DIR}" || true    #ensure that artifact dir exists
 # Molecule does not produce logs outside of STDOUT
 popd


### PR DESCRIPTION
This commit adds `mkdir` commands for the `RE_HOOK_RESULT_DIR` and
the `RE_HOOK_RESULT_DIR` to ensure that they exist prior to collecting
the assets to move to them. The commands are followed by a `|| true`
conditional in order to suppress an `exit 1` in the event that the
directories have been created prior to these commands being executed.

Prior to this commit, collecting the JUnit XML results for system
testing failed because the `RE_HOOK_RESULT_DIR` location was properly
set but did not exist at the specified location path.

Issue: [ASC-144](https://rpc-openstack.atlassian.net/browse/ASC-144)