### PR TITLE
RI-356 Decouple MaaS from RPCO

### DIFF
--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -65,7 +65,7 @@ export RPC_BRANCH="${RE_JOB_BRANCH}"
 export DEFAULT_MIRROR_HOSTNAME=mirror.rackspace.com
 export DEFAULT_MIRROR_DIR=/ubuntu
 export INFRA_VM_SERVER_RAM=16384
-
+export DEPLOY_MAAS=false
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
 # place variable in file to be sourced by parent calling script 'run'

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -20,6 +20,9 @@ export DEPLOY_MAAS=${DEPLOY_MAAS:-false}
 export DEPLOY_TELEGRAF=${DEPLOY_TELEGRAF:-false}
 export DEPLOY_INFLUX=${DEPLOY_INFLUX:-false}
 
+if [ ${DEPLOY_AIO} == true ]; then
+  export DEPLOY_MAAS=false
+fi
 # To send data to the influxdb server, we need to deploy and configure
 #  telegraf. By default, telegraf will use log_hosts (rsyslog hosts) to
 #  define its influxdb servers. These playbooks need maas-get to have run


### PR DESCRIPTION
This sets the DEPLOY_MAAS variable to false when
deploying an AIO and MNAIO. We can turn it on by exporting
DEPLOY_MAAS=true.

Issue: [RI-356](https://rpc-openstack.atlassian.net/browse/RI-356)