### PR TITLE
(ASC-219) Manage exit failures with trap

### DIFF
--- a/gating/pre_merge_test/run_system_tests.sh
+++ b/gating/pre_merge_test/run_system_tests.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-## Deploy virualenv for testing enironment molecule/ansible-playbook/infratest
+## Deploy virtualenv for testing environment molecule/ansible-playbook/infratest
 
 ## Shell Opts ----------------------------------------------------------------
 
-set -ev
+set -v
 set -o pipefail
 
 ## Variables -----------------------------------------------------------------
 
+# RC is a sentinel value to capture failed exit codes of portions of the script
+RC=0
 RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 SYS_WORKING_DIR=$(mktemp  -d -t system_test_workingdir.XXXXXXXX)
@@ -19,30 +21,65 @@ SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
 SYS_TEST_BRANCH="${SYS_TEST_BRANCH:-master}"
 export SYS_INVENTORY="/opt/openstack-ansible/playbooks/inventory"
 
+## Functions -----------------------------------------------------------------
+
+# Update the RC return code value unless it has previously been set to a
+# non-zero value.
+update_return_code() {
+    if [ "$RC" -eq "0" ]; then
+        RC=$1
+    fi
+}
+
+# Return the RC return code value unless it has not previously been set.
+# If that is the case, pass through the exit code of the last call.
+my_exit() {
+    if [ "$RC" -eq "0" ]; then
+        exit $1
+    else
+        exit $RC
+    fi
+}
+
 ## Main ----------------------------------------------------------------------
 
+# Trap script termination to return a captured RC value without prematurely
+# terminating the script.
+trap 'my_exit $?' INT TERM EXIT
 
+
+# fail hard if the setup fails
+set -e
 # 1. Clone test repo into working directory.
+
 pushd "${SYS_WORKING_DIR}"
 git clone "${SYS_TEST_SOURCE_REPO}"
 pushd "${SYS_TEST_SOURCE}"
 
 # Checkout defined branch
 git checkout "${SYS_TEST_BRANCH}"
+echo "${SYS_TEST_SOURCE} at SHA $(git rev-parse HEAD)"
 
 # Gather submodules
 git submodule init
 git submodule update --recursive
 
 
+# fail softly if the tests or artifact gathering fails
+set +e
 # 2. Execute script from repo
 ./execute_tests.sh
+update_return_code $?
 
 # 3. Collect results from script
 mkdir -p "${RE_HOOK_RESULT_DIR}" || true      #ensure that result dir exists
 tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
+update_return_code $?
 
 # 4. Collect logs from script
 mkdir -p "${RE_HOOK_ARTIFACT_DIR}" || true    #ensure that artifact dir exists
 # Molecule does not produce logs outside of STDOUT
+update_return_code $?
+
 popd
+# End run_system_tests.sh


### PR DESCRIPTION
This commit alters the `run_system_tests.sh` script to manage failures
with a custom `trap`. This enables all steps of the script to get
executed, but will return the exit code of the first failing command.

The setup portion of the script is set to fail immediately, while the
script execution and artifact gathering portions will all get executed
in order to gather any log and test results that may be available. The
failing exit code of any process is captured in a global `RC` variable
and is returned as the scripts exit code.

This ensures the Jenkins job will be marked as failed if the test step
or one of the artifact gathering steps fail.

Issue: [ASC-119](https://rpc-openstack.atlassian.net/browse/ASC-119)

Issue: [ASC-219](https://rpc-openstack.atlassian.net/browse/ASC-219)