### PR TITLE
Add osquery to the standard rpco deployment

### DIFF
--- a/etc/openstack_deploy/env.d/fleet.yml
+++ b/etc/openstack_deploy/env.d/fleet.yml
@@ -1,0 +1,28 @@
+---
+component_skel:
+  kolide-fleet:
+    belongs_to:
+      - fleet_all
+      - kolide-fleet_all
+
+  mariadb:
+    belongs_to:
+      - fleet_all
+      - mariadb_all
+
+container_skel:
+  kolide-fleet_container:
+    belongs_to:
+      - kolide_containers
+    contains:
+      - kolide-fleet
+      - mariadb
+
+physical_skel:
+  kolide_containers:
+    belongs_to:
+      - all_containers
+
+  kolide_hosts:
+    belongs_to:
+      - hosts

--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -132,7 +132,9 @@ haproxy_extra_services:
       haproxy_ssl: True
       haproxy_port: 8443
       haproxy_backend_port: 81
-      haproxy_balance_type: tcp
+      haproxy_balance_type: http
+      haproxy_backend_options:
+        - "httpchk"
   - service:
       haproxy_service_name: appformix
       haproxy_backend_nodes: "{{ groups['log_hosts'] }}"
@@ -141,6 +143,14 @@ haproxy_extra_services:
       haproxy_balance_type: http
       haproxy_backend_options:
         - "httpchk"
+  - service:
+      haproxy_service_name: kolide-fleet
+      haproxy_ssl: False
+      haproxy_backend_nodes: "{{ groups['fleet_all'] | default([]) }}"
+      haproxy_port: 6443
+      haproxy_check_port: 443
+      haproxy_backend_port: 443
+      haproxy_balance_type: tcp
 
 # Define the distro version globally
 repo_build_os_distro_version: "{{ (ansible_distribution | lower) | replace(' ', '_') }}-{{ ansible_distribution_version.split('.')[:2] | join('.') }}-{{ ansible_architecture | lower }}"

--- a/playbooks/deployment-elk.yml
+++ b/playbooks/deployment-elk.yml
@@ -13,29 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Clone openstack-ansible-ops
-  hosts: localhost
-  environment: "{{ deployment_environment_variables | default({}) }}"
-  connection: local
-  gather_facts: false
-  tasks:
-    - name: Refresh local facts
-      setup:
-        filter: ansible_local
-        gather_subset: "!all"
-      tags:
-        - always
-
-    - name: Clone RPC-MaaS
-      git:
-        repo: "https://github.com/openstack/openstack-ansible-ops"
-        dest: "/opt/openstack-ansible-ops"
-        version: "{{ ansible_local['rpc_openstack']['rpc_product']['openstack_ansible_ops'] }}"
-  tags:
-    - elk
-    - elk-get
-
-
 - name: Bootstrap embedded ansible
   hosts: localhost
   environment: "{{ deployment_environment_variables | default({}) }}"
@@ -89,11 +66,14 @@
         chdir: "/opt/openstack-ansible/playbooks"
       tags:
         - skip_ansible_lint
+      environment:
+        ANSIBLE_LOG_PATH: "/var/log/ansible-elk-beats-deployment.log"
 
     - name: Find secrets files
       find:
         paths: "/etc/openstack_deploy"
-        patterns: 'user*secret*.yml'
+        patterns: 'user_.*(secret|elk|aio).*.(yml|yaml)$'
+        use_regex: yes
       register: secrets_files
 
     - name: Run elk+beat(s) deployment

--- a/playbooks/deployment-osquery.yml
+++ b/playbooks/deployment-osquery.yml
@@ -1,0 +1,130 @@
+---
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Bootstrap embedded ansible
+  hosts: localhost
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  connection: local
+  gather_facts: true
+  tasks:
+    - name: Run bootstrap process
+      command: "/opt/openstack-ansible-ops/elk_metrics_6x/bootstrap-embedded-ansible.sh"
+      changed_when: false
+
+    - name: Create kolide-fleet groups
+      copy:
+        content: |
+          ---
+          # Fleet hosts
+          kolide_hosts:
+          {% for item in groups['log_hosts'] %}
+            {{ item }}:
+              ip: {{ hostvars[item]['ansible_host'] }}
+          {% endfor %}
+        dest: "/etc/openstack_deploy/conf.d/fleet.yml"
+
+    - name: Reload inventory
+      command: "ansible -m ping localhost"
+      changed_when: false
+      args:
+        chdir: "/opt/openstack-ansible/playbooks"
+  tags:
+    - fleet
+    - fleet-bootstrap
+
+
+- name: Run kolide-fleet deployment
+  hosts: localhost
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  connection: local
+  gather_facts: true
+  tasks:
+    - name: Create kolide-fleet container(s)
+      become: yes
+      become_user: root
+      command: >-
+        openstack-ansible containers-lxc-create.yml --limit lxc_hosts:fleet_all
+      args:
+        chdir: "/opt/openstack-ansible/playbooks"
+      tags:
+        - skip_ansible_lint
+      environment:
+        ANSIBLE_LOG_PATH: "/var/log/ansible-kolide-fleet-deployment.log"
+
+    - name: Set kolide-fleet secrets
+      lineinfile:
+        dest: /etc/openstack_deploy/user_secrets.yml
+        state: present
+        regexp: "^{{ item.key }}"
+        line: '{{ item.key }}: "{{ item.value }}"'
+      no_log: True
+      with_items:
+        - key: kolide_fleet_db_password
+          value: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters') }}"
+        - key: kolide_fleet_jwt_key
+          value: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters') }}"
+        - key: kolide_fleet_admin_password
+          value: "{{ lookup('password', '/dev/null length=8 chars=ascii_letters') }}"
+
+    - name: Get osquery roles
+      become: yes
+      become_user: root
+      command: >-
+        {{ ansible_env.HOME }}/ansible25/bin/ansible-galaxy install -r ansible-role-requirements.yml
+        --roles-path={{ ansible_env.HOME }}/ansible25/repositories/roles
+        --ignore-errors
+      tags:
+        - skip_ansible_lint
+      environment:
+        ANSIBLE_LOG_PATH: "/var/log/ansible-kolide-fleet-deployment.log"
+        ANSIBLE_INVENTORY: "{{ ansible_env.HOME }}/ansible25/inventory/openstack_inventory.sh"
+        ANSIBLE_HOST_KEY_CHECKING: "False"
+        ANSIBLE_ROLES_PATH: "{{ ansible_env.HOME }}/ansible25/repositories/roles"
+        ANSIBLE_ACTION_PLUGINS: "{{ ansible_env.HOME }}/ansible25/repositories/ansible-config_template/action"
+        ANSIBLE_CONNECTION_PLUGINS: "{{ ansible_env.HOME }}/ansible25/repositories/openstack-ansible-plugins/connection/"
+      args:
+        chdir: "/opt/openstack-ansible-ops/osquery"
+
+    - name: Find secrets files
+      find:
+        paths: "/etc/openstack_deploy"
+        patterns: 'user_.*(secret|kolide|fleet|aio).*.(yml|yaml)$'
+        use_regex: yes
+      register: secrets_files
+
+    - name: Run osquery deployment
+      become: yes
+      become_user: root
+      command: >-
+        {{ ansible_env.HOME }}/ansible25/bin/ansible-playbook
+        {{ secrets_files.files | map(attribute='path') | list | map('regex_replace', '(.*)' ,'-e @' ~ '\1') | list | join(' ') }}
+        {{ item }}
+      with_items:
+        - site-fleet.yml
+        - site-osquery.yml
+      tags:
+        - skip_ansible_lint
+      environment:
+        ANSIBLE_LOG_PATH: "/var/log/ansible-kolide-fleet-deployment.log"
+        ANSIBLE_INVENTORY: "{{ ansible_env.HOME }}/ansible25/inventory/openstack_inventory.sh"
+        ANSIBLE_HOST_KEY_CHECKING: "False"
+        ANSIBLE_ROLES_PATH: "{{ ansible_env.HOME }}/ansible25/repositories/roles"
+        ANSIBLE_ACTION_PLUGINS: "{{ ansible_env.HOME }}/ansible25/repositories/ansible-config_template/action"
+        ANSIBLE_CONNECTION_PLUGINS: "{{ ansible_env.HOME }}/ansible25/repositories/openstack-ansible-plugins/connection/"
+      args:
+        chdir: "/opt/openstack-ansible-ops/osquery"
+  tags:
+    - fleet
+    - fleet-deployment

--- a/playbooks/openstack-ansible-ops-get.yml
+++ b/playbooks/openstack-ansible-ops-get.yml
@@ -1,0 +1,36 @@
+---
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Clone openstack-ansible-ops
+  hosts: localhost
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+      tags:
+        - always
+
+    - name: Clone OpenStack-Ansible-OPS
+      git:
+        repo: "https://github.com/openstack/openstack-ansible-ops"
+        dest: "/opt/openstack-ansible-ops"
+        version: "{{ ansible_local['rpc_openstack']['rpc_product']['openstack_ansible_ops'] }}"
+  tags:
+    - ops
+    - ops-get

--- a/playbooks/site-logging.yml
+++ b/playbooks/site-logging.yml
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: elk-deployment.yml
+- include: openstack-ansible-ops-get.yml
+- include: deployment-osquery.yml
+- include: deployment-elk.yml

--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -38,18 +38,20 @@ for file_name in user_secrets.yml user_rpco_secrets.yml; do
   fi
 done
 
-# Begin the RPC installation by uploading images and creating flavors and
-# deploying ELK.
+if [ "${DEPLOY_AIO:-false}" != false ]; then
+  cp "${SCRIPT_PATH}/user_aio_variables.yml" /etc/openstack_deploy/user_aio_variables.yml
+fi
+
+# Begin the RPC installation by uploading images and creating flavors.
 pushd "${SCRIPT_PATH}/../playbooks"
   # Create default VM images and flavors
-  if [ "${DEPLOY_AIO:-false}" != false ]; then
-    openstack-ansible site-openstack.yml -e 'openstack_images=[]'
-  else
-    openstack-ansible site-openstack.yml
-  fi
+  openstack-ansible site-openstack.yml
 
   # Deploy RPC operational modifications
   openstack-ansible site-ops.yml
+
+  # Deploy logging tools
+  openstack-ansible site-logging.yml
 popd
 
 if [ "${DEPLOY_MAAS}" != false ]; then

--- a/scripts/user_aio_variables.yml
+++ b/scripts/user_aio_variables.yml
@@ -1,0 +1,8 @@
+---
+
+# NOTE(cloudnull): Test configs used to minimize the impact of a
+#                  multi-node install with limited resources.
+openstack_images: []
+q_storage: 1
+q_mem: 512
+h_mem: 512


### PR DESCRIPTION
The osquery stack is being added to the standard rpco deployment. This
change enhances our ability to operate clouds by providing a means to
query environments via CLI and UI as well as to report security
characteristics of an environment to our ELK stack.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
(cherry picked from commit 87433e4487648e8ca021f2a2b75c0be0a85dc877)
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>