### PR TITLE
RO-4206 Change AIO/MNAIO tests for better diagnostics [pike]

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -115,6 +115,12 @@ cat > /opt/rpc-openstack/deploy-infra1.sh <<EOF
 set -evu
 # starts the deploy from infra1 vm
 source /opt/rpc-openstack/RE_ENV
+
+# RO-4206
+# Use fork of Ansible which exposes the apt errors so that we
+# can diagnose the cause of the apt fetch failures.
+export ANSIBLE_PACKAGE="git+https://github.com/rcbops/ansible@v2.3-OSA_SHA-with_apt_errors"
+
 pushd /opt/rpc-openstack
   scripts/deploy.sh
 popd

--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -125,7 +125,7 @@ pushd /opt/openstack-ansible/scripts
   python pw-token-gen.py --file /etc/openstack_deploy/user_secrets.yml
 popd
 pushd /opt/openstack-ansible/playbooks
-  openstack-ansible setup-everything.yml
+  openstack-ansible setup-hosts.yml setup-infrastructure.yml setup-openstack.yml
 popd
 EOF
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -43,6 +43,11 @@ if [ "${DEPLOY_AIO}" != false ]; then
   # Install OpenStack-Ansible
   openstack-ansible "${SCRIPT_PATH}/../playbooks/openstack-ansible-install.yml"
 
+  # RO-4206
+  # Use fork of Ansible which exposes the apt errors so that we
+  # can diagnose the cause of the apt fetch failures.
+  export ANSIBLE_PACKAGE="git+https://github.com/rcbops/ansible@v2.3-OSA_SHA-with_apt_errors"
+
   ## Create the AIO
   pushd /opt/openstack-ansible
     bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"


### PR DESCRIPTION
In this PR we set the AIO/MNAIO builds to use a fork of Ansible
which exposes the apt errors so that we can diagnose the cause of
the apt fetch failures.

We also change the playbook executed in the MNAIO builds to match
the 3-stage execution of the AIO so that we get better reporting
and to reduce the style gap a little.

Issue: [RO-4206](https://rpc-openstack.atlassian.net/browse/RO-4206)