### PR TITLE
ASC-592 Move 'RPC_PRODUCT_RELEASE' Env Var

### DIFF
--- a/gating/pre_merge_test/post_send_junit_to_qtest.sh
+++ b/gating/pre_merge_test/post_send_junit_to_qtest.sh
@@ -10,9 +10,6 @@ export QTEST_API_TOKEN=$RPC_ASC_QTEST_API_TOKEN
 VENV_NAME="venv-qtest"
 PROJECT_ID="76551"
 
-# Work-around for ASC-592. Hardcoded for proper results in qtest
-export RPC_PRODUCT_RELEASE="newton"
-
 ## Functions -----------------------------------------------------------------
 
 source $(dirname ${0})/../../scripts/functions.sh

--- a/gating/pre_merge_test/run_system_tests.sh
+++ b/gating/pre_merge_test/run_system_tests.sh
@@ -19,6 +19,9 @@ SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
 SYS_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
 export SYS_INVENTORY="/opt/openstack-ansible/playbooks/inventory"
 
+# Work-around for ASC-592. Hardcoded for proper results in qtest
+export RPC_PRODUCT_RELEASE="newton"
+
 ## Main ----------------------------------------------------------------------
 
 # 1. Clone test repository into working directory.


### PR DESCRIPTION
A bit of a facepalm on my part. The hardcoded 'RPC_PRODUCT_RELEASE' environment
variable was placed in the wrong bash script. Moved to the correct location as
the variable is read when JUnitXML test result file is PRODUCED and not
when it is uploaded.