### PR TITLE
Include OSA changes for get-pip.py pin

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -41,4 +41,4 @@
 - name: pip_install
   scm: git
   src: https://github.com/rcbops/openstack-ansible-pip_install
-  version: ed68b924b8f54e9c45fb068ef27efe6367ccc48d
+  version: 2480ab547e22f5b0a0bb27a1abce561a7832ec96


### PR DESCRIPTION
This PR pulls in the following changes:

pip_install:
1. https://github.com/rcbops/openstack-ansible-pip_install/commit/323c8ac2c3e0154cfcd86f16bdc75b8c37faac74
2. https://github.com/rcbops/openstack-ansible-pip_install/commit/3718023244c857c4aeb58aacb15d2d795804f055
3. https://github.com/rcbops/openstack-ansible-pip_install/commit/2480ab547e22f5b0a0bb27a1abce561a7832ec96

openstack-ansible:
1. https://github.com/rcbops/openstack-ansible/commit/78e6727d48ee2749e67bc02e8e4ea905019b73ff
2. https://github.com/rcbops/openstack-ansible/commit/0086696141a68ba19f3bfb628112324c312b947c
3. https://github.com/rcbops/openstack-ansible/commit/b898adb9aafd5bff3856a5a667e5972b9cd7d0d3

JIRA: RI-504

Issue: [RI-504](https://rpc-openstack.atlassian.net/browse/RI-504)