### PR TITLE
Artifact MNAIO image download logs

### DIFF
--- a/gating/check/pre_deploy_mnaio.sh
+++ b/gating/check/pre_deploy_mnaio.sh
@@ -22,6 +22,8 @@ echo "Preparing a Multi Node AIO (MNAIO)"
 
 ## Vars and Functions --------------------------------------------------------
 
+source "$(readlink -f $(dirname ${0}))/../gating_vars.sh"
+
 source /opt/rpc-openstack/scripts/functions.sh
 
 source "$(readlink -f $(dirname ${0}))/../mnaio_vars.sh"
@@ -58,7 +60,7 @@ pushd /opt/openstack-ansible-ops/multi-node-aio
   # then we need to download the images, then create the VM's. The conditional
   # was already evaluated in mnaio_vars, so we key off DEPLOY_VMS here.
   if [[ "${DEPLOY_VMS}" == "false" ]]; then
-    run_mnaio_playbook playbooks/download-vms.yml -e manifest_url=${RPCO_IMAGE_MANIFEST_URL}
+    run_mnaio_playbook playbooks/download-vms.yml -e manifest_url=${RPCO_IMAGE_MANIFEST_URL} -e aria2c_log_path=${RE_HOOK_ARTIFACT_DIR}
     run_mnaio_playbook playbooks/deploy-vms.yml
   fi
 popd


### PR DESCRIPTION
In this patch we ensure that the download logs for MNAIO images
are stored along with the other job artifacts so that we can easily
review them to determine any issues which arose causing the download
to fail.

JIRA: RE-2072
(cherry picked from commit 3e10bc78177701dd090d683dd4bf6be59cf0d422)

Issue: [RE-2072](https://rpc-openstack.atlassian.net/browse/RE-2072)