### PR TITLE
Fix os_neutron and etcd handler naming conflict

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -25,3 +25,11 @@
   scm: git
   src: https://github.com/rcbops/openstack-ansible-repo_build
   version: a87ce06b2c5ae567ab28a13085dfbf81393cd153
+# Note (shananigans) - RE-1396:
+# Handler naming conflict on os_neutron and etc dependancy
+# causing neutron services to remain on old versions on 
+# minor upgrades. Using a patched fork to fix.
+- name: os_neutron
+  scm: git
+  src: https://github.com/rcbops/openstack-ansible-os_neutron
+  version: cf7802828f85b38deccb8d9674fc229780a50da1

--- a/releasenotes/notes/os_neutron-etcd-handler-conflict-fix-0e30ccbd4b97ed29.yaml
+++ b/releasenotes/notes/os_neutron-etcd-handler-conflict-fix-0e30ccbd4b97ed29.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - | 
+    `ansible-role-requirements.yml` is modified to point to a forked
+    openstack-ansible-os_neutron repo with a fix to a bug that is 
+    causing neutron services to run on old versions after a minor
+    upgrade.  This was due to a conflict on the os_neutron and its
+    etcd dependancy's handler for reloading the systemd daemon. When
+    the .service files were updated the call to reload the systemd 
+    daemon was being handled by the etcd role and skipped.  The 
+    fix was to rename the handler for os_neutron role to keep the 
+    conflict from happening.
+


### PR DESCRIPTION
ansible-role-requirements.yml is modified to point to a forked
openstack-ansible-os_neutron repo with a fix to a bug that is
causing neutron services to run on old versions after a minor
upgrade.  This was due to a conflict on the os_neutron and its
etcd dependancy's handler for reloading the systemd daemon. When
the .service files were updated the call to reload the systemd
daemon was being handled by the etcd role and skipped.  The
fix was to rename the handler for os_neutron role to keep the
conflict from happening.

JIRA: RE-1396

Issue: [RE-1396](https://rpc-openstack.atlassian.net/browse/RE-1396)