### PR TITLE
[RO-4207] Update ELK SHAs

### DIFF
--- a/ansible-role-newton-requirements.yml
+++ b/ansible-role-newton-requirements.yml
@@ -16,11 +16,11 @@
 - name: logstash
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
-  version: f42bd2ccdc9c4608e2a357a9f088e3873a6ecad4
+  version: 50438ef199e60eb6f604b057273f9c282063c246
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: ce4c1b16e9bfd7b27a874b95218cde2bc1293bec
+  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git

--- a/ansible-role-newton-requirements.yml
+++ b/ansible-role-newton-requirements.yml
@@ -20,7 +20,7 @@
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
+  version: 0b9b02dc26c5812d2e5a8b8266832a9dba2fe4e1
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git

--- a/ansible-role-ocata-requirements.yml
+++ b/ansible-role-ocata-requirements.yml
@@ -20,7 +20,7 @@
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
+  version: 0b9b02dc26c5812d2e5a8b8266832a9dba2fe4e1
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git

--- a/ansible-role-ocata-requirements.yml
+++ b/ansible-role-ocata-requirements.yml
@@ -16,11 +16,11 @@
 - name: logstash
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
-  version: f42bd2ccdc9c4608e2a357a9f088e3873a6ecad4
+  version: 50438ef199e60eb6f604b057273f9c282063c246
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: ce4c1b16e9bfd7b27a874b95218cde2bc1293bec
+  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git
@@ -28,7 +28,7 @@
 - name: elasticsearch
   scm: git
   src: https://github.com/elastic/ansible-elasticsearch
-  version: 0bffa37035652fc06b547c8ef68c2aaf15b92f80
+  version: 0179bd1eefa6d5c6358f3db29b9e2ad902625393
 
 # RPC-Support specific role
 - name: rcbops_openstack-ops

--- a/ansible-role-pike-requirements.yml
+++ b/ansible-role-pike-requirements.yml
@@ -5,7 +5,7 @@
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
+  version: 0b9b02dc26c5812d2e5a8b8266832a9dba2fe4e1
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git

--- a/ansible-role-pike-requirements.yml
+++ b/ansible-role-pike-requirements.yml
@@ -1,11 +1,11 @@
 - name: logstash
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
-  version: df5e033dbd9942c091299079a470b192c2f20050
+  version: 50438ef199e60eb6f604b057273f9c282063c246
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: 4bbf30df1fb3c36c3e0a9fbfebd999d3ed087a57
+  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git
@@ -13,7 +13,7 @@
 - name: elasticsearch
   scm: git
   src: https://github.com/elastic/ansible-elasticsearch
-  version: eb82e1b055ddcac2ee9d9c1b38bcf9b093962a95
+  version: 0179bd1eefa6d5c6358f3db29b9e2ad902625393
 - name: rcbops_openstack-ops
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops

--- a/ansible-role-queens-requirements.yml
+++ b/ansible-role-queens-requirements.yml
@@ -5,7 +5,7 @@
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
+  version: 0b9b02dc26c5812d2e5a8b8266832a9dba2fe4e1
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git

--- a/ansible-role-queens-requirements.yml
+++ b/ansible-role-queens-requirements.yml
@@ -1,11 +1,11 @@
 - name: logstash
   scm: git
   src: https://github.com/rcbops/rpc-role-logstash.git
-  version: fb6a2a038048595bb0468d82b9954f4208547d55
+  version: 50438ef199e60eb6f604b057273f9c282063c246
 - name: filebeat
   scm: git
   src: https://github.com/rcbops/rpc-role-filebeat.git
-  version: 4bbf30df1fb3c36c3e0a9fbfebd999d3ed087a57
+  version: dd2c65f2bc827b45417ecafc4ef1db8f4fda4643
 - name: kibana
   scm: git
   src: https://github.com/rcbops/rpc-role-kibana.git


### PR DESCRIPTION
This updates the ELK SHAs to pull in 6.x versions of all packages as
well as incoporate new filtering rules to match more types of
timestamps.  This should clear up the massive log files that logstash is
creating.

Issue: RO-4207

Issue: [RO-4207](https://rpc-openstack.atlassian.net/browse/RO-4207)