### PR TITLE
Update RPC-O Octavia for Rocky

### DIFF
--- a/playbooks/templates/octavia/base.j2
+++ b/playbooks/templates/octavia/base.j2
@@ -17,7 +17,6 @@
 global
     daemon
     user nobody
-    group {{ usergroup }}
     log {{ log_http | default('/dev/log', true)}} local0
     log {{ log_server | default('/dev/log', true)}} local1 notice
     stats socket {{ sock_path }} mode 0666 level user

--- a/playbooks/templates/octavia/macros.j2
+++ b/playbooks/templates/octavia/macros.j2
@@ -175,9 +175,20 @@ frontend {{ listener.id }}
     {% else %}
         {% set proxy_protocol_opt = "" %}
     {% endif %}
-    {{ "server %s %s:%d weight %s%s%s%s"|e|format(
+    {% if member.backup %}
+        {% set member_backup_opt = " backup" %}
+    {% else %}
+        {% set member_backup_opt = "" %}
+    {% endif %}
+    {% if member.enabled %}
+        {% set member_enabled_opt = "" %}
+    {% else %}
+        {% set member_enabled_opt = " disabled" %}
+    {% endif %}
+    {{ "server %s %s:%d weight %s%s%s%s%s%s"|e|format(
         member.id, member.address, member.protocol_port, member.weight,
-        hm_opt, persistence_opt, proxy_protocol_opt)|trim() }}
+        hm_opt, persistence_opt, proxy_protocol_opt, member_backup_opt,
+        member_enabled_opt)|trim() }}
 {% endmacro %}
 
 
@@ -246,6 +257,7 @@ backend {{ pool.id }}
     {% if listener.connection_limit is defined %}
     fullconn {{ listener.connection_limit }}
     {% endif %}
+    option allbackups
     {% for member in pool.members if member.enabled %}
         {{- member_macro(constants, pool, member) -}}
     {% endfor %}


### PR DESCRIPTION
In Rocky the deprecated "user_group" configuration setting was removed
as Octavia now automatically detects it.
This patch removes the "group" from the haproxy jinja2 template
override in RPC-Openstack