### PR TITLE
RE-1501 Generate dstat graphs for AIO tests

### DIFF
--- a/gating/pre_merge_test/post
+++ b/gating/pre_merge_test/post
@@ -14,3 +14,10 @@ fi
 if [ $RE_JOB_ACTION == "system" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi
+
+if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ "$RE_JOB_ACTION" != "system" ]]; then
+  # RE-1501
+  # Generate the dstat charts using the function built
+  # into OSA.
+  bash -c "source /opt/openstack-ansible/scripts/scripts-library.sh; generate_dstat_charts"
+fi


### PR DESCRIPTION
In order to understand the CPU, memory, disk and network IO
during an AIO test we execute a graph generation from the
data collected by dstat which is started by OSA's gate check
script. The graph for this will be collected with all other
logs and is useful for diagnosing issues.

Issue: [RE-1501](https://rpc-openstack.atlassian.net/browse/RE-1501)