### PR TITLE
RI-359 Add basic auth information

### DIFF
--- a/etc/openstack_deploy/group_vars/all/elasticsearch.yml
+++ b/etc/openstack_deploy/group_vars/all/elasticsearch.yml
@@ -21,6 +21,11 @@ es_api_host: "{{ container_address }}"
 es_api_port: "{{ elasticsearch_http_port }}"
 es_version: "{{ elasticsearch_version }}"
 es_major_version: "{{ elasticsearch_major_version }}"
+es_basic_auth_username: "admin"
+es_basic_auth_password: "{{ elasticsearch_basic_auth_password }}"
+es_api_basic_auth_username: "admin"
+es_api_basic_auth_password: "{{ elasticsearch_basic_auth_password }}"
+
 
 es_config:
   node.name: "{{ container_name }}"

--- a/etc/openstack_deploy/user_rpco_secrets.yml.example
+++ b/etc/openstack_deploy/user_rpco_secrets.yml.example
@@ -19,3 +19,4 @@ fsid_uuid:
 maas_swift_accesscheck_password:
 maas_rabbitmq_password:
 maas_keystone_password:
+elasticsearch_basic_auth_password:


### PR DESCRIPTION
ELK now needs basic auth when security is enabled.  This adds two basic
auth variables for the endpoint as well as the API.

(cherry picked from commit b055de59fb1c4d642049e72371b8b77016c4a3c4)