### PR TITLE
Reduce confusing output from system test script

### DIFF
--- a/gating/check/run_system_tests.sh
+++ b/gating/check/run_system_tests.sh
@@ -17,7 +17,6 @@ SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
 SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
 SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
 SYS_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
-export SYS_INVENTORY="/opt/openstack-ansible/playbooks/inventory"
 
 # Switch system test branch to `dev` on the experimental-asc job.
 # This job is specifically for running system tests under development.
@@ -30,7 +29,7 @@ fi
 # 1. Clone test repository into working directory.
 pushd "${SYS_WORKING_DIR}"
 git clone "${SYS_TEST_SOURCE_REPO}"
-pushd "${SYS_TEST_SOURCE}"
+cd "${SYS_TEST_SOURCE}"
 
 # Checkout defined branch
 git checkout "${SYS_TEST_BRANCH}"
@@ -47,18 +46,17 @@ set +e
 ./execute_tests.sh
 [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
 
-# 3. Collect results from script
+# 3. Collect results from script, if they exist
 mkdir -p "${RE_HOOK_RESULT_DIR}" || true  # ensure that result directory exists
-tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
-# record non-zero exit code if not already recorded
-[[ $? -ne 0 ]] && [[ ! -z ${RC+x} ]] && RC=$?
+if [[ -e test_results.tar ]]; then
+  tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
+fi
 
-# 4. Collect logs from script
+# 4. Collect logs from script, if they exist
 mkdir -p "${RE_HOOK_ARTIFACT_DIR}" || true  # ensure that artifact directory exists
-cp test_results.tar "${RE_HOOK_ARTIFACT_DIR}/molecule_test_results.tar"
-# Molecule does not produce logs outside of STDOUT
-# record non-zero exit code if not already recorded
-[[ $? -ne 0 ]] && [[ ! -z ${RC+x} ]] && RC=$?
+if [[ -e test_results.tar ]]; then
+  cp test_results.tar "${RE_HOOK_ARTIFACT_DIR}/molecule_test_results.tar"
+fi
 popd
 
 # if exit code is recorded, use it, otherwise let it exit naturally


### PR DESCRIPTION
1. The SYS_INVENTORY environment variable is not used in
   this script, but only in the script being called. It
   is already defined in that script, so we remove it from
   here to remove having to manage it in two places.
2. We now only do the test result extraction if they exist.
3. We only artifact the test results if they exist.
4. The return code for the system tests should only come
   from the execute_tests.sh script, so we remove the
   return code setting in the artifacting steps as they're
   no longer necessary given the conditional extraction/copy.


Issue: [RE-2030](https://rpc-openstack.atlassian.net/browse/RE-2030)