### PR TITLE
[RI-357] Disable test_minimum_basic tempest scenario

### DIFF
--- a/group_vars/all/osa.yml
+++ b/group_vars/all/osa.yml
@@ -83,3 +83,9 @@ haproxy_extra_services:
       haproxy_balance_type: tcp
       haproxy_backend_options:
         - "ssl-hello-chk"
+
+# RI-357 Tempest Overrides
+# TODO(d34dh0r53): Once the test_minimum_basic_scenario is working we can remove
+# this
+tempest_test_blacklist:
+  - tempest.scenario.test_minimum_basic


### PR DESCRIPTION
The test_minimum_basic tempest scenario is causing a lot of gate 
failures.  Until we can increase the stability of this test we are 
disabling it.

Issue: RI-357

Issue: [RI-357](https://rpc-openstack.atlassian.net/browse/RI-357)