### PR TITLE
RO-4241 Correct queens series number to r17

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -18,4 +18,4 @@ rpc_product_releases:
   queens:
     maas_release: 1.7.2.1
     osa_release: 33dcfa0478679f7606404078dddbeb2130268067
-    rpc_release: r18.0.0
+    rpc_release: r17.0.0


### PR DESCRIPTION
Queens is supposed to be r17.x.y, not r18.x.y.

Issue: [RO-4241](https://rpc-openstack.atlassian.net/browse/RO-4241)