### PR TITLE
README: Remove reference to deleted openstack-ansible wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ created for convenience and will maintain impotency.
 ``` shell
 cd /opt/rpc-openstack
 export RPC_PRODUCT_RELEASE="queens"  # This is optional, if unset the current stable product will be used
-openstack-ansible openstack-ansible-install.yml
+/opt/rpc-ansible/bin/ansible-playbook -i localhost, openstack-ansible-install.yml
 ```
 
 ###### Optional | Setting the OpenStack-Ansible release
@@ -91,7 +91,7 @@ variable `osa_release` to a SHA, Branch, or Tag and run the `site-release.yml`
 and `openstack-ansible-install.yml` playbooks to install the correct version.
 
 ``` shell
-openstack-ansible site-release.yml openstack-ansible-install.yml -e 'osa_release=master'
+/opt/rpc-ansible/bin/ansible-playbook -i localhost, site-release.yml openstack-ansible-install.yml -e 'osa_release=master'
 ```
 
 ##### Running the playbooks


### PR DESCRIPTION
The `openstack-ansible` "minimal wrapper" was removed in commit
e250dc4f, but is still implicitly referenced in README.md (ie
`openstack-ansible` can't be used [at least initially] to execute
site-release.yml and/or openstack-ansible-install.yml because it
hasn't been installed yet as part of OpenStack-Ansible), so change the
documentation the same as the aforementioned commit changed the
execution of those two playbooks in deploy.sh and install.sh:

`openstack-ansible` =>
`/opt/rpc-ansible/bin/ansible-playbook -i localhost,`