### PR TITLE
Add CPU govenor setup playbook

### DIFF
--- a/playbooks/ops-cpu-govenor-setup.yml
+++ b/playbooks/ops-cpu-govenor-setup.yml
@@ -1,0 +1,87 @@
+---
+# Copyright 2018-Present, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Configure Linux CPU governor
+  hosts: hosts:mons:osds
+  vars:
+    governor: "{{ cpu_governor | default('performance') }}"
+  handlers:
+    - name: restart sysfs
+      systemd:
+        name: sysfsutils
+        enabled: yes
+        state: restarted
+  tasks:
+    - name: Check for cpuidle
+      stat:
+        path: /sys/devices/system/cpu/cpu0/cpuidle
+      register: cpuidle_check
+
+    - name: Check for governor
+      stat:
+        path: /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+      register: scaling_governor_check
+
+    - name: setup cpu_scaling_governor
+      block:
+        - name: Disable ondemand service
+          systemd:
+            name: ondemand
+            state: stopped
+            masked: yes
+            enabled: no
+          failed_when: false
+
+        - name: Disable cpufrequtils service
+          systemd:
+            name: cpufrequtils
+            state: stopped
+            enabled: no
+            masked: yes
+          failed_when: false
+
+        - name: Find cpus scaling governor
+          shell: ls -1 /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor
+          changed_when: false
+          register: cpus_scaling_governor
+
+        - name: Persist cpus scaling governor
+          lineinfile:
+            dest: "/etc/sysfs.conf"
+            line: "{{ item.lstrip('/sys/') }} = {{ governor }}"
+            regexp: "^{{ item.lstrip('/sys/') }}.*"
+          with_items: "{{ cpus_scaling_governor.stdout_lines }}"
+          notify:
+            - restart sysfs
+      when:
+        - scaling_governor_check.stat.exists
+
+    - name: setup cpuidle
+      block:
+        - name: Find cpus cpuidle
+          shell: ls -1 /sys/devices/system/cpu/cpu*/cpuidle/state[2-4]/disable
+          changed_when: false
+          register: cpus_cpuidle
+
+        - name: Persist cpus scaling governor
+          lineinfile:
+            dest: "/etc/sysfs.conf"
+            line: "{{ item.lstrip('/sys/') }} = 1"
+            regexp: "^{{ item.lstrip('/sys/') }}.*"
+          with_items: "{{ cpus_cpuidle.stdout_lines }}"
+          notify:
+            - restart sysfs
+      when:
+        - cpuidle_check.stat.exists

--- a/playbooks/site-ops.yml
+++ b/playbooks/site-ops.yml
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: site-release.yml
-- include: site-openstack.yml
-- include: site-ops.yml
+- include: ops-cpu-govenor-setup.yml

--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -6,26 +6,26 @@ rpc_product_releases:
     rpc_release: master
   newton:
     maas_release: 1.7.0
-    openstack_ansible_ops: 9237bc3abe039a748cd2502bd67de02b648b030e
+    openstack_ansible_ops: master
     osa_release: 3553c048188093c7a8d912cc32c30730536d70d3
     rpc_release: r14.8.0
   ocata:
     maas_release: 1.7.0
-    openstack_ansible_ops: 9237bc3abe039a748cd2502bd67de02b648b030e
+    openstack_ansible_ops: master
     osa_release: 5047124f1fe181306674c60beeccd189252a9d62
     rpc_release: r15.0.0
   pike:
     maas_release: 1.7.0
-    openstack_ansible_ops: 9237bc3abe039a748cd2502bd67de02b648b030e
+    openstack_ansible_ops: master
     osa_release: 5c341a7bada78edab5f3d132d55adb00eaf2413f
     rpc_release: r16.2.0
   queens:
     maas_release: 1.7.4
-    openstack_ansible_ops: 9237bc3abe039a748cd2502bd67de02b648b030e
+    openstack_ansible_ops: master
     osa_release: d38e190e43dfb737e6684096084b9f98f89e0637
     rpc_release: r17.0.2
   rocky:
     maas_release: 1.7.5
-    openstack_ansible_ops: 9237bc3abe039a748cd2502bd67de02b648b030e
+    openstack_ansible_ops: master
     osa_release: 9e72443b0d0a2e72f85419ae3aba94dee22f1436
     rpc_release: r18.0.0

--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -46,6 +46,9 @@ pushd "${SCRIPT_PATH}/../playbooks"
   else
     openstack-ansible site-openstack.yml
   fi
+
+  # Deploy RPC operational modifications
+  openstack-ansible site-ops.yml
 popd
 
 if [ "${DEPLOY_MAAS}" != false ]; then


### PR DESCRIPTION
The CPU govenor setup was being done by request post installation. This
change simply makes this operational tuning part of our standard
deployment.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>