### PR TITLE
ASC-1042 Enable multiple system actions (#3318)

### DIFF
--- a/gating/check/post
+++ b/gating/check/post
@@ -15,6 +15,6 @@ if [ $RE_JOB_ACTION != "tox-test" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_deploy.sh)"
 fi
 
-if [ $RE_JOB_ACTION == "system" ]; then
+if [ $RE_JOB_ACTION == system* ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi

--- a/gating/check/run
+++ b/gating/check/run
@@ -29,6 +29,6 @@ else
   bash -c "$(readlink -f $(dirname ${0})/../../scripts/deploy.sh)"
 fi
 
-if [[ $RE_JOB_ACTION == "system" ]]; then
+if [[ $RE_JOB_ACTION == system* ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
 fi


### PR DESCRIPTION
This commit modifies the match for the 'system' gating action. Any
action that begins with the string 'system' will be matched. This is
done to allow multiple variants of the system action to be defined in CI
in order to segment jobs.

(cherry picked from commit 065a7c350a27ca51ccaf0807a9e34ea5cddec11e)

Issue: [ASC-1042](https://rpc-openstack.atlassian.net/browse/ASC-1042)