### PR TITLE
Update pike-rc dependencies

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -13,5 +13,5 @@ rpc_product_releases:
     rpc_release: r15.0.0
   pike:
     maas_release: 1.6.0
-    osa_release: 00d84d91c488e4e92b3cc552bec6ebb9dd20e38d
+    osa_release: ed0bd76a4271231886ebd778a6e4435a5682224f
     rpc_release: r16.0.1


### PR DESCRIPTION
This updates the pike-rc OSA dependencies to include the Nova cell
fixes that were included with this commit:

https://review.openstack.org/#/c/554675/

Issue: RI-230

Issue: [RI-230](https://rpc-openstack.atlassian.net/browse/RI-230)