### PR TITLE
[Rocky] RI-462 Remove openstack-ansible binary clean up

### DIFF
--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -167,7 +167,6 @@ ${MNAIO_SSH} <<EOC
   echo -e '---\nsecurity_sshd_client_alive_interval: 1200' | tee /etc/openstack_deploy/user_mnaio_long_hardening_timeout.yml
   chmod +x /opt/rpc-openstack/deploy-infra1.sh
   rm -rf /opt/openstack-ansible
-  rm /usr/local/bin/openstack-ansible
 EOC
 
 # start the rpc-o install from infra1


### PR DESCRIPTION
With the merge of https://review.openstack.org/#/c/600875/
RUN_OSA="false" now skips bootstrap and the OSA install
during MNAIO so that we only run bootstrap once RPC-O
install starts.

Previously bootstrap would run during MNAIO and we'd reset
it as part of the gating process so that RPC-O could install
it fresh.

Issue: [RI-462](https://rpc-openstack.atlassian.net/browse/RI-462)