### PR TITLE
RE-1596 Install required packages during AIO bootstrap

### DIFF
--- a/gating/check/pre_deploy.sh
+++ b/gating/check/pre_deploy.sh
@@ -21,14 +21,6 @@ if [[ "$(basename ${PWD})" == "rpc-openstack" ]]; then
   fi
 fi
 
-# NOTE(odyssey4me):
-# The test execution nodes do not have these packages installed in
-# order for boostrap-aio to complete. This is used for AIO and MNAIO
-# tests, but applicable only for host bootstrapping for tests, so we
-# add this here rather than in the normal production execution.
-apt-get update
-apt-get install -y iptables util-linux
-
 # Clone the kibana-selenium git repository
 git clone -b ${KIBANA_SELENIUM_BRANCH} ${KIBANA_SELENIUM_REPO} /opt/kibana-selenium
 
@@ -39,6 +31,7 @@ cd /opt/kibana-selenium
 # https://github.com/ariya/phantomjs/issues/14900
 # https://bugs.launchpad.net/ubuntu/+source/phantomjs/+bug/1578444
 #apt-get install -y phantomjs
+apt-get update
 apt-get install -y fontconfig
 wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -27,6 +27,14 @@ source ${BASE_DIR}/scripts/functions.sh
 # Check the openstack-ansible submodule status
 check_submodule_status
 
+# NOTE(odyssey4me):
+# The test execution nodes do not have these packages installed in
+# order for bootstrap-aio to complete.
+# iptables   - used for the br-vxlan network config
+# util-linux - used by lsblk for data disk device detection
+apt-get update
+apt-get install -y iptables util-linux
+
 # Get minimum disk size
 DATA_DISK_MIN_SIZE="$((1024**3 * $(awk '/bootstrap_host_data_disk_min_size/{print $2}' ${OA_DIR}/tests/roles/bootstrap-host/defaults/main.yml) ))"
 # Determine the largest secondary disk device available for repartitioning which meets the minimum size requirements


### PR DESCRIPTION
The nodepool nodes need these packages for AIO testing,
and for artifact building. This is the best place to
install them which is used by both use-cases.

Issue: [RE-1596](https://rpc-openstack.atlassian.net/browse/RE-1596)