### PR TITLE
RO-4232 Updating openstack images to RPC standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ created for convenience and will maintain impotency.
 ``` shell
 cd /opt/rpc-openstack
 export RPC_PRODUCT_RELEASE="queens"  # This is optional, if unset the current stable product will be used
-openstack-ansible openstack-ansible-install.yml
+/opt/rpc-ansible/bin/ansible-playbook -i 'localhost,' playbooks/openstack-ansible-install.yml
 ```
 
 ###### Optional | Setting the OpenStack-Ansible release


### PR DESCRIPTION
virtio-blk is considerd the standard driver,
hence the images should use to hypervisor defaults.

Image filenames are now hashed to prevent names containing
spaces or other characters.

OpenSuse images removed due to size and uncommon usage

Issue: RO-4232

Issue: [RO-4232](https://rpc-openstack.atlassian.net/browse/RO-4232)