### PR TITLE
Use local facts to retrieve and set release options

### DIFF
--- a/ansible-role-rocky-requirements.yml
+++ b/ansible-role-rocky-requirements.yml
@@ -1,3 +1,19 @@
+---
+# Copyright 2014-2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RPC-Support specific role
 - name: rcbops_openstack-ops
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops

--- a/etc/openstack_deploy/group_vars/all/release.yml
+++ b/etc/openstack_deploy/group_vars/all/release.yml
@@ -22,6 +22,3 @@ rpc_release: "undefined"
 #                 The release tag to use for the repo and venvs
 #                 This can't be overriden because OSA is using group_vars.
 openstack_release: "{{ rpc_release }}"
-
-# Set the release of the maas
-maas_release: "undefined"

--- a/playbooks/configure-release.yml
+++ b/playbooks/configure-release.yml
@@ -208,6 +208,14 @@
         - { option: "rpc_product_release", value: "{{ rpc_product_release }}" }
         - { option: "rpc_product_bootstrapped", value: "{{ rpc_product_new_bootstrap }}" }
 
+    - name: Set the product release local facts
+      ini_file:
+        dest: "/etc/ansible/facts.d/rpc_openstack.fact"
+        section: "rpc_product"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict: "{{ rpc_product_releases[rpc_product_release] }}"
+
   vars:
     ansible_python_interpreter: "/usr/bin/python"
     rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') | default('undefined', true) }}"

--- a/playbooks/get-maas.yml
+++ b/playbooks/get-maas.yml
@@ -19,20 +19,30 @@
   connection: local
   gather_facts: false
   tasks:
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
     - name: Clone RPC-MaaS
       git:
         repo: "https://github.com/rcbops/rpc-maas"
         dest: "/opt/rpc-maas"
-        version: "{{ maas_release }}"
+        version: "{{ ansible_local['rpc_openstack']['maas_release'] }}"
+
     - name: Stat /etc/openstack_deploy
       stat:
         path: "/etc/openstack_deploy"
       register: stat_openstack_deploy
+
     - name: Fail when /etc/openstack_deploy doesn't exist
       fail:
         msg: "/etc/openstack_deploy is required but doesn't exist"
       when:
         - not stat_openstack_deploy.stat.exists
+
     - name: Copy over base maas vars
       copy:
         src: "/opt/rpc-maas/tests/user_master_vars.yml"


### PR DESCRIPTION
The local facts can be used to set and retrieve the release variables
without needing to have user intervention. This change sets all of the
release options and ensures that the get maas playbook uses these facts
during its execution.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
(cherry picked from commit 952aee59dd430b7ed3919ce5df91f4b8a8edb7c0)