### PR TITLE
(ASC-220) Emit SHA during gating run

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -28,6 +28,8 @@ export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 
 ## Main ----------------------------------------------------------------------
 
+echo "rpc-openstack at SHA $(git rev-parse HEAD)"
+
 if [[ $RE_JOB_ACTION == "tox-test" ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_tox.sh)"
 elif [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then


### PR DESCRIPTION
This commit add an echo statement to emit the SHA of the openstack
repository during the gating run. The purpose of this is to ensure that
the SHA can be easily introspected in the logs of the gating runs in
order to facilitate triaging failures.

Issue: [ASC-220](https://rpc-openstack.atlassian.net/browse/ASC-220)