### PR TITLE
Use local facts to retrieve and set release options

### DIFF
--- a/ansible-role-rocky-requirements.yml
+++ b/ansible-role-rocky-requirements.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, Rackspace US, Inc.
+# Copyright 2014-2017, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The release tag to use
-# Note that this is set here so that the openstack_release override in
-# "osa_defaults" is able to use it.
-rpc_release: "undefined"
-
-# TODO(evrardjp): Move this to group_vars/all/release.yml when possible
-#                 The release tag to use for the repo and venvs
-#                 This can't be overriden because OSA is using group_vars.
-openstack_release: "{{ rpc_release }}"
+# RPC-Support specific role
+- name: rcbops_openstack-ops
+  scm: git
+  src: https://github.com/rsoprivatecloud/openstack-ops
+  version: master

--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -208,6 +208,14 @@
         - { option: "rpc_product_release", value: "{{ rpc_product_release }}" }
         - { option: "rpc_product_bootstrapped", value: "{{ rpc_product_new_bootstrap }}" }
 
+    - name: Set the product release local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_product"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict: "{{ rpc_product_releases[rpc_product_release] }}"
+
   vars:
     ansible_python_interpreter: "/usr/bin/python"
     rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') | default('undefined', true) }}"

--- a/playbooks/get-maas.yml
+++ b/playbooks/get-maas.yml
@@ -19,20 +19,30 @@
   connection: local
   gather_facts: false
   tasks:
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
     - name: Clone RPC-MaaS
       git:
         repo: "https://github.com/rcbops/rpc-maas"
         dest: "/opt/rpc-maas"
-        version: "{{ maas_release }}"
+        version: "{{ ansible_local['rpc_openstack']['maas_release'] }}"
+
     - name: Stat /etc/openstack_deploy
       stat:
         path: "/etc/openstack_deploy"
       register: stat_openstack_deploy
+
     - name: Fail when /etc/openstack_deploy doesn't exist
       fail:
         msg: "/etc/openstack_deploy is required but doesn't exist"
       when:
         - not stat_openstack_deploy.stat.exists
+
     - name: Copy over base maas vars
       copy:
         src: "/opt/rpc-maas/tests/user_master_vars.yml"

--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -19,3 +19,7 @@ rpc_product_releases:
     maas_release: 1.7.4
     osa_release: d38e190e43dfb737e6684096084b9f98f89e0637
     rpc_release: r17.0.2
+  rocky:
+    maas_release: 1.7.5
+    osa_release: 9e72443b0d0a2e72f85419ae3aba94dee22f1436
+    rpc_release: r18.0.0


### PR DESCRIPTION
The local facts can be used to set and retrieve the release variables
without needing to have user intervention. This change sets all of the
release options and ensures that the get maas playbook uses these facts
during its execution.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>