### PR TITLE
(RI-224) Run tempest tests on MNAIO deploy

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -33,6 +33,13 @@ if [[ $RE_JOB_ACTION == "tox-test" ]]; then
 elif [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_deploy_mnaio.sh)"
   source "${MNAIO_VAR_FILE}"
+  if [[ $RE_JOB_ACTION == "deploy" ]]; then
+    # run tempest tests on MNAIO for deploy action
+    ${MNAIO_SSH} <<EOS
+      cd /opt/openstack-ansible
+      openstack-ansible -e tempest_run=yes playbooks/os-tempest-install.yml
+EOS
+  fi
 else
   bash -c "$(readlink -f $(dirname ${0})/run_deploy.sh)"
 fi


### PR DESCRIPTION
This commit runs the tempest playbook on MNAIO deployments after the
deployment has concluded when the action is equal to `deploy`.

Backport of https://github.com/rcbops/rpc-openstack/commit/70d15d170c436a778e2b784df9bed3022877b399 from #master to #pike

Issue: RI-213
Issue: RI-224

Issue: [RI-213](https://rpc-openstack.atlassian.net/browse/RI-213)