### PR TITLE
[RI-357] Disable test_minimum_basic tempest scenario

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -155,3 +155,9 @@ ironic_ironic_conf_overrides:
     user_domain_id: "{{ glance_service_user_domain_id }}"
     password: "{{ glance_service_password }}"
     glance_api_servers: "{{ ironic_glance_api_servers }}"
+
+# RI-357 Tempest Overrides
+# TODO(d34dh0r53): Once the test_minimum_basic_scenario is working we can remove
+# this
+tempest_test_blacklist:
+  - tempest.scenario.test_minimum_basic


### PR DESCRIPTION
The test_minimum_basic tempest scenario is causing a lot of gate 
failures.  Until we can increase the stability of this test we are 
disabling it.

Issue: RI-357

Issue: [RI-357](https://rpc-openstack.atlassian.net/browse/RI-357)