### PR TITLE
Fix creation of RE_ENV file

### DIFF
--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -80,7 +80,11 @@ echo "export RPC_PRODUCT_RELEASE=\"${RPC_PRODUCT_RELEASE}\"" >> "${MNAIO_VAR_FIL
 ## Main --------------------------------------------------------------------
 
 # capture all RE_ variables
-env | grep RE_ | sed 's/^/export /' > /opt/rpc-openstack/RE_ENV
+> /opt/rpc-openstack/RE_ENV
+env | grep RE_ | while read -r match; do
+  varName=$(echo ${match} | cut -d= -f1)
+  echo "export ${varName}='${!varName}'" >> /opt/rpc-openstack/RE_ENV
+done
 
 # checkout openstack-ansible-ops
 if [ ! -d "/opt/openstack-ansible-ops" ]; then


### PR DESCRIPTION
This change fixes the RE_ENV file so that the environment variables
defined have values that are quoted. So for example without this fix,
`export RE_FOO_BAR=foo bar` is added to the file and when exported that
gives `RE_FOO_BAR=foo`. With this change it would become `export
RE_FOO_BAR='foo bar'` which gives `RE_FOO_BAR=foo bar`.

JIRA: RE-1685

Issue: [RE-1685](https://rpc-openstack.atlassian.net/browse/RE-1685)