### PR TITLE
RE-1463 Install required packages before AIO test

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -43,6 +43,13 @@ if [ "${DEPLOY_AIO}" != false ]; then
   # Install OpenStack-Ansible
   openstack-ansible "${SCRIPT_PATH}/../playbooks/openstack-ansible-install.yml"
 
+  # NOTE(odyssey4me):
+  # The test execution nodes do not have these packages installed, so
+  # we need to do that until an upstream patch is merged and used by
+  # RPC-O which does not require it to be installed, or installs the
+  # required packages, before running gate-check-commit.
+  apt-get install -y iptables util-linux
+
   ## Create the AIO
   pushd /opt/openstack-ansible
     bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/gate-check-commit.sh"


### PR DESCRIPTION
The test nodes we use no longer include iptables by
default, and the gate-check-commit script expects it
to be there.

(cherry picked from commit 1d467d66a2d68971da5ceda3e696d83952acc4f8)