### PR TITLE
RI-314: add timeout for calls to apt

### DIFF
--- a/playbooks/elasticsearch.yml
+++ b/playbooks/elasticsearch.yml
@@ -22,6 +22,10 @@
       apt_key:
         url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
         state: "present"
+      register: apt_res
+      delay: 15
+      retries: 3
+      until: apt_res | success
 
     - name: Create ElasticSearch data directory on host
       file:

--- a/playbooks/filebeat.yml
+++ b/playbooks/filebeat.yml
@@ -23,6 +23,10 @@
       apt_key:
         url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
         state: "present"
+      register: apt_res
+      delay: 15
+      retries: 3
+      until: apt_res | success
 
   roles:
     - role: "filebeat"

--- a/playbooks/kibana.yml
+++ b/playbooks/kibana.yml
@@ -49,6 +49,10 @@
       apt_key:
         url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
         state: "present"
+      register: apt_res
+      delay: 15
+      retries: 3
+      until: apt_res | success
 
   roles:
     - role: "kibana"

--- a/playbooks/logstash.yml
+++ b/playbooks/logstash.yml
@@ -22,10 +22,18 @@
       apt_key:
         url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
         state: "present"
+      register: apt_res
+      delay: 15
+      retries: 3
+      until: apt_res | success
     - name: Debian - Add HTTPS Apt Transport
       apt:
         name: apt-transport-https
         state: present
+      register: apt_res
+      delay: 15
+      retries: 3
+      until: apt_res | success
 
   roles:
     - role: "logstash"


### PR DESCRIPTION
Adding the timeout to the only apt update or install call in our playbooks.

Issue: [RI-314](https://rpc-openstack.atlassian.net/browse/RI-314)