### PR TITLE
RI-520 Update Pike Dependencies in Master

### DIFF
--- a/playbooks/vars/rpc-release.yml
+++ b/playbooks/vars/rpc-release.yml
@@ -15,10 +15,10 @@ rpc_product_releases:
     osa_release: 5047124f1fe181306674c60beeccd189252a9d62
     rpc_release: r15.0.0
   pike:
-    maas_release: 1.7.0
-    openstack_ansible_ops: master
-    osa_release: 5c341a7bada78edab5f3d132d55adb00eaf2413f
-    rpc_release: r16.2.0
+    maas_release: 1.7.9
+    openstack_ansible_ops: d3b53d6f802259b5ea4d12f5a567a7ec86677087
+    osa_release: bc0098042f6ff7fbda89157bb66483ad65af0ce0
+    rpc_release: r16.2.6
   queens:
     maas_release: 1.7.4
     openstack_ansible_ops: master


### PR DESCRIPTION
I think the Octavia gate is deploying pike from master and is using the 
wrong version of rpc-maas.  This updates the SHAs in master to reflect 
those in pike.

Issue: RI-520

Issue: [RI-520](https://rpc-openstack.atlassian.net/browse/RI-520)