### PR TITLE
RE-1501 Generate dstat graphs for AIO tests [pike]

### DIFF
--- a/gating/pre_merge_test/post
+++ b/gating/pre_merge_test/post
@@ -14,3 +14,10 @@ fi
 if [ $RE_JOB_ACTION == "system" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi
+
+if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ "$RE_JOB_ACTION" != "system" ]]; then
+  # RE-1501
+  # Generate the dstat charts using the function built
+  # into OSA.
+  bash -c "source /opt/openstack-ansible/scripts/scripts-library.sh; generate_dstat_charts"
+fi

--- a/gating/pre_merge_test/post
+++ b/gating/pre_merge_test/post
@@ -14,10 +14,3 @@ fi
 if [ $RE_JOB_ACTION == "system" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi
-
-if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ "$RE_JOB_ACTION" != "system" ]]; then
-  # RE-1501
-  # Generate the dstat charts using the function built
-  # into OSA.
-  bash -c "source /opt/openstack-ansible/scripts/scripts-library.sh; generate_dstat_charts"
-fi

--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -18,6 +18,13 @@ source $(dirname ${0})/../../scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
 
+echo "Killing dstat process to ensure the data file is flushed for log collection."
+if [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
+  ansible -m shell -a 'kill $(pgrep -f dstat) || true' pxe_servers || true
+else
+  kill $(pgrep -f dstat) || true
+fi
+
 echo "#### BEGIN LOG COLLECTION ###"
 
 collect_logs_cmd="ansible-playbook"
@@ -44,7 +51,6 @@ echo "#### BEGIN DSTAT CHART GENERATION ###"
 # Unfortunately using the OSA function does not work, and
 # it spits out a bunch of junk we don't want either.
 # We therefore replicate the content of it here instead.
-kill $(pgrep -f dstat) || true
 dstat_files=$(find ${RE_HOOK_ARTIFACT_DIR} -name 'dstat.csv')
 if [ -n "${dstat_files}" ]; then
   if [[ ! -d /opt/dstat_graph ]]; then

--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -38,26 +38,27 @@ eval $collect_logs_cmd || true
 
 echo "#### END LOG COLLECTION ###"
 
-if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
-  echo "#### BEGIN DSTAT CHART GENERATION ###"
-  # RE-1501
-  # Generate the dstat charts.
-  # Unfortunately using the OSA function does not work, and
-  # it spits out a bunch of junk we don't want either.
-  # We therefore replicate the content of it here instead.
-  kill $(pgrep -f dstat) || true
+echo "#### BEGIN DSTAT CHART GENERATION ###"
+# RE-1501
+# Generate the dstat charts.
+# Unfortunately using the OSA function does not work, and
+# it spits out a bunch of junk we don't want either.
+# We therefore replicate the content of it here instead.
+kill $(pgrep -f dstat) || true
+dstat_files=$(find ${RE_HOOK_ARTIFACT_DIR} -name 'dstat.csv')
+if [ -n "${dstat_files}" ]; then
   if [[ ! -d /opt/dstat_graph ]]; then
     git clone https://github.com/Dabz/dstat_graph /opt/dstat_graph
   fi
   pushd /opt/dstat_graph
-    if [[ -e /openstack/log/instance-info/dstat.csv ]]; then
-      /usr/bin/env bash -e ./generate_page.sh /openstack/log/instance-info/dstat.csv >> /openstack/log/instance-info/dstat.html
-    else
-      echo "Source file dstat.csv not found. Skipping report generation."
-    fi
+    for dstat_file in ${dstat_files}; do
+      /usr/bin/env bash -e ./generate_page.sh ${dstat_file} > ${dstat_file%.csv}.html
+    done
   popd
-  echo "#### END DSTAT CHART GENERATION ###"
+else
+  echo "No dstat.csv source files found. Skipping report generation."
 fi
+echo "#### END DSTAT CHART GENERATION ###"
 
 # Only enable snapshot when triggered by a commit push.
 # This is to enable image updates whenever a PR is merged, but not before

--- a/gating/pre_merge_test/post_deploy.sh
+++ b/gating/pre_merge_test/post_deploy.sh
@@ -38,6 +38,27 @@ eval $collect_logs_cmd || true
 
 echo "#### END LOG COLLECTION ###"
 
+if [[ ! $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
+  echo "#### BEGIN DSTAT CHART GENERATION ###"
+  # RE-1501
+  # Generate the dstat charts.
+  # Unfortunately using the OSA function does not work, and
+  # it spits out a bunch of junk we don't want either.
+  # We therefore replicate the content of it here instead.
+  kill $(pgrep -f dstat) || true
+  if [[ ! -d /opt/dstat_graph ]]; then
+    git clone https://github.com/Dabz/dstat_graph /opt/dstat_graph
+  fi
+  pushd /opt/dstat_graph
+    if [[ -e /openstack/log/instance-info/dstat.csv ]]; then
+      /usr/bin/env bash -e ./generate_page.sh /openstack/log/instance-info/dstat.csv >> /openstack/log/instance-info/dstat.html
+    else
+      echo "Source file dstat.csv not found. Skipping report generation."
+    fi
+  popd
+  echo "#### END DSTAT CHART GENERATION ###"
+fi
+
 # Only enable snapshot when triggered by a commit push.
 # This is to enable image updates whenever a PR is merged, but not before
 if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then


### PR DESCRIPTION
In order to understand the CPU, memory, disk and network IO
during a test, we execute a graph generation from any file found
named ``dstat.csv``, which is what OSA generates for AIO tests.

The resulting file is called ``dstat.html`` which can be opened
in the published job artefacts.

This PR contains multiple cherry-picked commits from master so
that the history of implementation is easy to match.

Issue: [RE-1501](https://rpc-openstack.atlassian.net/browse/RE-1501)