### PR TITLE
[RI-355] update reno version and add earliest_version to config

### DIFF
--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -10,7 +10,7 @@ export REPO_URL=${RE_HOOK_REPO_HTTP_URL}
 
 apt-get install -y pandoc
 
-pip install osa_differ==0.3.9 rpc_differ==0.3.9 reno==2.5.1
+pip install osa_differ==0.3.9 rpc_differ==0.3.9 reno==2.11.2
 
 gating/generate_release_notes/generate_release_notes.sh
 

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,3 +1,4 @@
 ---
+earliest_version: r17.1.1
 release_tag_re: '^r\d+\.\d+\.\d+(rc\d+)?'
 pre_release_tag_re: '(?P<pre_release>rc\d+$)'

--- a/releasenotes/source/master.rst
+++ b/releasenotes/source/master.rst
@@ -3,4 +3,3 @@ Current Series Release Notes
 ============================
 
 .. release-notes:: Release Notes
-    :branch: origin/master

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,8 @@ extensions = .rst
 
 
 [testenv:releasenotes]
+install_command =
+    pip install {opts} {packages} --isolated
 commands =
     sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
 


### PR DESCRIPTION
In order to get reno to work properly for pike, it needs to be passed
the earliest_version flag to ensure it traverses the release history
correctly. We set that flag in the reno config here.

Additionally:

- we update the version of reno so that it parses the
  config file correctly to pick up the flag.
- we remove the config for the sphinx reno extension that was forcing
  it to parse the master branch
- we add a copy of the install_command to the releasenotes tox test to
  skip the upper constraints (which was forcing reno==2.5.0 to be
installed)

Issue: RI-355
(cherry picked from commit fa6e31c2eb9964db839cd20b04078cc11d8c1343)

Issue: [RI-355](https://rpc-openstack.atlassian.net/browse/RI-355)