### PR TITLE
RE-1479 Re-populate /etc/hosts file

### DIFF
--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -16,6 +16,8 @@ cp /opt/root_ssh_backup/.ssh/id_rsa.pub /root/.ssh
 cp /opt/root_ssh_backup/.ssh/known_hosts /root/.ssh ||:
 ssh-keyscan localhost >> /root/.ssh/known_hosts
 
+# Re-populate /etc/hosts file with container data
+/usr/local/bin/openstack-host-hostfile-setup.sh
 
 cd /opt/openstack-ansible/playbooks/
 


### PR DESCRIPTION
This commit adds the execution of
/usr/local/bin/openstack-host-hostfile-setup.sh to the thaw process to
ensure that instances built from snapshot have the necessary entries for
existing containers in the /etc/hosts file.

(cherry picked from commit 458c4116cf768a57d9b898c7a0cfcdd83488fd01)

Issue: [RE-1479](https://rpc-openstack.atlassian.net/browse/RE-1479)