### PR TITLE
INTAKERPC-172 Remove references to rpc-repo

### DIFF
--- a/etc/openstack_deploy/group_vars/all/rpc-o.yml
+++ b/etc/openstack_deploy/group_vars/all/rpc-o.yml
@@ -31,7 +31,3 @@ horizon_custom_uploads:
   favicon:
     src: "{{ rackspace_static_files_folder }}/favicon.ico"
     dest: img/favicon.ico
-
-# Use RPC python package index
-repo_build_pip_extra_indexes:
-  - "https://rpc-repo.rackspace.com/pools"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -53,7 +53,6 @@ done
 
 # Other
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
-export HOST_RCBOPS_DOMAIN="rpc-repo.rackspace.com"
 export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py -f ${BASE_DIR}/playbooks/vars/rpc-release.yml)"
 export OSA_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py -f ${BASE_DIR}/playbooks/vars/rpc-release.yml -c osa)"
 export RPC_OS="${ID}-${VERSION_ID}-x86_64"


### PR DESCRIPTION
1. The environment variable HOST_RCBOPS_DOMAIN is not used
   anywhere, so we can remove it.

2. The use of rpc-repo for the repo-build process adds a
   dependency which is not required. No queens packages are
   being built, so using rpc-repo as an extra index will,
   over time, just slow down deployments. As such, we may
   as well remove it and be rid of the extra dependency.

Issue: [INTAKERPC-172](https://rpc-openstack.atlassian.net/browse/INTAKERPC-172)