### PR TITLE
Prep MNAIO and make pre stage idempotent

### DIFF
--- a/gating/check/pre_deploy.sh
+++ b/gating/check/pre_deploy.sh
@@ -21,22 +21,42 @@ if [[ "$(basename ${PWD})" == "rpc-openstack" ]]; then
   fi
 fi
 
+if [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
+  # We need to ensure that we use the rackspace mirrors, as they are
+  # most reliable. We also need to ensure that python and the python
+  # yaml library are present for ansible to work. This is implemented
+  # only for MNAIO tests as AIO's use artifacts and already have the
+  # right things implemented in the images they use.
+  source "$(readlink -f $(dirname ${0}))/pre_deploy_mnaio.sh"
+fi
+
 # Clone the kibana-selenium git repository
-git clone -b ${KIBANA_SELENIUM_BRANCH} ${KIBANA_SELENIUM_REPO} /opt/kibana-selenium
+if [[ ! -e /opt/kibana-selenium ]]; then
+  git clone -b ${KIBANA_SELENIUM_BRANCH} ${KIBANA_SELENIUM_REPO} /opt/kibana-selenium
+fi
 
 # Prepare for Kibana Selenium Tests
 cd /opt/kibana-selenium
 
+# Install pre-requisites
+pkgs_to_install=""
 # The phantomjs package on 16.04 is buggy, see:
 # https://github.com/ariya/phantomjs/issues/14900
 # https://bugs.launchpad.net/ubuntu/+source/phantomjs/+bug/1578444
-#apt-get install -y phantomjs
-apt-get update
-apt-get install -y fontconfig
-wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
-tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+#dpkg-query --list | grep phantomjs &>/dev/null || pkgs_to_install+="phantonjs "
+dpkg-query --list | grep fontconfig &>/dev/null || pkgs_to_install+="fontconfig "
+virtualenv --version &>/dev/null || pkgs_to_install+="python-virtualenv virtualenv "
+if [ "${pkgs_to_install}" != "" ]; then
+  apt-get update
+  apt-get install -y ${pkgs_to_install}
+fi
+
+if [[ ! -e phantomjs-2.1.1-linux-x86_64.tar.bz2 ]]; then
+  wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+fi
+
 if [[ ! -d ".venv" ]]; then
-  pip install virtualenv
   virtualenv .venv
 fi
 

--- a/gating/check/pre_deploy_mnaio.sh
+++ b/gating/check/pre_deploy_mnaio.sh
@@ -1,0 +1,46 @@
+# Save a backup of the original file
+if [[ ! -e /etc/apt/sources.list.original ]]; then
+  mv /etc/apt/sources.list /etc/apt/sources.list.original
+fi
+
+# Set the environment variables
+DISTRO_MIRROR="http://mirror.rackspace.com/ubuntu"
+DISTRO_COMPONENTS="main,universe"
+
+# Get the distribution name
+if [[ -e /etc/lsb-release ]]; then
+  source /etc/lsb-release
+  DISTRO_RELEASE=${DISTRIB_CODENAME}
+elif [[ -e /etc/os-release ]]; then
+  source /etc/os-release
+  DISTRO_RELEASE=${UBUNTU_CODENAME}
+else
+  echo "Unable to determine distribution due to missing lsb/os-release files."
+  exit 1
+fi
+
+# Rewrite the apt sources file
+cat << EOF >/etc/apt/sources.list
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE} ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-security ${DISTRO_COMPONENTS//,/ }
+EOF
+
+# Add apt debug configuration
+echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
+
+# Ensure package installs are in headless mode
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the apt cache
+apt-get update
+
+# Install pre-requisites
+pkgs_to_install=""
+dpkg-query --list | grep python-minimal &>/dev/null || pkgs_to_install+="python-minimal "
+dpkg-query --list | grep python-yaml &>/dev/null || pkgs_to_install+="python-yaml "
+if [ "${pkgs_to_install}" != "" ]; then
+  apt-get install -y ${pkgs_to_install}
+fi
+


### PR DESCRIPTION
When using nodepool, pip is not installed on the host.
This causes the 'pre' stage to fail to install virtualenv,
then (as usual) the pre stage repeats three times and fails
at a different point because the script is not idempotent.

We make the script more idempotent so that any failure
should be more consistent, and we ensure that we handle
the preparation of apt sources and the installation of
python/python-yaml/virtualenv.

Part of this includes ensuring that we use the
Rackspace apt mirrors. This is a necessary change
specifically for MNAIO tests where they are setup
to use archive.ubuntu.com which is slow and fails
often due to there being more hops to it.

Issue: [RE-1730](https://rpc-openstack.atlassian.net/browse/RE-1730)