### PR TITLE
Add support for bandit

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ pyasn1!=0.2.3 # BSD
 pyOpenSSL>=0.14 # Apache-2.0
 requests>=2.14.2 # Apache-2.0
 ndg-httpsclient>=0.4.2;python_version<'3.0' # BSD
+bandit>=1.4.0
 
 # this is required for the docs build jobs
 sphinx>=1.5.1 # BSD

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,21 @@ deps =
 commands =
     bash -c "{toxinidir}/run-bindep.sh"
 
+[testenv:bandit]
+deps = -rtest-requirements.txt
+commands =
+# Ignore B404 about importing subprocess. We're knowingly and intentionally
+# using subprocess and don't need a warning about mere usage alone.
+# Specific warnings will still come through as they're found.
+#
+# Until bandit has the ability to log issues at lower severities than it's
+# configured to pass/fail based on, we need to run bandit twice. Run it
+# once with no severity or confidence level set to get everything, but ignore
+# that exit status. Then run it again on the highest severity and confidence
+# levels and get our pass/fail status from that.
+# This is reported to bandit at https://github.com/PyCQA/bandit/issues/341
+    - bandit -s B404 -i -l -r playbooks/ scripts/ gating/
+    bandit -s B404 -iii -lll -r playbooks/ scripts/ gating/
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
This change adds support for running bandit on several directories that contain Python code. The configuration being run in tox.ini is that there are two runs: one at the lowest settings so we get a log of all issues regardless of severity or confidence, and a second run at the most strict severity and confidence levels. The first run's exit code is ignored because bandit can't currently evaluate pass/fail status at the highest levels while continuing logging lower level issues, which we want. The second run, done at strict settings, is what determines whether or not our bandit run passes. https://github.com/PyCQA/bandit/issues/341 was entered to the bandit tracker to see what can be done about this.

JIRA: TURTLES-1017

Issue: [TURTLES-1017](https://rpc-openstack.atlassian.net/browse/TURTLES-1017)