### PR TITLE
ASC-954 Fix Broken ZigZag Install (Pike)

### DIFF
--- a/gating/check/post_send_junit_to_qtest.sh
+++ b/gating/check/post_send_junit_to_qtest.sh
@@ -8,6 +8,7 @@ set -x
 
 export QTEST_API_TOKEN=$RPC_ASC_QTEST_API_TOKEN
 VENV_NAME="venv-qtest"
+VENV_PATH="${WORKSPACE}/${VENV_NAME}"
 PROJECT_ID="76551"
 
 ## Functions -----------------------------------------------------------------
@@ -17,12 +18,12 @@ source $(dirname ${0})/../../scripts/functions.sh
 ## Main ----------------------------------------------------------------------
 
 # Create virtualenv for <TOOL NAME>
-virtualenv --no-wheel "${VENV_NAME}"
+virtualenv --no-wheel "${VENV_PATH}"
 
 # Activate virtualenv
-source "${VENV_NAME}/bin/activate"
+source "${VENV_PATH}/bin/activate"
 
-VENV_PIP="${VENV_NAME}/bin/pip"
+VENV_PIP="${VENV_PATH}/bin/pip"
 
 # Install zigzag from PyPI
 ${VENV_PIP} install rpc-zigzag


### PR DESCRIPTION
The interpreter directive became too long so now we need to install the venv
in a different location.

Cherry pick of #3240

Issue: [ASC-954](https://rpc-openstack.atlassian.net/browse/ASC-954)