### PR TITLE
RE-1501 Actually generate the dstat report

### DIFF
--- a/gating/pre_merge_test/post
+++ b/gating/pre_merge_test/post
@@ -14,10 +14,3 @@ fi
 if [ $RE_JOB_ACTION == "system" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi
-
-if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ "$RE_JOB_ACTION" != "system" ]]; then
-  # RE-1501
-  # Generate the dstat charts using the function built
-  # into OSA.
-  bash -c "source /opt/openstack-ansible/scripts/scripts-library.sh; generate_dstat_charts"
-fi

--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -38,6 +38,27 @@ eval $collect_logs_cmd || true
 
 echo "#### END LOG COLLECTION ###"
 
+if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
+  echo "#### BEGIN DSTAT CHART GENERATION ###"
+  # RE-1501
+  # Generate the dstat charts.
+  # Unfortunately using the OSA function does not work, and
+  # it spits out a bunch of junk we don't want either.
+  # We therefore replicate the content of it here instead.
+  kill $(pgrep -f dstat) || true
+  if [[ ! -d /opt/dstat_graph ]]; then
+    git clone https://github.com/Dabz/dstat_graph /opt/dstat_graph
+  fi
+  pushd /opt/dstat_graph
+    if [[ -e /openstack/log/instance-info/dstat.csv ]]; then
+      /usr/bin/env bash -e ./generate_page.sh /openstack/log/instance-info/dstat.csv >> /openstack/log/instance-info/dstat.html
+    else
+      echo "Source file dstat.csv not found. Skipping report generation."
+    fi
+  popd
+  echo "#### END DSTAT CHART GENERATION ###"
+fi
+
 # Only enable snapshot when triggered by a commit push.
 # This is to enable image updates whenever a PR is merged, but not before
 if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then


### PR DESCRIPTION
The previous mechanism did not work for some reason, and
a bunch of extra junk was output when trying to use the
OSA function. In this approach we pull what it does into
the post_deploy.sh script and add some guards around it
to make sure that it doesn't fail unnecessarily.

We're still only targeting AIO's right now. Once this is
working we can try to do the same for MNAIO's.

Issue: [RE-1501](https://rpc-openstack.atlassian.net/browse/RE-1501)