### PR TITLE
RI-469 Fix moving image & flavor setup to a different host

### DIFF
--- a/playbooks/openstack-flavor-setup.yml
+++ b/playbooks/openstack-flavor-setup.yml
@@ -28,6 +28,10 @@
       retries: 5
       delay: 2
 
+    - name: Create OpenStack client configuration
+      include_role:
+        name: "openstack_openrc"
+
     - name: Create flavors of nova VMs
       os_nova_flavor:
         endpoint_type: internal

--- a/playbooks/openstack-image-setup.yml
+++ b/playbooks/openstack-image-setup.yml
@@ -28,10 +28,14 @@
       retries: 5
       delay: 2
 
+    - name: Create OpenStack client configuration
+      include_role:
+        name: "openstack_openrc"
+
     - name: Download system image file
       get_url:
         url: "{{ item.url }}"
-        dest: "/var/backup/os_image_{{ item.name }}"
+        dest: "/var/tmp/os_image_{{ item.name }}"
         timeout: 1200
       with_items: "{{ openstack_images }}"
 
@@ -42,14 +46,14 @@
         state: present
         is_public: true
         name: "{{ item.name }}"
-        filename: "/var/backup/os_image_{{ item.name }}"
+        filename: "/var/tmp/os_image_{{ item.name }}"
         disk_format: "{{ item.format }}"
         properties: "{{ item.properties | default(omit) }}"
       with_items: "{{ openstack_images }}"
 
     - name: Clean up temp file
       file:
-        dest: "/var/backup/os_image_{{ item.name }}"
+        dest: "/var/tmp/os_image_{{ item.name }}"
         state: absent
       with_items: "{{ openstack_images }}"
 


### PR DESCRIPTION
Git commit 0001021e moved OpenStack image and flavor setup from the
first utility container to the deploy host, commonly the first infra
host, but overlooked a few requirements necessary in the different
environment.

* Don't reference non-existent cloud configuration.  The
  openstack_openrc role is applied to just about all deployed nodes,
  but not necessarily the deploy node itself.  Apply the
  openstack_openrc role to the deploy node.

    os_client_config.exceptions.OpenStackConfigException: Cloud
    default was not found.

* Don't cache cloud images to a non-existent directory.  /var/backup
  exists within containers (by way of lxc_container_create bind
  mounting from the host), but hosts, whether an infra or deploy host,
  are not guaranteed to have such a directory.  As this directory is
  not used for backups, but instead temporary image files, save it to
  a temporary directory, but not /tmp in case it's a RAM-backed
  filesystem because these image files are relatively large.

    Destination /var/backup does not exist

Issue: https://rpc-openstack.atlassian.net/browse/RI-469

Issue: [RI-469](https://rpc-openstack.atlassian.net/browse/RI-469)