### PR TITLE
RO-4216 Update OSA SHA to include improved resolver fix

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -17,5 +17,5 @@ rpc_product_releases:
     rpc_release: r16.2.0
   queens:
     maas_release: 1.7.2
-    osa_release: 5e45ec4535677cec67d7e178c21ad48594878ec8
+    osa_release: b487ccbd545be1d127c49630234829d5610a89e9
     rpc_release: r18.0.0


### PR DESCRIPTION
The implementation of https://review.openstack.org/565933 was
somewhat brutal in the approach based on the assumption that
systemd networking is implemented in the base cache. This may
be true for Rocky, but is not true for any of the older branches.

This patch returns the previous method, but fixes it in two ways:

1. It uses the -f file test operator, instead of the deprecated
   -a operator.
2. It also tests for the presence of a symbolic link with -L.

The downloaded image has resolvconf installed, so there is a symlink
for /etc/resolv.conf which points to /run/resolvconf/resolv.conf
in the cache. Given that in a chroot /run does not exist, the file
test operator fails. This is why we're adding the symlink check.

Instead of then removing resolv.conf at the end, we return it back
so that resolveconf works as expected. This is important for anyone
implementing their resolvers through configuration of network
interfaces.

Issue: [RO-4216](https://rpc-openstack.atlassian.net/browse/RO-4216)