### PR TITLE
RO-4211 Add apt debug output config for tests [pike]

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -133,6 +133,13 @@ pushd /opt/openstack-ansible/scripts
   python pw-token-gen.py --file /etc/openstack_deploy/user_secrets.yml
 popd
 pushd /opt/openstack-ansible/playbooks
+  # RO-4211
+  # Implement debug output for apt so that we can see more information
+  # about whether the 'Acquire-by-hash' feature is being used, and what
+  # might be causing it to fall back to the old style.
+  # This config file should be copied into containers by the lxc_hosts
+  # role.
+  ansible hosts -m lineinfile -a 'create=yes dest=/etc/apt/apt.conf.d/99debug line="Debug::Acquire::http \"true\";"'
   openstack-ansible setup-hosts.yml setup-infrastructure.yml setup-openstack.yml
 popd
 EOF

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,6 +56,13 @@ if [ "${DEPLOY_AIO}" != false ]; then
   # role.
   echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
 
+  # NOTE(odyssey4me):
+  # The test execution nodes do not have these packages installed, so
+  # we need to do that until an upstream patch is merged and used by
+  # RPC-O which does not require it to be installed, or installs the
+  # required packages, before running gate-check-commit.
+  apt-get install -y iptables util-linux
+
   ## Create the AIO
   pushd /opt/openstack-ansible
     bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,6 +48,14 @@ if [ "${DEPLOY_AIO}" != false ]; then
   # can diagnose the cause of the apt fetch failures.
   export ANSIBLE_PACKAGE="git+https://github.com/rcbops/ansible@v2.3-OSA_SHA-with_apt_errors"
 
+  # RO-4211
+  # Implement debug output for apt so that we can see more information
+  # about whether the 'Acquire-by-hash' feature is being used, and what
+  # might be causing it to fall back to the old style.
+  # This config file should be copied into containers by the lxc_hosts
+  # role.
+  echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
+
   ## Create the AIO
   pushd /opt/openstack-ansible
     bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"


### PR DESCRIPTION
In order to be able to see more debug information to
allow us to troubleshoot the 'hash sum mismatch' apt
failures properly, we add debug output for all http
apt things.

(cherry picked from commit b0215bbf69c9b6eaf148e332a32564a0101c88de)

Issue: [RO-4211](https://rpc-openstack.atlassian.net/browse/RO-4211)