### PR TITLE
ASC-655 Add sdqc action

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -48,3 +48,7 @@ fi
 if [[ $RE_JOB_ACTION == "system" ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
 fi
+if [[ $RE_JOB_ACTION == "sdqc" ]]; then
+  export RE_JOB_BRANCH="openstack-ops-only"
+  bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
+fi


### PR DESCRIPTION
This commit adds a conditional for the "sdqc" action. If this action is
used, then the `RE_JOB_BRANCH` is changed to `openstack-ops-only` in
order to trigger the checkout of that branch when the
`run_system_tests.sh` script is executed. The purpose of this is to run
the deployment and validation of
[openstack-ops](https://github.com/rsoprivatecloud/openstack-ops/) in
isolation from other system test suites. Currently, this is necessary
due to a conflict in the deployment ansible code.

Issue: [ASC-655](https://rpc-openstack.atlassian.net/browse/ASC-655)