### PR TITLE
RE-36 Additional thaw adjustments

### DIFF
--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -27,4 +27,13 @@ cd /opt/rpc-openstack/openstack-ansible/playbooks/
 export ANSIBLE_GATHERING=implicit
 openstack-ansible -v /opt/rpc-openstack/gating/thaw/thaw.yml
 openstack-ansible -t haproxy_server-config haproxy-install.yml
+
+lxc-autostart --all
+
 openstack-ansible -v /opt/rpc-openstack/gating/thaw/haproxycheck.yml
+
+# Remove the /gating directory to prevent any further snapshots from being
+# taken.
+if [[ -d "/gating" ]]; then
+    rm -rf /gating
+fi

--- a/gating/thaw/thaw.yml
+++ b/gating/thaw/thaw.yml
@@ -49,12 +49,3 @@
       dest: /etc/haproxy/conf.d/keystone_service
       regexp: "bind.*"
       replace: "bind {{ ansible_default_ipv4.address }}:5000"
-
-  - name: Start stopped containers
-    shell: |
-      lxc-autostart --all
-
-  - name: Restart haproxy
-    service:
-      name: haproxy
-      state: restarted


### PR DESCRIPTION
We're still having issues w/ the thaw process, which this PR aims to
resolve.  This change involves:

- reconfiguring haproxy BEFORE containers start (this avoids service
  timeouts due to services like galera being accessible)
- removing the haproxy restart, since this is handled when
  reconfiguring haproxy
- deleting the /gating directory after the thaw has completed (failing
  to do this results in a further snapshot being saved, which is not
  what we want)

(cherry picked from commit b0381dfcf7da07be6d85e58163bb596be9e9d175)

Issue: [RE-36](https://rpc-openstack.atlassian.net/browse/RE-36)