### PR TITLE
Remove non-existing nspawn playbook execution

### DIFF
--- a/playbooks/elk-deployment.yml
+++ b/playbooks/elk-deployment.yml
@@ -84,7 +84,7 @@
       become: yes
       become_user: root
       command: >-
-        openstack-ansible containers-nspawn-create.yml containers-lxc-create.yml --limit lxc_hosts:elk_all
+        openstack-ansible containers-lxc-create.yml --limit lxc_hosts:elk_all
       args:
         chdir: "/opt/openstack-ansible/playbooks"
       tags:


### PR DESCRIPTION
The nspawn-container-create playbook does not exist in Queens.

Issue: [RI-507](https://rpc-openstack.atlassian.net/browse/RI-507)