### PR TITLE
RE-65 Generate ARA report and gather results

### DIFF
--- a/gating/pre_merge_test/collect_logs.yml
+++ b/gating/pre_merge_test/collect_logs.yml
@@ -10,6 +10,30 @@
         - "{{ artifacts_dir }}/{{ inventory_hostname }}/containers"
       delegate_to: "localhost"
 
+    - name: Generate ARA reports
+      shell: |
+        ARA_CMD="/opt/ansible-runtime/bin/ara"
+        if [[ -e ${ARA_CMD} ]]; then
+            ARA_REPORT_PATH="/openstack/log/ara-report"
+            mkdir -p ${ARA_REPORT_PATH}
+            ${ARA_CMD} generate html ${ARA_REPORT_PATH}
+            ${ARA_CMD} generate junit ${ARA_REPORT_PATH}/deployment_results.xml
+            cp "${HOME}/.ara/ansible.sqlite" ${ARA_REPORT_PATH}/
+        fi
+      args:
+        executable: /bin/bash
+      # We never want a failure of this task to cause a
+      # failure in the playbook, so we ignore errors to
+      # ensure that the task shows failure, but does not
+      # fail the playbook.
+      ignore_errors: yes
+      # This needs to run wherever the ansible runtime is.
+      # For AIO deployments, the deploy host is localhost.
+      # For MNAIO deployments, the deploy host is infra1.
+      when:
+        - (inventory_hostname == 'localhost') or
+          (inventory_hostname == 'infra1')
+
     - name: Grab host data
       command: >
                rsync
@@ -89,7 +113,7 @@
       find:
         paths: "{{ artifacts_dir }}"
         recurse: yes
-        patterns: "tempest_results.xml"
+        patterns: "deployment_results.xml,tempest_results.xml"
       register: results_files
 
     - name: Copy tempest results to RE_HOOK_RESULT_DIR


### PR DESCRIPTION
The gate-check-commit script in OSA, which is used for deployment
execution in RPC-O queens & pike, installs ARA [1] which is a tool
that gathers the ansible runtime execution results for each task
and is able to generate html/junit result files.

In this patch we use ARA to generate an html report and a junit
report, and we gather the database and all results with the rest
of the log data.

This has proved very useful for diagnostics in OSA gating, so we
expect that it will be very useful to RPC-O too.

[1] https://github.com/openstack/ara

Issue: [RE-65](https://rpc-openstack.atlassian.net/browse/RE-65)