### PR TITLE
AC-340 use published version of zigzag

### DIFF
--- a/gating/pre_merge_test/post_send_junit_to_qtest.sh
+++ b/gating/pre_merge_test/post_send_junit_to_qtest.sh
@@ -25,9 +25,8 @@ source "${VENV_NAME}/bin/activate"
 
 VENV_PIP="${VENV_NAME}/bin/pip"
 
-# Install tagged development version of <TOOL NAME>
-${VENV_PIP} install -e git+git://github.com/ryan-rs/qtest-swagger-client.git@master#egg=swagger-client-1.0.0
-${VENV_PIP} install -e git+git://github.com/ryan-rs/py-result-uploader.git@v0.3.0#egg=py-result-uploader-0.3.0
+# Install zigzag from PyPI
+${VENV_PIP} install --process-dependency-links rpc-zigzag
 
 # Search for xml files in RE_HOOK_RESULT_DIR
 xml_files=()
@@ -40,7 +39,7 @@ echo "Attempting upload of ${#xml_files[@]} XML files"
 printf '%s\n' "${xml_files[@]}"
 for i in "${xml_files[@]}"; do
     # Use <TOOL NAME> to process and upload to qtest
-    if py_result_uploader $i $PROJECT_ID $TEST_CYCLE; then
+    if zigzag $i $PROJECT_ID $TEST_CYCLE; then
         echo "Upload Success: $i"
     else
         echo "Upload Failure: $i"


### PR DESCRIPTION
- removes install of py-result-uploader directly from github
- uses published version of zigzag (formerly py-result-uploader) from PyPI

Issue: [AC-340](https://rpc-openstack.atlassian.net/browse/AC-340)