### PR TITLE
RO-4216 Update OSA SHA to include improved resolver fix [pike]

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -13,5 +13,5 @@ rpc_product_releases:
     rpc_release: r15.0.0
   pike:
     maas_release: 1.7.2
-    osa_release: b97e2163fb2e732bdc0ba6c30fa911fc9c6928ac
+    osa_release: ed4e2198a94b94cdcf0a304d14ac8affb9579e06
     rpc_release: r16.2.1


### PR DESCRIPTION
The implementation of https://review.openstack.org/566046 was
somewhat brutal in the approach based on the assumption that
systemd networking is implemented in the base cache. This may
be true for Rocky, but is not true for any of the older branches.

This patch returns the previous method, but fixes it in two ways:

It uses the -f file test operator, instead of the deprecated
-a operator.
It also tests for the presence of a symbolic link with -L.
The downloaded image has resolvconf installed, so there is a symlink
for /etc/resolv.conf which points to /run/resolvconf/resolv.conf
in the cache. Given that in a chroot /run does not exist, the file
test operator fails. This is why we're adding the symlink check.

Instead of then removing resolv.conf at the end, we return it back
so that resolveconf works as expected. This is important for anyone
implementing their resolvers through configuration of network
interfaces.

Issue: [RO-4216](https://rpc-openstack.atlassian.net/browse/RO-4216)