### PR TITLE
[RI-538 and RI-561] ELK Fixes

### DIFF
--- a/etc/openstack_deploy/group_vars/all/osa.yml
+++ b/etc/openstack_deploy/group_vars/all/osa.yml
@@ -79,21 +79,17 @@ haproxy_extra_services:
       haproxy_balance_type: http
       haproxy_backend_options:
         - "httpchk"
+      haproxy_enabled: "{{ groups['elasticsearch'] is defined and groups['elasticsearch'] | length > 0 }}"
   - service:
       haproxy_service_name: kibana_ssl
       haproxy_backend_nodes: "{{ groups['kibana'] | default([]) }}"
       haproxy_ssl: True
       haproxy_port: 8443
       haproxy_backend_port: 81
-      haproxy_balance_type: tcp
-  - service:
-      haproxy_service_name: appformix
-      haproxy_backend_nodes: "{{ groups['log_hosts'] }}"
-      haproxy_ssl: True
-      haproxy_port: 9000
       haproxy_balance_type: http
       haproxy_backend_options:
         - "httpchk"
+      haproxy_enabled: "{{ groups['kibana'] is defined and groups['kibana'] | length > 0 }}"
 
 # Define the distro version globally
 repo_build_os_distro_version: "{{ (ansible_distribution | lower) | replace(' ', '_') }}-{{ ansible_distribution_version.split('.')[:2] | join('.') }}-{{ ansible_architecture | lower }}"

--- a/gating/check/run_elk_tests.sh
+++ b/gating/check/run_elk_tests.sh
@@ -32,5 +32,5 @@ source "$(readlink -f $(dirname ${0}))/../mnaio_vars.sh"
 
 ${MNAIO_SSH} <<EOS
   cd /opt/rpc-openstack
-  openstack-ansible playbooks/elk-deployment.yml
+  openstack-ansible playbooks/site-logging.yml
 EOS


### PR DESCRIPTION
This makes the ELK HAproxy services conditional based on whether or not
the proper inventory exists, if not those services are not enabled in
HAProxy.

JIRA: RI-538

The elk-deployment.yml file was renamed to deployment-elk.yml but the
references to elk-deployment.yml were not adjusted.  This rectifies
that.

JIRA: RI-561
(cherry picked from commit 78cea6ffccfbb2a0674b5f14a4504bf3199b4cca)