### PR TITLE
Correct MNAIO gate post queens merge

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -119,7 +119,7 @@ pushd /opt/rpc-openstack
   scripts/deploy.sh
 popd
 pushd /opt/rpc-openstack/playbooks
-  openstack-ansible openstack-ansible-install.yml
+  /opt/rpc-ansible/bin/ansible-playbook -i 'localhost,' openstack-ansible-install.yml
 popd
 pushd /opt/openstack-ansible/scripts
   python pw-token-gen.py --file /etc/openstack_deploy/user_secrets.yml


### PR DESCRIPTION
The openstack-ansible bootstrap wrapper was removed but the MNAIO gate
 was not updated to reflect that. This change corrects the issue.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [INTAKERPC-172](https://rpc-openstack.atlassian.net/browse/INTAKERPC-172)