### PR TITLE
Change APT artifact to loose

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ DEPLOY_RPC         | yes                                | Deploy the RPCO specif
 BOOTSTRAP_OPTS     |                                    | Any options used for the bootstrap process           | Only used if DEPLOY_AIO=yes
 FORKS              | `grep -c ^processor /proc/cpuinfo` | Number of forks Ansible may use                      | May have issues if FORKS > SSHD's MaxSessions. Adjust accordingly
 ANSIBLE_PARAMETERS |                                    | Additional paramters passed to Ansible               |
-RPC_APT_ARTIFACT_MODE | strict                          | Set the behaviour for the use of the apt artifacts   | Set to 'loose' to leave existing sources in place
+RPC_APT_ARTIFACT_MODE | loose                          | Set the behaviour for the use of the apt artifacts   |
 
 All of the variables for deploy.sh are made available by sourcing the [functions.sh](https://github.com/rcbops/rpc-openstack/blob/master/scripts/functions.sh) script
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -53,8 +53,8 @@ export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 export HOST_SOURCES_REWRITE=${HOST_SOURCES_REWRITE:-"yes"}
 export HOST_UBUNTU_REPO=${HOST_UBUNTU_REPO:-"http://mirror.rackspace.com/ubuntu"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
-export RPC_APT_ARTIFACT_ENABLED=${RPC_APT_ARTIFACT_ENABLED:-"yes"}
-export RPC_APT_ARTIFACT_MODE=${RPC_APT_ARTIFACT_MODE:-"strict"}
+export RPC_APT_ARTIFACT_ENABLED=${RPC_APT_ARTIFACT_ENABLED:-"no"}
+export RPC_APT_ARTIFACT_MODE=${RPC_APT_ARTIFACT_MODE:-"loose"}
 
 # Derive the rpc_release version from the group vars
 export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"


### PR DESCRIPTION
The APT artifacts are set to loose mode in accordance how we
currently deploy newton releases.