### PR TITLE
Fix for get-rpc_release.py ignoring RPC_PRODUCT_RELEASE

### DIFF
--- a/releasenotes/notes/fix-get-rpc_release-rpc_product_release.yaml
+++ b/releasenotes/notes/fix-get-rpc_release-rpc_product_release.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    `scripts/get-rpc_release.py` was ignoring the RPC_PRODUCT_RELEASE
+    environment variable to allow for branchless deployments. This fix
+    will cause allow RPC_PRODUCT_RELEASE to overfide the branch 
+    default.
+
+

--- a/scripts/get-rpc_release.py
+++ b/scripts/get-rpc_release.py
@@ -22,9 +22,8 @@ import yaml
 # Sourced from: https://stackoverflow.com/a/10551190
 class EnvDefault(argparse.Action):
     def __init__(self, envvar, required=True, default=None, **kwargs):
-        if not default and envvar:
-            if envvar in os.environ:
-                default = os.environ[envvar]
+        if envvar in os.environ:
+            default = os.environ[envvar]
         if required and default:
             required = False
         super(EnvDefault, self).__init__(default=default, required=required,


### PR DESCRIPTION
The scripts/get-rpc_release.py used by the deployment to allow
for what looks like branchless deployments was ignoring the
RPC_PRODUCT_RELEASE.  It looks like argparse pulls that
environment variable to use for a release_series variable.
A default of 'queens' was being set as well.  The EnvDefault
class being used by that argument only uses the environment
variable if no default is set.  This change is to allow any
setting of RPC_PRODUCT_RELEASE to override or set the default.

Issue: RO-4110

Issue: [RO-4110](https://rpc-openstack.atlassian.net/browse/RO-4110)