### PR TITLE
[RO-4311] Update Pike-rc OSA SHA

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -13,5 +13,5 @@ rpc_product_releases:
     rpc_release: r15.0.0
   pike:
     maas_release: 1.7.3
-    osa_release: fc2cb9eef48cc13924fdedd1f881bfd4fc6f5bfa
+    osa_release: 48652d5ea29ccf1f4ca429790fdcf58d0502c5a6
     rpc_release: r16.2.2


### PR DESCRIPTION
This updates the OSA SHA to point to OSA release 16.0.16.  This pulls in
needed fixes for RO-4305.

Issue: RO-4311