### PR TITLE
RE-1479 Revert hostname to previous hostname

### DIFF
--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -66,5 +66,6 @@ if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
   ln -s /opt/rpc-openstack/gating/thaw/run /gating/thaw/run
 
   echo "rpc-${RPC_RELEASE}-${RE_JOB_IMAGE}-${RE_JOB_SCENARIO}" > /gating/thaw/image_name
+  echo "${HOSTNAME}" > /gating/thaw/hostname
   echo "### END SNAPSHOT PREP ###"
 fi

--- a/gating/thaw/thaw.yml
+++ b/gating/thaw/thaw.yml
@@ -17,7 +17,19 @@
 # are up.
 - name: Post Network Thaw Tasks
   hosts: localhost
+  vars:
+    old_hostname: "{{ lookup('file', '/gating/thaw/hostname') }}"
   tasks:
+  - name: Update /etc/hosts with old hostname
+    replace:
+      name: /etc/hosts
+      regexp: "{{ ansible_hostname }}"
+      replace: "{{ old_hostname }}"
+
+  - name: Set running hostname to old hostname
+    hostname:
+      name: "{{ old_hostname }}"
+
   - name: Check for cinder loop image
     stat:
       path: /openstack/cinder.img


### PR DESCRIPTION
This commit updates the running instance's hostname to that of the
instance that created the snapshot. This ensures that the hostname
matches what exists in the ansible inventory, etc.

Issue: [RE-1479](https://rpc-openstack.atlassian.net/browse/RE-1479)