### PR TITLE
ASC-1042 Enable multiple system actions (#3318)

### DIFF
--- a/gating/check/post
+++ b/gating/check/post
@@ -11,6 +11,6 @@ if [ $RE_JOB_ACTION != "tox-test" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_deploy.sh)"
 fi
 
-if [ $RE_JOB_ACTION == "system" ]; then
+if [ $RE_JOB_ACTION == system* ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi

--- a/gating/check/run
+++ b/gating/check/run
@@ -38,6 +38,7 @@ elif [[ $RE_JOB_IMAGE =~ .*mnaio.* ]]; then
 else
   bash -c "$(readlink -f $(dirname ${0})/run_deploy.sh)"
 fi
-if [[ $RE_JOB_ACTION == "system" ]]; then
+
+if [[ $RE_JOB_ACTION == system* ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
 fi


### PR DESCRIPTION
This commit modifies the match for the 'system' gating action. Any
action that begins with the string 'system' will be matched. This is
done to allow multiple variants of the system action to be defined in CI
in order to segment jobs.

(cherry picked from commit 065a7c350a27ca51ccaf0807a9e34ea5cddec11e)

The following conflict was resolved while committing this cherry pick:
```
41 <<<<<<< HEAD
42 if [[ $RE_JOB_ACTION == "system" ]]; then
43 =======
44
45 if [[ $RE_JOB_ACTION == system* ]]; then
46 >>>>>>> 065a7c35... ASC-1042 Enable multiple system actions (#3318)
```

Issue: [ASC-1042](https://rpc-openstack.atlassian.net/browse/ASC-1042)