### PR TITLE
Implement MNAIO post hook for saving VM images [newton]

### DIFF
--- a/gating/check/post_deploy.sh
+++ b/gating/check/post_deploy.sh
@@ -45,7 +45,7 @@ extract_rpc_release(){
 
 # Only enable snapshot when triggered by a commit push.
 # This is to enable image updates whenever a PR is merged, but not before
-if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
+if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]] && [[ ${RE_JOB_STATUS:-SUCCESS} == "SUCCESS" ]]; then
   echo "### BEGIN SNAPSHOT PREP ###"
   mkdir -p /gating/thaw
 
@@ -76,7 +76,7 @@ if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]]; then
   echo "### END SNAPSHOT PREP ###"
 fi
 
-if [[ $RE_JOB_IMAGE =~ .*mnaio.* ]] && [[ ${RE_JOB_ACTION} == "deploy" ]]; then
+if [[ ${RE_JOB_IMAGE} =~ .*mnaio.* ]] && [[ ${RE_JOB_ACTION} == "deploy" ]] && [[ "${RE_JOB_STATUS:-SUCCESS}" == "SUCCESS" ]]; then
   echo "Preparing machine image artifacts."
   pushd /opt/openstack-ansible-ops/multi-node-aio
     ansible-playbook -vv -i ${MNAIO_INVENTORY:-"playbooks/inventory"} playbooks/save-vms.yml

--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -68,6 +68,7 @@ export RPC_BRANCH="${RE_JOB_BRANCH}"
 export DEFAULT_MIRROR_HOSTNAME=mirror.rackspace.com
 export DEFAULT_MIRROR_DIR=/ubuntu
 export INFRA_VM_SERVER_RAM=16384
+export MNAIO_ANSIBLE_PARAMETERS="-e default_vm_disk_mode=file"
 export OSA_REPO="https://github.com/rcbops/openstack-ansible.git"
 
 # ssh command used to execute tests on infra1


### PR DESCRIPTION
In order to be able to re-use MNAIO VM images for other
projects to reduce test times when using the MNAIO build
we implement a change to the MNAIO tooling to use a file
backing store for the VM's, the post hook to prepare them
for uploading, and the component_metadata.yml file to
upload them to Cloud Files using the standard RE hook for
uploading file artifacts.

Issue: [RE-1995](https://rpc-openstack.atlassian.net/browse/RE-1995)

Issue: [RE-1989](https://rpc-openstack.atlassian.net/browse/RE-1989)