### PR TITLE
Revert OSA SHA to known working version

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -13,7 +13,7 @@ rpc_product_releases:
     rpc_release: r15.0.0
   pike:
     maas_release: 1.7.7
-    osa_release: 159a70d0d7dc002c497f868c823555ae9baa9cd3
+    osa_release: d132911b92fa87c4dbd5ef5faf4880ce201a111e
     rpc_release: r16.2.5
   queens:
     maas_release: 1.7.4


### PR DESCRIPTION
A recent change [1] in OSA broke multi-node builds. There is a
fix proposed, but the gate times are really long, so it may not
merge in time for the next RPC-O release. Rather than delay our
release, we revert to a known good SHA.

[1] https://github.com/openstack/openstack-ansible/commit/83f0bdaeeb579666affeb46552a59c8cd4bd4434
[2] https://review.openstack.org/605518

Issue: [RI-483](https://rpc-openstack.atlassian.net/browse/RI-483)