### PR TITLE
[RI-481] Add yaml.h

### DIFF
--- a/gating/check/pre_deploy.sh
+++ b/gating/check/pre_deploy.sh
@@ -39,7 +39,7 @@ fi
 cd /opt/kibana-selenium
 
 # Install pre-requisites
-pkgs_to_install=""
+pkgs_to_install="libyaml-cpp-dev"
 # The phantomjs package on 16.04 is buggy, see:
 # https://github.com/ariya/phantomjs/issues/14900
 # https://bugs.launchpad.net/ubuntu/+source/phantomjs/+bug/1578444


### PR DESCRIPTION
The libyaml-cpp-dev package contains the yaml.h package required for 
kibana-selenium to compile correctly.

Issue: RI-481

Issue: [RI-481](https://rpc-openstack.atlassian.net/browse/RI-481)