### PR TITLE
Update Octavia settings for Rocky

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -69,6 +69,8 @@ octavia_tls_listener_enabled: False
 octavia_loadbalancer_topology: ACTIVE_STANDBY
 octavia_spare_amphora_pool_size: 0
 octavia_enable_anti_affinity: "{{ lookup('env', 'DEPLOY_AIO') != 'yes' }}"
+# RPC disables connection logging, so setting this back to 2GB
+octavia_amp_disk: 2
 
 rackspace_octavia_files_folder: "/opt/rpc-openstack/playbooks/templates/octavia"
 octavia_user_haproxy_templates:
@@ -85,6 +87,9 @@ octavia_octavia_conf_overrides:
   haproxy_amphora:
     connection_max_retries: 120
     build_active_retries: 120
+    # RPC is disabling connection logging in the amphroa as they are not
+    # accessible anyway.
+    connection_logging: False
   keepalived_vrrp:
     vrrp_check_interval: 2
   # Wait for up to half an hour for nova to actually delete an instance and

--- a/playbooks/templates/octavia/base.j2
+++ b/playbooks/templates/octavia/base.j2
@@ -35,7 +35,11 @@ global
     {% endfor %}
 
 defaults
+    {% if connection_logging %}
+    log global
+    {% else %}
     no log
+    {% endif %}
     retries 3
     option redispatch
     option splice-request 


### PR DESCRIPTION
Rocky added native support for disabling connection logging. Upstream OSA
also increased the default image size to accomidate large connection logs.

RPC-O disables connection logging (it is not accessible in RPC-O anyway).
This patch updates the RPC-O configuration to use the native connection
logging setting and revert a previous custom change. It also sets the image
size back to 2GB as shipped for Queens.