### PR TITLE
Fix rocky RPC_PRODUCT_RELEASE variable default

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -33,7 +33,7 @@ export INFLUX_PORT="${INFLUX_PORT:-8086}"
 export BUILD_TAG="${BUILD_TAG:-testing}"
 
 # RPC-OpenStack product release, this variable is used in the config playbooks.
-export RPC_PRODUCT_RELEASE="${RPC_PRODUCT_RELEASE:-master}"
+export RPC_PRODUCT_RELEASE="${RPC_PRODUCT_RELEASE:-rocky}"
 
 # OSA release branch
 if [ -z ${OSA_RELEASE_BRANCH+x} ]; then

--- a/tox.ini
+++ b/tox.ini
@@ -25,13 +25,13 @@ setenv =
     # bug#1682108
     PYTHONPATH={envsitepackagesdir}
     # RPC product release name
-    RPC_PRODUCT_RELEASE={env:RPC_PRODUCT_RELEASE:master}
+    RPC_PRODUCT_RELEASE={env:RPC_PRODUCT_RELEASE:rocky}
     ### OSA specific call back files
     # Set the checkout to any supported tag, branch, or sha.
     # NOTE(cloudnull): This should be set to "master" as soon the gate is capable of
     #                  setting this option.
-    OSA_RELEASE_BRANCH={env:OSA_RELEASE_BRANCH:master}
-    OSA_TEST_RELEASE=master
+    OSA_RELEASE_BRANCH={env:OSA_RELEASE_BRANCH:stable/rocky}
+    OSA_TEST_RELEASE=stable/rocky
     UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_ROLE_REQUIREMENTS=https://git.openstack.org/cgit/openstack/openstack-ansible/plain/ansible-role-requirements.yml?h={env:OSA_RELEASE_BRANCH:master}


### PR DESCRIPTION
It was still 'master' from the branching. Need to update.