### PR TITLE
Use a common gating script for gating host prep

### DIFF
--- a/gating/check/run_deploy.sh
+++ b/gating/check/run_deploy.sh
@@ -9,15 +9,6 @@ set -o pipefail
 
 export DEPLOY_AIO="true"
 
-# In order to get the value for rpc_release, we need to use
-# a python script, so we need to make sure that python and
-# the python yaml library are installed. If not, the value
-# for rpc_release cannot be read and the check for the value
-# will result in a null return, causing all artifacts to be
-# disabled.
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-yaml
-
 # When a PR contains a change to rpc_release, there may not
 # be any artifacts for the new release version. If this is
 # the case then we need to disable the artifact usage. In

--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -23,9 +23,6 @@ echo "+-------------------- MNAIO ENV VARS --------------------+"
 env
 echo "+-------------------- MNAIO ENV VARS --------------------+"
 
-echo "Installing python"
-apt-get update && apt-get install -y python-minimal python-yaml
-
 ## Vars ----------------------------------------------------------------------
 
 # These vars are set by the CI environment, but are given defaults

--- a/gating/gating_prerequisites.sh
+++ b/gating/gating_prerequisites.sh
@@ -1,0 +1,46 @@
+# Save a backup of the original file
+if [[ ! -e /etc/apt/sources.list.original ]]; then
+  mv /etc/apt/sources.list /etc/apt/sources.list.original
+fi
+
+# Set the environment variables
+DISTRO_MIRROR="http://mirror.rackspace.com/ubuntu"
+DISTRO_COMPONENTS="main,universe"
+
+# Get the distribution name
+if [[ -e /etc/lsb-release ]]; then
+  source /etc/lsb-release
+  DISTRO_RELEASE=${DISTRIB_CODENAME}
+elif [[ -e /etc/os-release ]]; then
+  source /etc/os-release
+  DISTRO_RELEASE=${UBUNTU_CODENAME}
+else
+  echo "Unable to determine distribution due to missing lsb/os-release files."
+  exit 1
+fi
+
+# Rewrite the apt sources file
+cat << EOF >/etc/apt/sources.list
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE} ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-updates ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-backports ${DISTRO_COMPONENTS//,/ }
+deb ${DISTRO_MIRROR} ${DISTRO_RELEASE}-security ${DISTRO_COMPONENTS//,/ }
+EOF
+
+# Add apt debug configuration
+echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
+
+# Ensure package installs are in headless mode
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the apt cache
+apt-get update
+
+# Install pre-requisites
+pkgs_to_install=""
+dpkg-query --list | grep python-minimal &>/dev/null || pkgs_to_install+="python-minimal "
+dpkg-query --list | grep python-yaml &>/dev/null || pkgs_to_install+="python-yaml "
+if [ "${pkgs_to_install}" != "" ]; then
+  apt-get install -y ${pkgs_to_install}
+fi
+

--- a/gating/update_dependencies/pre
+++ b/gating/update_dependencies/pre
@@ -9,18 +9,7 @@ set -o pipefail
 
 ## Main ----------------------------------------------------------------------
 
-# If the current folder's basename is rpc-openstack then we assume
-# that it is the root of the git clone. If the git clone is not in
-# /opt then we symlink the current folder there so that all the
-# rpc-openstack scripts work as expected.
-if [[ "$(basename ${PWD})" == "rpc-openstack" ]]; then
-  if [[ "${PWD}" != "/opt/rpc-openstack" ]]; then
-    ln -sfn ${PWD} /opt/rpc-openstack
-  fi
-fi
-
 # We need to ensure that we use the rackspace mirrors, as they are
 # most reliable. We also need to ensure that python and the python
 # yaml library are present for ansible to work.
 source "$(readlink -f $(dirname ${0}))/../gating_prerequisites.sh"
-

--- a/gating/update_dependencies/run
+++ b/gating/update_dependencies/run
@@ -11,13 +11,6 @@ export GATING_PATH="$(readlink -f $(dirname ${0}))"
 # Set the base RPC-O directory which the functions use
 export BASE_DIR="$(readlink -f ${GATING_PATH}/../..)"
 
-# As get-rpc_release.py requires a yaml import, make
-# sure that it is installed and available.
-if ! python -c 'import yaml' &>/dev/null; then
-  echo "Python YAML library not available. Installing it."
-  apt-get install -y python-yaml
-fi
-
 # Source the functions
 source "${BASE_DIR}/scripts/functions.sh"
 


### PR DESCRIPTION
Rather than repeat the preparation of apt sources
and the installation of python/python-yaml in
several locations, we consolidate the necessary
preparation into a common script.

Part of this includes ensuring that we use the
Rackspace apt mirrors. This is a necessary change
specifically for MNAIO tests where they are setup
to use archive.ubuntu.com which is slow and fails
often due to there being more hops to it.

JIRA: RE-1730
(cherry picked from commit c3674b33ec550fa21dc5d248a2bc4f15a70898ab)

Issue: [RE-1730](https://rpc-openstack.atlassian.net/browse/RE-1730)