### PR TITLE
[RO-4342] Update ELK and dependencies for Pike

### DIFF
--- a/etc/openstack_deploy/group_vars/all/elasticsearch.yml
+++ b/etc/openstack_deploy/group_vars/all/elasticsearch.yml
@@ -6,8 +6,8 @@
 # role then attempts to render these datasets, and will fail if it cannot resolve
 # a variable. Putting these variables in here ensures the repo_build
 # role can interpolate the variables correctly.
-elasticsearch_version: 5.6.7
-elasticsearch_major_version: 5.x
+elasticsearch_version: 6.3.1
+elasticsearch_major_version: 6.x
 elasticsearch_reindex_version: 1.7.5
 
 es_instance_name: "openstack"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,6 +50,17 @@ if [[ -d "/opt/openstack-ansible" ]] && [[ ! -d "/opt/openstack-ansible/.git" ]]
   mv /opt/openstack-ansible /opt/openstack-ansible.original
 fi
 
+# Generate the RPCO secrets required for the deployment.
+if [[ ! -f "/etc/openstack_deploy/user_rpco_secrets.yml" ]]; then
+  cp ${SCRIPT_PATH}/../etc/openstack_deploy/user_rpco_secrets.yml.example /etc/openstack_deploy/user_rpco_secrets.yml
+fi
+
+for file_name in user_rpco_secrets.yml; do
+  if [[ -f "/etc/openstack_deploy/${file_name}" ]]; then
+    python /opt/openstack-ansible/scripts/pw-token-gen.py --file "/etc/openstack_deploy/${file_name}"
+  fi
+done
+
 # NOTE(cloudnull): Create a virtualenv for RPC-Ansible which is used for
 #                  initial bootstrap purposes. While playbooks can be run using
 #                  this ansible release in the general sense, the OSA ansible


### PR DESCRIPTION
ELK and related dependencies need to be updated for the Pike release.
The initial commit updates the Elasticsearch packages to the latest
6.1.3 release.

Issue: RO-4342

Issue: [RO-4342](https://rpc-openstack.atlassian.net/browse/RO-4342)