### PR TITLE
Update RPC-O Octavia for disabled members

### DIFF
--- a/playbooks/templates/octavia/macros.j2
+++ b/playbooks/templates/octavia/macros.j2
@@ -258,7 +258,7 @@ backend {{ pool.id }}
     fullconn {{ listener.connection_limit }}
     {% endif %}
     option allbackups
-    {% for member in pool.members if member.enabled %}
+    {% for member in pool.members %}
         {{- member_macro(constants, pool, member) -}}
     {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Rocky Octavia changed how administratively disabled members are
handled in the amphora. They are now included, but marked in the
"disabled" state. This improves health reporting.
This patch makes sure those "disabled" members are rendered to
the haproxy configuration file.