### PR TITLE
RO-4265 Update spice-html5 git repository URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openstack-ansible"]
 	path = openstack-ansible
-	url = https://git.openstack.org/openstack/openstack-ansible
+	url = https://github.com/rcbops/openstack-ansible

--- a/gating/generate_release_notes/generate_commit_diff_notes.sh
+++ b/gating/generate_release_notes/generate_commit_diff_notes.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -xe
 
-rpc-differ --debug -r "$REPO_URL" --update "$PREVIOUS_TAG" "$NEW_TAG" --file diff_notes.rst
+rpc-differ --debug -r "$REPO_URL" --update --osa-repo-url https://github.com/rcbops/openstack-ansible "$PREVIOUS_TAG" "$NEW_TAG" --file diff_notes.rst
 pandoc --from rst --to markdown_github < diff_notes.rst > diff_notes.md

--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -8,7 +8,7 @@ RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 RUN apt-get install -y pandoc
 
-RUN pip install osa_differ==0.3.8 rpc_differ==0.3.8 reno==2.5.1
+RUN pip install osa_differ==0.3.9 rpc_differ==0.3.9 reno==2.5.1
 
 COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
 COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh


### PR DESCRIPTION
Recently the spice-html5 git repository was entirely moved from
[1] to [2]. This results in a failure in the git clone stage of
the repo-build.yml playbook.

Given that newton is EOL upstream, this patch changes the submodule
to point at a fork of the openstack-ansible repository which contains
a fix of the spice-html5 repo URL.

[1] https://github.com/SPICE/spice-html5
[2] https://gitlab.freedesktop.org/spice/spice-html5

Issue: [RO-4265](https://rpc-openstack.atlassian.net/browse/RO-4265)