### PR TITLE
RE-1466 Ensure the apt cache is updated

### DIFF
--- a/gating/pre_merge_test/pre_deploy.sh
+++ b/gating/pre_merge_test/pre_deploy.sh
@@ -31,6 +31,7 @@ cd /opt/kibana-selenium
 # https://github.com/ariya/phantomjs/issues/14900
 # https://bugs.launchpad.net/ubuntu/+source/phantomjs/+bug/1578444
 #apt-get install -y phantomjs
+apt-get update
 apt-get install -y fontconfig
 wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2


### PR DESCRIPTION
Before we can install the fontconfig package, we need to
update the apt cache so that apt is aware of where it
can be installed from.

This is required in order to make use of nodepool nodes
which do not come with an updated cache when handed over
to tests.

Issue: [RE-1466](https://rpc-openstack.atlassian.net/browse/RE-1466)