### PR TITLE
RE-1190 Update rpc/osa differ for PR ref support [newton]

### DIFF
--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,8 +8,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-RUN pip install rpc_differ==0.3.0 reno==2.5.1
-RUN pip install git+https://github.com/major/osa_differ@0.3.3
+RUN pip install osa_differ==0.3.8 rpc_differ==0.3.8 reno==2.5.1
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
In order to support testing PR's from remote forks
properly, the osa_differ tooling has been updated
to support pulling in PR refs.

And with [2] and [3] the release job is changed to
pass the correct repo and PR ref to the tooling for
the test.

[2] https://github.com/rcbops/rpc-gating/pull/688
[3] https://github.com/rcbops/rpc-gating/pull/696

(cherry picked from commit 31ec2e807d5961e8233e4f7fb29dcce7815a92c8)

Issue: [RE-1190](https://rpc-openstack.atlassian.net/browse/RE-1190)