### PR TITLE
RO-4125 - Revert "disable the hardening role for PM MNAIO testing" (#2918)

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -146,6 +146,7 @@ ${MNAIO_SSH} <<EOC
   cp -R /opt/openstack-ansible/etc/openstack_deploy /etc
   cp /etc/openstack_deploy/user_variables.yml.bak /etc/openstack_deploy/user_variables.yml
   cp -R /opt/rpc-openstack/etc/openstack_deploy/* /etc/openstack_deploy/
+  echo -e '---\nsecurity_rhel7_session_timeout: 1200' | tee /etc/openstack_deploy/user_mnaio_long_hardening_timeout.yml
   chmod +x /opt/rpc-openstack/deploy-infra1.sh
   rm -rf /opt/openstack-ansible
   rm /usr/local/bin/openstack-ansible


### PR DESCRIPTION
This reverts commit a3b6e359bd9d618d36537b513f6e4d2282c6ae8f.

To keep tests passing we need to lengthen the timeout before we are kicked.
Lengthen the timeout to 20 minutes from the default of 10 minutes.

(cherry picked from commit 7d1b22dd755a4e9eb52e7f91814d234cd4166b2d)
Signed-off-by: Matthew Thode <mthode@mthode.org>