### PR TITLE
RE-1190 Update rpc/osa differ for PR ref support [pike]

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,7 +8,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-RUN pip install osa_differ==0.3.6 rpc_differ==0.3.6 reno==2.5.1
+RUN pip install osa_differ==0.3.8 rpc_differ==0.3.8 reno==2.5.1
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
In order to support testing PR's from remote forks
properly, the osa_differ tooling has been updated
to support pulling in PR refs.

And with [2] and [3] the release job is changed to
pass the correct repo and PR ref to the tooling for
the test.

[2] https://github.com/rcbops/rpc-gating/pull/688
[3] https://github.com/rcbops/rpc-gating/pull/696

Issue: [RE-1190](https://rpc-openstack.atlassian.net/browse/RE-1190)