### PR TITLE
RE-1550 Update endpoints w/ openstack cli

### DIFF
--- a/gating/thaw/fix_endpoints.yml
+++ b/gating/thaw/fix_endpoints.yml
@@ -1,15 +1,17 @@
-- name: Fix keystone endpoints
-  hosts: localhost
+- hosts: utility_all[0]
+  user: root
   tasks:
-    - name: Start galera container
+    - name: Get a list of public endpoints
       shell: |
-        lxc-start -d -n {{ groups['galera_all'][0] }}
-    - name: Wait for MySQL to become available
-      wait_for:
-        port: 3306
-        delay: 30
-      delegate_to: "{{ groups['galera_all'][0] }}"
-    - name: Update endpoint table
-      command: |
-        mysql keystone -e "UPDATE endpoint SET url = REPLACE(url, '{{ orig_ip }}', '{{ ansible_default_ipv4.address }}')";
-      delegate_to: "{{ groups['galera_all'][0] }}"
+        . {{ ansible_env.HOME }}/openrc
+        openstack endpoint list --interface public --column ID --column URL -f json
+      args:
+        executable: /bin/bash
+      register: public_endpoints
+    - name: Update all public endpoints w/ new public IP
+      shell: |
+        . {{ ansible_env.HOME }}/openrc
+        openstack endpoint set --url '{{ item.URL | replace(orig_ip, hostvars['localhost']['ansible_default_ipv4']['address']) }}' {{ item.ID }}
+      args:
+        executable: /bin/bash
+      with_items: "{{ public_endpoints.stdout | from_json }}"

--- a/gating/thaw/fix_endpoints.yml
+++ b/gating/thaw/fix_endpoints.yml
@@ -1,0 +1,15 @@
+- name: Fix keystone endpoints
+  hosts: localhost
+  tasks:
+    - name: Start galera container
+      shell: |
+        lxc-start -d -n {{ groups['galera_all'][0] }}
+    - name: Wait for MySQL to become available
+      wait_for:
+        port: 3306
+        delay: 30
+      delegate_to: "{{ groups['galera_all'][0] }}"
+    - name: Update endpoint table
+      command: |
+        mysql keystone -e "UPDATE endpoint SET url = REPLACE(url, '{{ orig_ip }}', '{{ ansible_default_ipv4.address }}')";
+      delegate_to: "{{ groups['galera_all'][0] }}"

--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -6,6 +6,10 @@
 # an RPCO deployment. It should fix things that are broken by the switch
 # to a difference instance (eg IPs, hostname)
 
+ORIG_IP=$(
+  cat /etc/openstack_deploy/openstack_user_config.yml | \
+  awk '/external_lb_vip_address/{print $2}' | sed -e 's/[ "]//g'
+)
 
 # Need to ensure SSH config is ok before running ansible
 mkdir -p /root/.ssh
@@ -29,6 +33,7 @@ cd /opt/rpc-openstack/openstack-ansible/playbooks/
 # IP fact being up to date.
 export ANSIBLE_GATHERING=implicit
 openstack-ansible -v /opt/rpc-openstack/gating/thaw/thaw.yml
+openstack-ansible -v /opt/rpc-openstack/gating/thaw/fix_endpoints.yml -e orig_ip=${ORIG_IP}
 openstack-ansible -t haproxy_server-config haproxy-install.yml
 
 lxc-autostart --all

--- a/gating/thaw/run
+++ b/gating/thaw/run
@@ -33,12 +33,12 @@ cd /opt/rpc-openstack/openstack-ansible/playbooks/
 # IP fact being up to date.
 export ANSIBLE_GATHERING=implicit
 openstack-ansible -v /opt/rpc-openstack/gating/thaw/thaw.yml
-openstack-ansible -v /opt/rpc-openstack/gating/thaw/fix_endpoints.yml -e orig_ip=${ORIG_IP}
 openstack-ansible -t haproxy_server-config haproxy-install.yml
 
 lxc-autostart --all
 
 openstack-ansible -v /opt/rpc-openstack/gating/thaw/haproxycheck.yml
+openstack-ansible -v /opt/rpc-openstack/gating/thaw/fix_endpoints.yml -e orig_ip=${ORIG_IP}
 
 # Remove the /gating directory to prevent any further snapshots from being
 # taken.


### PR DESCRIPTION
When we thaw a snapshot image, we currently do not fix the keystone
endpoints referencing the old IP address. This commit simply updates
the thaw to update the ednpoints w/ the new public IP address.

Issue: [RE-1550](https://rpc-openstack.atlassian.net/browse/RE-1550)