### PR TITLE
[RO-4227] Update pike-rc OSA SHAs for cmd2 fix

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -13,5 +13,5 @@ rpc_product_releases:
     rpc_release: r15.0.0
   pike:
     maas_release: 1.7.1
-    osa_release: b97e2163fb2e732bdc0ba6c30fa911fc9c6928ac
+    osa_release: 5c341a7bada78edab5f3d132d55adb00eaf2413f 
     rpc_release: r16.2.0

--- a/releasenotes/notes/cmd2-0.9.0-826f72890ab3d6b6.yaml
+++ b/releasenotes/notes/cmd2-0.9.0-826f72890ab3d6b6.yaml
@@ -1,0 +1,7 @@
+---
+issues:
+  - |
+    All RPC-O pike releases earlier than 16.2.0 will fail to build the rally
+    venv due to the release of the new cmd2-0.9.0 python library. Deployers are
+    encouraged to update to the latest RPC-O pike release which pins to an
+    appropriate version which is compatible with python2.


### PR DESCRIPTION
This updates the pike-rc OSA SHAs to pull in the cmd2 package pinning fix.

Issue: [RO-4227](https://rpc-openstack.atlassian.net/browse/RO-4227)