### PR TITLE
Only run ELK stack when the job 'action' = 'elk'

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -39,3 +39,7 @@ if [[ $RE_JOB_ACTION == "sdqc" ]]; then
   export RE_JOB_BRANCH="openstack-ops-only"
   bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
 fi
+
+if [[ ${RE_JOB_ACTION} == "elk" ]]; then
+  bash -c "$(readlink -f $(dirname ${0})/run_elk_tests.sh)"
+fi

--- a/gating/check/run_deploy_mnaio.sh
+++ b/gating/check/run_deploy_mnaio.sh
@@ -128,13 +128,6 @@ EOC
 # start the rpc-o install from infra1
 ${MNAIO_SSH} "/opt/rpc-openstack/deploy-infra1.sh"
 
-if [[ "${GATE_ELK}" == "true" ]]; then
-  ${MNAIO_SSH} <<EOS
-    cd /opt/rpc-openstack
-    openstack-ansible playbooks/elk-deployment.yml
-EOS
-fi
-
 echo "MNAIO RPC-O deploy completed..."
 
 if [[ ${RE_JOB_ACTION} == "deploy" ]]; then

--- a/gating/check/run_elk_tests.sh
+++ b/gating/check/run_elk_tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -exu
+
+echo "Installing the ELK stack on a RPC-O Multi Node AIO (MNAIO)"
+
+## Vars and Functions --------------------------------------------------------
+
+source "$(readlink -f $(dirname ${0}))/../gating_vars.sh"
+
+source /opt/rpc-openstack/scripts/functions.sh
+
+source "$(readlink -f $(dirname ${0}))/../mnaio_vars.sh"
+
+## Main --------------------------------------------------------------------
+
+${MNAIO_SSH} <<EOS
+  cd /opt/rpc-openstack
+  openstack-ansible playbooks/elk-deployment.yml
+EOS

--- a/gating/mnaio_vars.sh
+++ b/gating/mnaio_vars.sh
@@ -56,7 +56,6 @@ fi
 #
 export RPC_BRANCH="${RE_JOB_BRANCH}"
 export DEPLOY_MAAS=false
-export GATE_ELK=true
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"


### PR DESCRIPTION
Rather than always gate everything together, we split out
the ELK stack execution into its own action so that it can
be tested using MNAIO images. This also keeps the images
smaller.

JIRA: RI-263
(cherry picked from commit a5849b19fdd0d4ae7148d7a07394a122c52274d5)