### PR TITLE
[RI-355] update reno version and add earliest_version to config

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,3 +1,7 @@
 ---
+## TODO(odyssey4me):
+## Whenever master is branched, this must be enabled
+## and modified to include the first tag on the branch.
+#earliest_version: rx.y.z
 release_tag_re: '^r\d+\.\d+\.\d+(rc\d+)?'
 pre_release_tag_re: '(?P<pre_release>rc\d+$)'

--- a/releasenotes/source/master.rst
+++ b/releasenotes/source/master.rst
@@ -3,4 +3,3 @@ Current Series Release Notes
 ============================
 
 .. release-notes:: Release Notes
-    :branch: origin/master

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,8 @@ extensions = .rst
 
 
 [testenv:releasenotes]
+install_command =
+    pip install -c {toxinidir}/upper-constraints.txt {opts} {packages} --isolated
 commands =
     sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
 

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -15,7 +15,7 @@ MarkupSafe===1.0
 doc8===0.8.0
 traceback2===1.4.0
 extras===1.0.0
-reno===2.11.0
+reno===2.11.2
 imagesize===1.1.0
 rpc-differ===0.3.9
 urllib3===1.23


### PR DESCRIPTION
In order to get reno to work properly for pike, it needs to be passed
the earliest_version flag to ensure it traverses the release history
correctly. We set that flag in the reno config here.

Additionally:

- we update the version of reno so that it parses the
  config file correctly to pick up the flag.
- we remove the config for the sphinx reno extension that was forcing
  it to parse the master branch
- we add a copy of the install_command to the releasenotes tox test to
  skip the upper constraints (which was forcing reno==2.5.0 to be
installed)

Issue: RI-355
(cherry picked from commit fa6e31c2eb9964db839cd20b04078cc11d8c1343)

Issue: [RI-355](https://rpc-openstack.atlassian.net/browse/RI-355)