### PR TITLE
RE-1405 Update rpc_differ/osa_differ [pike]

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,7 +8,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-RUN pip install osa_differ==0.3.4 rpc_differ==0.3.4 reno==2.5.1
+RUN pip install osa_differ==0.3.6 rpc_differ==0.3.6 reno==2.5.1
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
rpc_differ is struggling to correctly find the OSA SHA.
This issue has been resolved in the tooling, so this PR
allows the fix to be used.

(cherry picked from commit 0d3d11b0029eaf0339b47891d0383dea9af6de0f)