### PR TITLE
[RI-308] Install Apt HTTPS transport

### DIFF
--- a/playbooks/logstash.yml
+++ b/playbooks/logstash.yml
@@ -22,6 +22,10 @@
       apt_key:
         url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
         state: "present"
+    - name: Debian - Add HTTPS Apt Transport
+      apt:
+        name: apt-transport-https
+        state: present
 
   roles:
     - role: "logstash"


### PR DESCRIPTION
Apt does not speak HTTPS by default so we need to add the
apt-transport-https package to the logstash container.

Issue: RI-308