### PR TITLE
Revert "RO-4125 lengthen timeout to make sure it's not breaking gate"

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -183,7 +183,7 @@ ${MNAIO_SSH} <<EOC
   cp -R /opt/openstack-ansible/etc/openstack_deploy /etc
   cp /etc/openstack_deploy/user_variables.yml.bak /etc/openstack_deploy/user_variables.yml
   cp -R /opt/rpc-openstack/etc/openstack_deploy/* /etc/openstack_deploy/
-  echo -e '---\nsecurity_rhel7_session_timeout: 28800' | tee /etc/openstack_deploy/user_mnaio_long_hardening_timeout.yml
+  echo -e '---\nsecurity_rhel7_session_timeout: 1200' | tee /etc/openstack_deploy/user_mnaio_long_hardening_timeout.yml
   chmod +x /opt/rpc-openstack/deploy-infra1.sh
   rm -rf /opt/openstack-ansible
   rm /usr/local/bin/openstack-ansible


### PR DESCRIPTION
This did not affect the tempest tests and creates a delta between pike and pike-rc.

Issue: [RO-4125](https://rpc-openstack.atlassian.net/browse/RO-4125)