### PR TITLE
[RI-437] Backport pike-rc fixes

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,7 +36,7 @@ function basic_install {
 ## Main ----------------------------------------------------------------------
 
 # Setup OpenStack
-if [ "${DEPLOY_AIO}" != false ]; then
+if [ "${DEPLOY_AIO:-false}" != false ]; then
   ## Run the basic installation script
   basic_install
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,8 +22,6 @@ set -o pipefail
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
 ## Functions -----------------------------------------------------------------
-source "${SCRIPT_PATH}/functions.sh"
-
 function exit_notice {
   cat "${SCRIPT_PATH}/../README.md"
 }


### PR DESCRIPTION
This backports a couple of fixes into pike which may help resolve RI-437.

Commit: 199c2f7
Remove functions source in deploy.sh

Sourcing the functions script in deploy.sh may result in failure on a
deployment where the base OS has been installed using a minimal image.
The functions script will be sourced by the install script so any and
all dependencies will be taken care of in the order in which they're
used.

Commit: 085d24b
add default option to the variable DEPLOY_AIO

Issue: RI-437