### PR TITLE
[RO-4097] Update pike OSA SHAs to pull in cmd2 fix

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -12,6 +12,6 @@ rpc_product_releases:
     osa_release: stable/ocata
     rpc_release: r15.0.0
   pike:
-    maas_release: 1.7.2
-    osa_release: b97e2163fb2e732bdc0ba6c30fa911fc9c6928ac
+    maas_release: 1.7.2.1
+    osa_release: 5c341a7bada78edab5f3d132d55adb00eaf2413f
     rpc_release: r16.2.1

--- a/releasenotes/notes/cmd2-0.9.0-35b6c209cbea798f.yaml
+++ b/releasenotes/notes/cmd2-0.9.0-35b6c209cbea798f.yaml
@@ -1,0 +1,7 @@
+---
+issues:
+  - |
+    All RPC-O pike releases earlier than r16.2.0 will fail to build the rally
+    venv due to the release of the new cmd2-0.9.0 python library. Deployers are
+    encouraged to update to the latest RPC-O pike release which pins to an
+    appropriate version which is compatible with python2.


### PR DESCRIPTION
This updates the pike OSA SHAs to pull in the cmd2 package pinning fix.

Issue: RO-4097