### PR TITLE
Allow unbound variables for virtualenv activation

### DIFF
--- a/gating/check/run_deploy.sh
+++ b/gating/check/run_deploy.sh
@@ -2,7 +2,7 @@
 
 ## Shell Opts ----------------------------------------------------------------
 
-set -euv
+set -eux
 set -o pipefail
 
 ## Vars ----------------------------------------------------------------------
@@ -78,7 +78,7 @@ cd /opt/kibana-selenium
 # Work around https://github.com/pypa/virtualenv/issues/1029
 export VIRTUAL_ENV_DISABLE_PROMPT=true
 
-set +x; source .venv/bin/activate; set -x
+set +ux; source .venv/bin/activate; set -ux
 
 export PYTHONPATH=$(pwd)
 export PATH=$PATH:./phantomjs-2.1.1-linux-x86_64/bin

--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -16,7 +16,7 @@
 
 ## Shell Opts ----------------------------------------------------------------
 
-set -evu
+set -eux
 
 echo "Building a Multi Node AIO (MNAIO)"
 echo "+-------------------- MNAIO ENV VARS --------------------+"


### PR DESCRIPTION
Enabling unbound variables appears to be required for
virtualenv activation. We also remove the verbose output
because it makes the output really difficult to read
because it shows the enture script. Instead we enable
debug output, as is done in most other scripts, because
it shows the commands run instead which is more useful.

Issue: [RI-492](https://rpc-openstack.atlassian.net/browse/RI-492)