### PR TITLE
Only prepare images if the run stage succeeded

### DIFF
--- a/gating/check/post_deploy.sh
+++ b/gating/check/post_deploy.sh
@@ -68,7 +68,7 @@ echo "#### END DSTAT CHART GENERATION ###"
 
 # Only enable snapshot when triggered by a commit push.
 # This is to enable image updates whenever a PR is merged, but not before
-if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
+if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]] && [[ ${RE_JOB_STATUS:-SUCCESS} == "SUCCESS" ]]; then
   echo "### BEGIN SNAPSHOT PREP ###"
   mkdir -p /gating/thaw
 
@@ -97,7 +97,7 @@ if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
   echo "### END SNAPSHOT PREP ###"
 fi
 
-if [[ $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ ${RE_JOB_ACTION} == "deploy" ]]; then
+if [[ ${RE_JOB_IMAGE} =~ .*mnaio.* ]] && [[ ${RE_JOB_ACTION} == "deploy" ]] && [[ "${RE_JOB_STATUS:-SUCCESS}" == "SUCCESS" ]]; then
   echo "Preparing machine image artifacts."
   pushd /opt/openstack-ansible-ops/multi-node-aio
     ansible-playbook -vv -i ${MNAIO_INVENTORY:-"playbooks/inventory"} playbooks/save-vms.yml


### PR DESCRIPTION
Currently the image preparation is always done, regardless of whether
the run stage succeeded or not. This change makes sure that the process
only happens if the job succeeded.

Issue: [RE-1989](https://rpc-openstack.atlassian.net/browse/RE-1989)