### PR TITLE
[RI-482] Fix newton pip

### DIFF
--- a/gating/check/pre_deploy.sh
+++ b/gating/check/pre_deploy.sh
@@ -71,6 +71,8 @@ if [[ ! -d ".venv" ]]; then
 fi
 
 # FrankZhang: Upgrade pip and setuptools due to outdate issue https://rpc-openstack.atlassian.net/browse/RI-458
+pip install --upgrade --force pip==9.0.1
+hash -d pip
 pip install --upgrade pip setuptools -c https://raw.githubusercontent.com/rcbops/openstack-ansible/stable/newton/global-requirement-pins.txt
 
 # Work around https://github.com/pypa/virtualenv/issues/1029


### PR DESCRIPTION
The existing version of pip doesn't support the -c option so we need to 
force upgrade the existing version of pip.  The hash command finds the 
new version of pip.

Issue: RI-482

Issue: [RI-482](https://rpc-openstack.atlassian.net/browse/RI-482)