### PR TITLE
Implement MNAIO post hook for saving VM images [rocky]

### DIFF
--- a/gating/check/post_deploy.sh
+++ b/gating/check/post_deploy.sh
@@ -96,3 +96,26 @@ if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
   echo "rpc-${RPC_RELEASE}-${RE_JOB_IMAGE}-${RE_JOB_SCENARIO}" > /gating/thaw/image_name
   echo "### END SNAPSHOT PREP ###"
 fi
+
+if [[ $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ ${RE_JOB_ACTION} == "deploy" ]]; then
+  echo "Preparing machine image artifacts."
+  pushd /opt/openstack-ansible-ops/multi-node-aio
+    ansible-playbook -vv -i ${MNAIO_INVENTORY:-"playbooks/inventory"} playbooks/save-vms.yml
+  popd
+
+  echo "Deleting unnecessary image files to prevent artifacting them."
+  find /data/images -name \*.img -not -name \*-base.img -delete
+
+  echo "Moving files to named folder for artifact upload."
+  mv /data/images /data/${RPC_RELEASE}-${RE_JOB_IMAGE}-${RE_JOB_SCENARIO}
+
+  echo "Preparing machine image artifact upload configuration."
+  cat > component_metadata.yml <<EOF
+"artifacts": [
+  {
+    "type": "file",
+    "source": "/data/${RPC_RELEASE}-${RE_JOB_IMAGE}-${RE_JOB_SCENARIO}"
+  }
+]
+EOF
+fi

--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -65,6 +65,7 @@ export RPC_BRANCH="${RE_JOB_BRANCH}"
 export DEFAULT_MIRROR_HOSTNAME=mirror.rackspace.com
 export DEFAULT_MIRROR_DIR=/ubuntu
 export INFRA_VM_SERVER_RAM=16384
+export MNAIO_ANSIBLE_PARAMETERS="-e default_vm_disk_mode=file"
 export DEPLOY_MAAS=false
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"


### PR DESCRIPTION
In order to be able to re-use MNAIO VM images for other
projects to reduce test times when using the MNAIO build
we implement a change to the MNAIO tooling to use a file
backing store for the VM's, the post hook to prepare them
for uploading, and the component_metadata.yml file to
upload them to Cloud Files using the standard RE hook for
uploading file artifacts.

JIRA: RE-1992
(cherry picked from commit 428966518197d28b6964cabf5c451fa1c19109e8)

Issue: [RE-1561](https://rpc-openstack.atlassian.net/browse/RE-1561)