### PR TITLE
ASC-1072 Source functions for system-tests gating

### DIFF
--- a/gating/check/run_system_tests.sh
+++ b/gating/check/run_system_tests.sh
@@ -9,6 +9,12 @@ set -o pipefail
 
 ## Variables -----------------------------------------------------------------
 
+# The RPC_PRODUCT_RELEASE and RPC_RELEASE need to be brought into scope
+# before running system tests.
+if [[ ${RE_JOB_IMAGE} =~ .*mnaio.* ]]; then
+  source /opt/rpc-openstack/scripts/functions.sh
+fi
+
 RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 SYS_WORKING_DIR=$(mktemp  -d -t system_test_workingdir.XXXXXXXX)


### PR DESCRIPTION
This commit adds the sourcing of the functions.sh script in order to
ensure that the RPC_RELEASE and RPC_PRODUCT_RELEASE environment
variables are set prior to the execution of any system-tests for gating.

(cherry picked from commit 7d82da8f3c7dd09c5419223af9961ac470bd73f4)

Issue: [ASC-1072](https://rpc-openstack.atlassian.net/browse/ASC-1072)