### PR TITLE
ASC-592 Hardcode Release Version Info

### DIFF
--- a/gating/pre_merge_test/post_send_junit_to_qtest.sh
+++ b/gating/pre_merge_test/post_send_junit_to_qtest.sh
@@ -10,6 +10,9 @@ export QTEST_API_TOKEN=$RPC_ASC_QTEST_API_TOKEN
 VENV_NAME="venv-qtest"
 PROJECT_ID="76551"
 
+# Work-around for ASC-592. Hardcoded for proper results in qtest
+export RPC_PRODUCT_RELEASE="newton"
+
 ## Functions -----------------------------------------------------------------
 
 source $(dirname ${0})/../../scripts/functions.sh

--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -41,6 +41,10 @@ export RE_JOB_TRIGGER="${RE_JOB_TRIGGER:-PR}"
 export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 
+## Functions -----------------------------------------------------------------
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
 ## OSA MNAIO Vars
 export PARTITION_HOST="true"
 export NETWORK_BASE="172.29"
@@ -70,9 +74,7 @@ export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
 # place variable in file to be sourced by parent calling script 'run'
 export MNAIO_VAR_FILE="${MNAIO_VAR_FILE:-/tmp/mnaio_vars}"
 echo "export MNAIO_SSH=\"${MNAIO_SSH}\"" > "${MNAIO_VAR_FILE}"
-
-## Functions -----------------------------------------------------------------
-source /opt/rpc-openstack/scripts/functions.sh
+echo "export RPC_RELEASE=\"${RPC_RELEASE}\"" >> "${MNAIO_VAR_FILE}"
 
 ## Main --------------------------------------------------------------------
 


### PR DESCRIPTION
In order to reliably collect Molecule system test results from "newton(-rc)"
the environment "RPC_RELEASE" and "RPC_PRODUCT_RELEASE" variables need to be
set. Given the age of Newton the appropriate environment variables will be
hardcoded so that qTest will publish the results in the correct spot.

Issue: [ASC-592](https://rpc-openstack.atlassian.net/browse/ASC-592)