### PR TITLE
RI-356 Remove call to get-maas.yml

### DIFF
--- a/playbooks/site-release.yml
+++ b/playbooks/site-release.yml
@@ -14,4 +14,3 @@
 # limitations under the License.
 
 - include: configure-release.yml
-- include: get-maas.yml

--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -49,9 +49,9 @@ pushd "${SCRIPT_PATH}/../playbooks"
   fi
 popd
 
-pushd /opt/rpc-maas/playbooks
+if [ "${DEPLOY_MAAS}" != false ]; then
+  pushd /opt/rpc-maas/playbooks
   # Deploy and configure RAX MaaS
-  if [ "${DEPLOY_MAAS}" != false ]; then
     if [ "${DEPLOY_TELEGRAF}" != false ]; then
       # Set the rpc_maas vars.
       if [[ ! -f "/etc/openstack_deploy/user_rpco_maas_variables.yml" ]]; then
@@ -65,5 +65,5 @@ pushd /opt/rpc-maas/playbooks
     fi
     # Run the rpc-maas setup process
     openstack-ansible site.yml
-  fi
-popd
+  popd
+fi


### PR DESCRIPTION
This removes the call to get-maas.yml.  Since we're decoupling MaaS this 
is no longer needed in the integrated build.

Issue: RI-356

Issue: [RI-356](https://rpc-openstack.atlassian.net/browse/RI-356)