### PR TITLE
RI-481 Add space to package name

### DIFF
--- a/gating/check/pre_deploy.sh
+++ b/gating/check/pre_deploy.sh
@@ -39,7 +39,7 @@ fi
 cd /opt/kibana-selenium
 
 # Install pre-requisites
-pkgs_to_install="libyaml-cpp-dev"
+pkgs_to_install="libyaml-cpp-dev "
 # The phantomjs package on 16.04 is buggy, see:
 # https://github.com/ariya/phantomjs/issues/14900
 # https://bugs.launchpad.net/ubuntu/+source/phantomjs/+bug/1578444


### PR DESCRIPTION
Adds a trailing space to the package name as it's interpolated as a 
concatenated string.

Issue: RI-481

Issue: [RI-481](https://rpc-openstack.atlassian.net/browse/RI-481)