### PR TITLE
Revert OSA SHA to known working version

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -21,5 +21,5 @@ rpc_product_releases:
     rpc_release: r17.0.2
   rocky:
     maas_release: 1.7.7
-    osa_release: b48e295c4c83d35de66ce99a5af7cf55292229d5
+    osa_release: 004c431b8c90caf6ec26441e876f686d7d58f357
     rpc_release: r18.0.0


### PR DESCRIPTION
A recent change [1] in OSA broke multi-node builds. There is a
fix proposed, but the gate times are really long, so it may not
merge in time for the next RPC-O release. Rather than delay our
release, we revert to a known good SHA.

[1] https://github.com/openstack/openstack-ansible/commit/6745b3727f70d609895e18ce15caa367e481265b
[2] https://review.openstack.org/605504

JIRA: RI-484

Issue: [RI-484](https://rpc-openstack.atlassian.net/browse/RI-484)