### PR TITLE
RI-445 Change default maas version

### DIFF
--- a/etc/openstack_deploy/group_vars/all/release.yml
+++ b/etc/openstack_deploy/group_vars/all/release.yml
@@ -24,4 +24,4 @@ rpc_release: "undefined"
 openstack_release: "{{ rpc_release }}"
 
 # Set the release of the maas
-maas_release: "undefined"
+maas_release: "master"


### PR DESCRIPTION
This changes the maas_release variable from 'undefined' to 'master'.

Issue: [RI-445](https://rpc-openstack.atlassian.net/browse/RI-445)