### PR TITLE
RE-1399 Set RC branch var when RC branch not found

### DIFF
--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -101,6 +101,7 @@ else
 If there is no RC branch then the mainline branch is considered unreleased and
 therefore the rpc_release value is left alone. It is still important for the
 dependencies to be updated regularly though, so that part continues to be done."
+  export RC_BRANCH_VERSION=""
 fi
 
 


### PR DESCRIPTION
The master-rc branch was deleted today, causing the dep_update PR job
to fail. This commit updates gating/update_dependencies/run by setting
RC_BRANCH_VERSION to an empty string when the RC branch is not found.

(cherry picked from commit 4430b08da6107ac11658fb7524b15db84a9cbadd)

Issue: [RE-1399](https://rpc-openstack.atlassian.net/browse/RE-1399)