### PR TITLE
ASC-319 Revert removal of submodule update

### DIFF
--- a/gating/pre_merge_test/run_system_tests.sh
+++ b/gating/pre_merge_test/run_system_tests.sh
@@ -30,7 +30,14 @@ pushd "${SYS_TEST_SOURCE}"
 git checkout "${SYS_TEST_BRANCH}"
 echo "${SYS_TEST_SOURCE} at SHA $(git rev-parse HEAD)"
 
-# 2. Execute script from repo
+# Gather submodules
+git submodule init
+git submodule update --recursive
+
+# fail softly if the tests or artifact gathering fails
+set +e
+
+# 2. Execute script from repository
 ./execute_tests.sh
 [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
 


### PR DESCRIPTION
This commit reverts the changes to run_system_tests.sh at commit
e250dc4f27011e1b534e4a5d6a09b7a13c8bc559

The change above caused system tests to fail due to the lack of the
submodule code being present during execution.

Issue: [ASC-319](https://rpc-openstack.atlassian.net/browse/ASC-319)