### PR TITLE
Change container backend to machinectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ and `openstack-ansible-install.yml` playbooks to install the correct version.
 openstack-ansible site-release.yml openstack-ansible-install.yml -e 'osa_release=master'
 ```
 
+###### Optional | Host setup
+
+Depending on how the host OS was deployed there may be additional setup steps
+required to prepare the host machines. The `host-setup.yml` playbook exists to
+assist with some of those additional steps. If **required** or **necessary**,
+run this playbook.
+
+``` shell
+openstack-ansible host-setup.yml -e 'host_vg=lxc'
+```
+
 ##### Running the playbooks
 
 Once the deploy configuration has been completed please refer to the

--- a/ansible-role-queens-requirements.yml
+++ b/ansible-role-queens-requirements.yml
@@ -14,3 +14,7 @@
   scm: git
   src: https://github.com/elastic/ansible-elasticsearch
   version: 0179bd1eefa6d5c6358f3db29b9e2ad902625393
+- name: systemd_mount
+  scm: git
+  src: https://github.com/openstack/ansible-role-systemd_mount
+  version: master

--- a/etc/openstack_deploy/group_vars/all/rpc-o.yml
+++ b/etc/openstack_deploy/group_vars/all/rpc-o.yml
@@ -31,3 +31,6 @@ horizon_custom_uploads:
   favicon:
     src: "{{ rackspace_static_files_folder }}/favicon.ico"
     dest: img/favicon.ico
+
+# Sets the default RPC-OpenStack container backing store.
+lxc_container_backing_store: machinectl

--- a/playbooks/host-setup.yml
+++ b/playbooks/host-setup.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Create, format and mount machines lv
+  hosts: shared-infra_hosts
+  become: true
+  gather_facts: true
+  vars:
+    host_vg: lxc
+
+  pre_tasks:
+    - name: Create machines lv
+      lvol:
+        vg: "{{ host_vg }}"
+        lv: machines00
+        size: 50G
+
+    - name: Format the machines lv
+      filesystem:
+        fstype: btrfs
+        dev: "/dev/{{ host_vg }}/machines00"
+
+  roles:
+    - role: systemd_mount
+      systemd_mounts:
+        - what: "/dev/{{ host_vg }}/machines00"
+          where: "/var/lib/machines"
+          options: "defaults,noatime,nodiratime,compress=lzo,commit=120,{{ (ansible_kernel is version_compare('4.5', '>=')) | ternary('space_cache=v2', 'space_cache') }}"
+          type: "btrfs"
+          state: 'started'

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -14,5 +14,6 @@
 # limitations under the License.
 
 - include: site-release.yml
+- include: host-setup.yml
 - include: site-logging.yml
 - include: site-openstack.yml

--- a/releasenotes/notes/run-in-machines-e51d7d14916c77ff.yaml
+++ b/releasenotes/notes/run-in-machines-e51d7d14916c77ff.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - All LXC containers will now run within a ``machinectl`` environment. This
+    change provides for simpler image management using built in universal
+    tooling. Moving to ``machinectl`` will reduce the storage required to run
+    our containerized workloads while retaining the file system properties
+    we've come rely on (FS barriers, auditing, etc).
+upgrade:
+  - With the change to ``machinectl`` as the default container back-end there's
+    no upgrade impact. Existing containers running in any other file-store will
+    not be touched. If the deployer wishes to move the container into the
+    ``machinectl`` back-end they can as a secondary maintenance, however this is
+    not required.


### PR DESCRIPTION
The gate has long been running containerized workloads using machinectl.
This change pulls in that option as our default. The change will reduce
the required storage used to run containerized workloads and improve
general image mangement.

An optional playbook has been added to assist deployers with general
host setup tasks. This playbook is not a required step and has been
documented in the README as such.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>