### PR TITLE
Remove functions source in deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,8 +22,6 @@ set -o pipefail
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
 ## Functions -----------------------------------------------------------------
-source "${SCRIPT_PATH}/functions.sh"
-
 function exit_notice {
   cat "${SCRIPT_PATH}/../README.md"
 }


### PR DESCRIPTION
Sourcing the functions script in `deploy.sh` may result in failure on a
deployment where the base OS has been installed using a minimal image.
The functions script will be sourced by the install script so any and
all dependencies will be taken care of in the order in which they're
used.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>