### PR TITLE
[RO-4356] Move ansible version to v2.5.5

### DIFF
--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -125,11 +125,6 @@ set -exu
 # starts the deploy from infra1 vm
 source /opt/rpc-openstack/RE_ENV
 
-# RO-4206
-# Use fork of Ansible which exposes the apt errors so that we
-# can diagnose the cause of the apt fetch failures.
-export ANSIBLE_PACKAGE="git+https://github.com/rcbops/ansible@v2.4.4.0-with_apt_errors"
-
 pushd /opt/rpc-openstack
   scripts/deploy.sh
 popd


### PR DESCRIPTION
Since RPC-O master is now pointing at rocky we need to update our 
ansible version.  Until our forked version of ansible is updated we'll 
point back to the standard version of ansible.

Issue: RO-4356

Issue: [RO-4356](https://rpc-openstack.atlassian.net/browse/RO-4356)