### PR TITLE
ASC-1042 Fix system condition in post gating

### DIFF
--- a/gating/check/post
+++ b/gating/check/post
@@ -15,6 +15,6 @@ if [ $RE_JOB_ACTION != "tox-test" ]; then
   bash -c "$(readlink -f $(dirname ${0})/post_deploy.sh)"
 fi
 
-if [ $RE_JOB_ACTION == system* ]; then
+if [[ ${RE_JOB_ACTION} == system* ]]; then
   bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
 fi


### PR DESCRIPTION
This commit fixes a bug in the condition to match RE_JOB_ACTION values
beginning with the string 'system'. This conditional requires bash
double brackets in order to perform pattern matching the wild card at the
end of the conditional.

(cherry picked from commit f0128016d58d21835db17547290ff171bff26039)

The following conflict was resolved while committing this cherry pick:
```
<<<<<<< HEAD
if [ $RE_JOB_ACTION == system* ]; then
=======
if [[ ${RE_JOB_ACTION} == system* ]]; then
>>>>>>> f0128016... ASC-1042 Fix system condition in post gating
```

Issue: [ASC-1042](https://rpc-openstack.atlassian.net/browse/ASC-1042)