### PR TITLE
RI-457 Add +u and -u around virtualenv activate

### DIFF
--- a/gating/check/pre_deploy.sh
+++ b/gating/check/pre_deploy.sh
@@ -67,7 +67,7 @@ fi
 # Work around https://github.com/pypa/virtualenv/issues/1029
 export VIRTUAL_ENV_DISABLE_PROMPT=true
 
-set +x; source .venv/bin/activate; set -x
+set +xu; source .venv/bin/activate; set -xu
 
 if [ -f ~/.pip/pip.conf ]; then
   mv ~/.pip/pip.conf ~/.pip/pip.conf.bak


### PR DESCRIPTION
There are issues with the legacy python-virtualenv package and
activating venvs. This adds +u before and -u after activating the venv.