### PR TITLE
RE-1464 Install pre-requisite packages for MNAIO tests

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -23,6 +23,9 @@ echo "+-------------------- MNAIO ENV VARS --------------------+"
 env
 echo "+-------------------- MNAIO ENV VARS --------------------+"
 
+echo "Installing python"
+apt-get update && apt-get install -y python-minimal python-yaml
+
 ## Vars ----------------------------------------------------------------------
 
 # These vars are set by the CI environment, but are given defaults


### PR DESCRIPTION
Previously Jenkins made sure that python and python-yaml
were installed on the host, but with the switch to using
nodepool all pre-requisites must be handled by the test
itself.

(cherry picked from commit f34b25439de2eed79441c4403bf5a4c4f255ac0a)

Issue: [RE-1464](https://rpc-openstack.atlassian.net/browse/RE-1464)