### PR TITLE
RO-4265 Set OSA_REPO to rcbops for newton

### DIFF
--- a/gating/pre_merge_test/run_deploy_mnaio.sh
+++ b/gating/pre_merge_test/run_deploy_mnaio.sh
@@ -61,6 +61,7 @@ export RPC_BRANCH="${RE_JOB_BRANCH}"
 export DEFAULT_MIRROR_HOSTNAME=mirror.rackspace.com
 export DEFAULT_MIRROR_DIR=/ubuntu
 export INFRA_VM_SERVER_RAM=16384
+export OSA_REPO="https://github.com/rcbops/openstack-ansible.git"
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"


### PR DESCRIPTION
Because newton is EOL upstream, we've forked newton to
rcbops.  This ensures MNAIO uses that forked version of Ansible.

Depends on https://review.openstack.org/#/c/573455/

Issue: [RO-4265](https://rpc-openstack.atlassian.net/browse/RO-4265)