### PR TITLE
Only run ELK stack when the job 'action' = 'elk'

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -32,3 +32,7 @@ fi
 if [[ $RE_JOB_ACTION == system* ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
 fi
+
+if [[ ${RE_JOB_ACTION} == "elk" ]]; then
+  bash -c "$(readlink -f $(dirname ${0})/run_elk_tests.sh)"
+fi

--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -61,13 +61,6 @@ fi
 
 ## Main --------------------------------------------------------------------
 
-# capture all RE_ variables
-> /opt/rpc-openstack/RE_ENV
-env | grep RE_ | while read -r match; do
-  varName=$(echo ${match} | cut -d= -f1)
-  echo "export ${varName}='${!varName}'" >> /opt/rpc-openstack/RE_ENV
-done
-
 echo "Multi Node AIO setup completed..."
 
 # capture all RE_ variables for push to infra1

--- a/gating/check/run_elk_tests.sh
+++ b/gating/check/run_elk_tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -exu
+
+echo "Installing the ELK stack on a RPC-O Multi Node AIO (MNAIO)"
+
+## Vars and Functions --------------------------------------------------------
+
+source "$(readlink -f $(dirname ${0}))/../gating_vars.sh"
+
+source /opt/rpc-openstack/scripts/functions.sh
+
+source "$(readlink -f $(dirname ${0}))/../mnaio_vars.sh"
+
+## Main --------------------------------------------------------------------
+
+${MNAIO_SSH} <<EOS
+  cd /opt/rpc-openstack
+  openstack-ansible playbooks/elk-deployment.yml
+EOS

--- a/playbooks/elk-deployment.yml
+++ b/playbooks/elk-deployment.yml
@@ -84,7 +84,7 @@
       become: yes
       become_user: root
       command: >-
-        openstack-ansible containers-nspawn-create.yml containers-lxc-create.yml --limit lxc_hosts:elk_all
+        openstack-ansible containers-lxc-create.yml --limit lxc_hosts:elk_all
       args:
         chdir: "/opt/openstack-ansible/playbooks"
       tags:


### PR DESCRIPTION
Rather than always gate everything together, we split out
the ELK stack execution into its own action so that it can
be tested using MNAIO images. This also keeps the images
smaller.

JIRA: RI-263
(cherry picked from commit a5849b19fdd0d4ae7148d7a07394a122c52274d5)

Issue: [RI-263](https://rpc-openstack.atlassian.net/browse/RI-263)