### PR TITLE
ASC-406 set SYS_TEST_BRANCH to RE_JOB_BRANCH

### DIFF
--- a/gating/pre_merge_test/run_system_tests.sh
+++ b/gating/pre_merge_test/run_system_tests.sh
@@ -16,7 +16,7 @@ export SYS_VENV_NAME="${SYS_VENV_NAME:-venv-molecule}"
 SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
 SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
 SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
-SYS_TEST_BRANCH="${SYS_TEST_BRANCH:-master}"
+SYS_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
 export SYS_INVENTORY="/opt/openstack-ansible/playbooks/inventory"
 
 ## Main ----------------------------------------------------------------------


### PR DESCRIPTION
This commit sets the value of `SYS_TEST_BRANCH` to match
`RE_JOB_BRANCH`. By doing so, the system testing branch that is checked
out will match that of the job branch being run. In other words,
a job running `master` will use the `master` branch of the system tests
repo to conduct the test. Likewise, with `pike`, etc.

Issue: [ASC-406](https://rpc-openstack.atlassian.net/browse/ASC-406)