### PR TITLE
RO-4265 Use stable/newton for dependency updates

### DIFF
--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -3,7 +3,7 @@
 ## Update OSA SHA to head of the applicable branch
 
 # These var must be set per branch of RPC-Openstack
-osa_branch=newton-eol
+osa_branch=stable/newton
 rpco_branch=${BRANCH:-newton} # BRANCH injected by Jenkins.
 
 # Env vars injected by Jenkins:


### PR DESCRIPTION
Now that we're using a fork, we need to do dependency updates
from that fork again, otherwise our previous fixes will be
reverted and no new fixes will be pulled in.

Issue: [RO-4265](https://rpc-openstack.atlassian.net/browse/RO-4265)