### PR TITLE
RE-1894 Update rpc_release match for RC tags

### DIFF
--- a/gating/update_dependencies/release-update.py
+++ b/gating/update_dependencies/release-update.py
@@ -52,7 +52,7 @@ rpc_release = release_data['rpc_release']
 # standard.
 
 release_naming_standard = re.compile(
-    "^r[0-9]+.[0-9]+.[0-9]+(-(alpha|beta).[0-9]+)?$|^master$")
+    "^r[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?$|^master$")
 
 assert release_naming_standard.match(rpc_release), (
     "The rpc_release value of %s does not comply with the release naming"


### PR DESCRIPTION
Currently only alpha/beta pre-release tags are supported.
This patch updates the regex match to also accept rc
pre-release tags so that they can be used for releases.

The accepted form is the same as with alpha/beta tags, eg:
1.0.0-rc.1, 1.0.0-rc.2, etc.

(cherry picked from commit 2340aa8ca27ae748640a55e9b5b44dab7b089ac3)

Issue: [RE-1894](https://rpc-openstack.atlassian.net/browse/RE-1894)