### PR TITLE
Remove machinectl container back-end usage

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -136,9 +136,7 @@ haproxy_extra_services:
 # Define the distro version globally
 repo_build_os_distro_version: "{{ (ansible_distribution | lower) | replace(' ', '_') }}-{{ ansible_distribution_version.split('.')[:2] | join('.') }}-{{ ansible_architecture | lower }}"
 
-lxc_container_backing_store: machinectl
-
 # NOTE(cloudnull): Ensure that the ceph client is always present and not "latest".
-#                  This is being done to ensure that the VMs created using RBD 
+#                  This is being done to ensure that the VMs created using RBD
 #                  are not terminated on client upgrades.
 ceph_client_package_state: "present"


### PR DESCRIPTION
In [1] we switched to using the machinectl back-end, but
this back-end is not yet working properly for Bionic/LXC3.

Rather than wait for upstream fixes, we can switch back to
using the defaults.

[1] f9b5202318fa0ac29d2f3f3ca923911c1fd6cc3e

Issue: [RI-352](https://rpc-openstack.atlassian.net/browse/RI-352)