### PR TITLE
[RO-4125] Increase SSH Timeout

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -148,7 +148,7 @@ ${MNAIO_SSH} <<EOC
   cp -R /opt/openstack-ansible/etc/openstack_deploy /etc
   cp /etc/openstack_deploy/user_variables.yml.bak /etc/openstack_deploy/user_variables.yml
   cp -R /opt/rpc-openstack/etc/openstack_deploy/* /etc/openstack_deploy/
-  echo -e '---\nsecurity_rhel7_session_timeout: 1200' | tee /etc/openstack_deploy/user_mnaio_long_hardening_timeout.yml
+  echo -e '---\nsecurity_rhel7_session_timeout: 1200\nsecurity_sshd_client_alive_interval: 1200' | tee /etc/openstack_deploy/user_mnaio_long_hardening_timeout.yml
   chmod +x /opt/rpc-openstack/deploy-infra1.sh
   rm -rf /opt/openstack-ansible
   rm /usr/local/bin/openstack-ansible


### PR DESCRIPTION
Tempest tests often take longer than 10 minutes to run and fail due to
ssh timeouts.  This increases the timeout to 20 minutes.

(cherry picked from commit 32ae4f5f9e364f981cc067aa7d05b00d2a732751)

Issue: RO-4125