### PR TITLE
disable the hardening role for PM MNAIO testing

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -146,6 +146,7 @@ ${MNAIO_SSH} <<EOC
   cp -R /opt/openstack-ansible/etc/openstack_deploy /etc
   cp /etc/openstack_deploy/user_variables.yml.bak /etc/openstack_deploy/user_variables.yml
   cp -R /opt/rpc-openstack/etc/openstack_deploy/* /etc/openstack_deploy/
+  echo -e '---\napply_security_hardening: false' | tee /etc/openstack_deploy/user_mnaio_no_hardening.yml
   chmod +x /opt/rpc-openstack/deploy-infra1.sh
   rm -rf /opt/openstack-ansible
   rm /usr/local/bin/openstack-ansible


### PR DESCRIPTION
the hardening role is kicking us out of the host while tempest is running
under the MNAIO PM job. This change disables the hardening role in the
MNAIO PM jobs which will improve deployment performance and allow tempest
tests to succeed, given the long runtime.

Issue: [RO-4125](https://rpc-openstack.atlassian.net/browse/RO-4125)
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>