### PR TITLE
RO-4222 Use newton-eol instead of stable/newton

### DIFF
--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -1,9 +1,9 @@
 #!/bin/bash -xe
 
-## Update OSA SHA to head of stable/ocata
+## Update OSA SHA to head of the applicable branch
 
 # These var must be set per branch of RPC-Openstack
-osa_branch=stable/newton
+osa_branch=newton-eol
 rpco_branch=${BRANCH:-newton} # BRANCH injected by Jenkins.
 
 # Env vars injected by Jenkins:
@@ -18,7 +18,7 @@ git submodule update
 
 # Set the submodule to the head of the appropriate branch
 pushd openstack-ansible
-git checkout origin/${osa_branch}
+git checkout ${osa_branch}
 popd
 
 


### PR DESCRIPTION
The OSA stable/newtn branch has been removed and
replaced with the newton-eol tag. In this patch
we update the dependency update hook to use the
tag instead of the non-existant branch.

Issue: [RO-4222](https://rpc-openstack.atlassian.net/browse/RO-4222)