### PR TITLE
ASC-665 Use sys-test dev branch for experiment job

### DIFF
--- a/gating/check/run_system_tests.sh
+++ b/gating/check/run_system_tests.sh
@@ -24,6 +24,12 @@ SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
 SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
 SYS_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
 
+# Switch system test branch to `dev` on the experimental-asc job.
+# This job is specifically for running system tests under development.
+if [[ $RE_JOB_NAME == experimental-asc* ]] ; then
+    SYS_TEST_BRANCH=dev
+fi
+
 ## Main ----------------------------------------------------------------------
 
 # 1. Clone test repository into working directory.


### PR DESCRIPTION
This commit sets the value of `SYS_TEST_BRANCH` to `dev` if the CI job
it is running on is the experimental-asc job. This job is specifically
for running system tests under development. It is designed to test
against the `master` branch of `rpc-openstack`, but should not run the
`master` branch of `rpc-openstack-system-tests` because that branch is
used for production CI jobs.

(cherry picked from commit 1afca9999cb28595538036532e41d64a9e63b2b5)

Issue: [ASC-665](https://rpc-openstack.atlassian.net/browse/ASC-665)