### PR TITLE
RE-1479 Re-populate /etc/hosts file

### DIFF
--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -19,6 +19,9 @@ ssh-keyscan localhost >> /root/.ssh/known_hosts
 # Remove Jenkins workspace reference from openstack-ansible.rc
 sed -i -e 's@/var/lib/jenkins/workspace/.*/rpc-openstack@/opt/rpc-openstack@g' /usr/local/bin/openstack-ansible.rc
 
+# Re-populate /etc/hosts file with container data
+/usr/local/bin/openstack-host-hostfile-setup.sh
+
 cd /opt/rpc-openstack/openstack-ansible/playbooks/
 
 # Use implicit fact gathering to ensure the fact cache is ignored,


### PR DESCRIPTION
This commit adds the execution of
/usr/local/bin/openstack-host-hostfile-setup.sh to the thaw process to
ensure that instances built from snapshot have the necessary entries for
existing containers in the /etc/hosts file.

(cherry picked from commit 458c4116cf768a57d9b898c7a0cfcdd83488fd01)

Conflicts:
    gating/thaw/run

Issue: [RE-1479](https://rpc-openstack.atlassian.net/browse/RE-1479)