### PR TITLE
RO-4147 / RE-1326 Add/update forked role overrides apt/pbr fixes [newton-rc]

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -10,14 +10,14 @@
   scm: git
   src: https://github.com/ceph/ansible-ceph-osd.git
   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
-# Created for JIRA RLM-322
-# Frank: this is a forked ansible role for removing
+# Note (Frank) - RLM-322:
+# this is a forked ansible role for removing
 # hardcoded period mark from hostname template.
 - name: openstack_hosts
   scm: git
   src: https://github.com/rcbops/openstack-ansible-openstack_hosts
-  version: 235ec6f0fc5570e7c657b243bcf4208cc2c7739c
-# Note (odyssey4me):
+  version: c6bab1bd157ec807b6b696f65290a4549e041fc5
+# Note (odyssey4me) - RO-4147:
 # PBR released a new version after newton went EOL,
 # causing various builds to break. We therefore use
 # a patched fork here to resolve the issue.

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -17,3 +17,11 @@
   scm: git
   src: https://github.com/rcbops/openstack-ansible-openstack_hosts
   version: 235ec6f0fc5570e7c657b243bcf4208cc2c7739c
+# Note (odyssey4me):
+# PBR released a new version after newton went EOL,
+# causing various builds to break. We therefore use
+# a patched fork here to resolve the issue.
+- name: repo_build
+  scm: git
+  src: https://github.com/rcbops/openstack-ansible-repo_build
+  version: a87ce06b2c5ae567ab28a13085dfbf81393cd153


### PR DESCRIPTION
A new version of PBR was released which causes some services, like
gnocchi, to break in new and exciting ways. Given that newton is now
EOL and therefore the repo_build role cannot be fixed upstream, this
PR implements the fix.

Also, the updates to the openstack_hosts role upstream to improve the
reliability of the apt get update process are now included in that role's
fork. This PR also updates the overriding role SHA to ensure it's used.

Issue: [RE-1326](https://rpc-openstack.atlassian.net/browse/RE-1326)
Issue: [RO-4147](https://rpc-openstack.atlassian.net/browse/RO-4147)