### PR TITLE
ASC-672 Install Swagger Client from PyPI

### DIFF
--- a/gating/check/post_send_junit_to_qtest.sh
+++ b/gating/check/post_send_junit_to_qtest.sh
@@ -25,8 +25,7 @@ source "${VENV_NAME}/bin/activate"
 VENV_PIP="${VENV_NAME}/bin/pip"
 
 # Install zigzag from PyPI
-${VENV_PIP} install -e git+git://github.com/ryan-rs/qtest-swagger-client.git@master#egg=swagger-client-1.0.0
-${VENV_PIP} install --process-dependency-links rpc-zigzag
+${VENV_PIP} install rpc-zigzag
 
 # Search for xml files in RE_HOOK_RESULT_DIR
 xml_files=()


### PR DESCRIPTION
QA Symphony does publish a package for their qTest swagger client on PyPI
which forced us to install the client from git instead. We've received
confirmation from QA Symphony to fork their code and publish a PyPI package
for our fork.

**Resources**

- [PyPI Package](https://pypi.org/project/rpc-qtest-swagger-client/)
- [Client GitHub Fork](https://github.com/rcbops/qtest-swagger-client)

Issue: [ASC-672](https://rpc-openstack.atlassian.net/browse/ASC-672)