### PR TITLE
Fix creation of RE_ENV file

### DIFF
--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -116,7 +116,11 @@ popd
 echo "Multi Node AIO setup completed..."
 
 # capture all RE_ variables for push to infra1
-env | grep RE_ | sed 's/^/export /' > /opt/rpc-openstack/RE_ENV
+> /opt/rpc-openstack/RE_ENV
+env | grep RE_ | while read -r match; do
+  varName=$(echo ${match} | cut -d= -f1)
+  echo "export ${varName}='${!varName}'" >> /opt/rpc-openstack/RE_ENV
+done
 
 # generate infra1 deploy script
 cat > /opt/rpc-openstack/deploy-infra1.sh <<EOF


### PR DESCRIPTION
This change fixes the RE_ENV file so that the environment variables
defined have values that are quoted. So for example without this fix,
`export RE_FOO_BAR=foo bar` is added to the file and when exported that
gives `RE_FOO_BAR=foo`. With this change it would become `export
RE_FOO_BAR='foo bar'` which gives `RE_FOO_BAR=foo bar`.

This address and issue missed by
bb5584a4bb463b1bf1b299e25b07a9eb82f454e8.

JIRA: RE-1798
(cherry picked from commit 99c89e49eaefd5c21db14051b34234f4f19d0ea3)