### PR TITLE
Disable amphora image download from upstream

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -71,6 +71,8 @@ octavia_spare_amphora_pool_size: 0
 octavia_enable_anti_affinity: "{{ lookup('env', 'DEPLOY_AIO') != 'yes' }}"
 # RPC disables connection logging, so setting this back to 2GB
 octavia_amp_disk: 2
+# RPC doesn't use images from an artefact storage - so disable download
+octavia_download_artefact: False
 
 rackspace_octavia_files_folder: "/opt/rpc-openstack/playbooks/templates/octavia"
 octavia_user_haproxy_templates:

--- a/releasenotes/notes/disable_octavia_image_download-0d64f2dc019f7d0d.yaml
+++ b/releasenotes/notes/disable_octavia_image_download-0d64f2dc019f7d0d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    OS-octavia was downlaoding its amphora image from the upstream
+    daily master build - thus delaying the deploy for the duration
+    of the downlaod and potentially using untested octavia versions.
+    This patch deactivates the automatic download which might result
+    in the deployer ghaving to uplaod the octavia amphora image to
+    glance themselves.


### PR DESCRIPTION
This will disable the download, speed up deployment, and
prevent a deployment having the wrong amphora image version.