### PR TITLE
Add neutron env file to sandbox agents

### DIFF
--- a/etc/openstack_deploy/env.d/neutron.yml
+++ b/etc/openstack_deploy/env.d/neutron.yml
@@ -1,0 +1,86 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+component_skel:
+  neutron_agent:
+    belongs_to:
+      - neutron_all
+  neutron_dhcp_agent:
+    belongs_to:
+      - neutron_all
+  neutron_linuxbridge_agent:
+    belongs_to:
+      - neutron_all
+  neutron_openvswitch_agent:
+    belongs_to:
+      - neutron_all
+  neutron_metering_agent:
+    belongs_to:
+      - neutron_all
+  neutron_l3_agent:
+    belongs_to:
+      - neutron_all
+  neutron_lbaas_agent:
+    belongs_to:
+      - neutron_all
+  neutron_bgp_dragent:
+    belongs_to:
+      - neutron_all
+  neutron_metadata_agent:
+    belongs_to:
+      - neutron_all
+  neutron_sriov_nic_agent:
+    belongs_to:
+      - neutron_all
+  neutron_server:
+    belongs_to:
+      - neutron_all
+  opendaylight:
+    belongs_to:
+      - neutron_all
+
+
+container_skel:
+  neutron_agents_container:
+    belongs_to:
+      - network_containers
+    contains:
+      - neutron_agent
+      - neutron_bgp_dragent
+      - neutron_dhcp_agent
+      - neutron_l3_agent
+      - neutron_lbaas_agent
+      - neutron_linuxbridge_agent
+      - neutron_metadata_agent
+      - neutron_metering_agent
+      - neutron_openvswitch_agent
+      - neutron_sriov_nic_agent
+    properties:
+      is_metal: true
+  neutron_server_container:
+    belongs_to:
+      - network_containers
+    contains:
+      - neutron_server
+      - opendaylight
+
+
+physical_skel:
+  network_containers:
+    belongs_to:
+      - all_containers
+  network_hosts:
+    belongs_to:
+      - hosts

--- a/releasenotes/notes/neutron-agent-baremetal-c229e65c77e615fa.yaml
+++ b/releasenotes/notes/neutron-agent-baremetal-c229e65c77e615fa.yaml
@@ -1,0 +1,16 @@
+---
+features:
+    - Neutron connectivity agents will now be deployed on baremetal within the
+      "network_hosts" defined within the ``openstack_user_config.yml``.
+
+upgrade:
+    - When upgrading there is nothing a deployer **must** immediately do to
+      run neutron agent services on hosts within the ``network_hosts`` group.
+      Simply executing the playbooks will deploy the neutron servers on the
+      baremetal machines and will leave all existing agents containers alone.
+    - It is recommended for deployers to clean up the **neutron_agents**
+      container(s) after an upgrade is complete and the cluster has been
+      verified as stable. This can be done by simply disabling the neutron
+      agents running in the **neutron_agent** container(s), re-balancing the
+      agent services targeting the new baremetal agents, deleting the
+      container(s), and finally removing the container(s) from inventory.


### PR DESCRIPTION
The neutron agents in OSA master/queens have been sand-boxed. This process
installs the agents on-metal (the host) instead of building a container
for them which improves stability and simplifies connectivity to the
rest of the cloud. Privilege escalation will be better understood and
the risk of container restarts, outages, shutdowns, or human error will be
removed given that the service will be running on the physical machines.

The ability to sandbox these services has long been available through
the use of environment overrides. This changes makes use of the override
capabilities.

The sandbox capabilities are built into OSA's use of systemd which
provides much of the constructs a container provides without the hacks
required to specifically make neutron run within a container. This
change matches what the community is already doing and will ensure our
pike customers can upgrade to queens in a seamless manor without any
need for additional maintenance's.

Issue: https://rpc-openstack.atlassian.net/projects/FLEEK/issues/FLEEK-36
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [FLEEK-36](https://rpc-openstack.atlassian.net/browse/FLEEK-36)