### PR TITLE
RI-384 Switch LXC backend to machinectl

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -118,3 +118,5 @@ haproxy_extra_services:
 
 # Define the distro version globally
 repo_build_os_distro_version: "{{ (ansible_distribution | lower) | replace(' ', '_') }}-{{ ansible_distribution_version.split('.')[:2] | join('.') }}-{{ ansible_architecture | lower }}"
+
+lxc_container_backing_store: machinectl


### PR DESCRIPTION
We want to utiliize the machinectl backend for LXC containers.

Issue: [RI-384](https://rpc-openstack.atlassian.net/browse/RI-384)