### PR TITLE
RI-575 Fix the ansible-sshd checkout version

### DIFF
--- a/ansible-role-newton-requirements.yml
+++ b/ansible-role-newton-requirements.yml
@@ -18,3 +18,7 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: dfc2180e9bf28c8f59baca2a233db2a726b97bcb
+- name: sshd
+  scm: git
+  src: https://github.com/willshersystems/ansible-sshd
+  version: v0.4.5

--- a/ansible-role-pike-requirements.yml
+++ b/ansible-role-pike-requirements.yml
@@ -18,3 +18,7 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 86c8e3c6327b5958b5eb3124455e3c12cd280e75
+- name: sshd
+  scm: git
+  src: https://github.com/willshersystems/ansible-sshd
+  version: v0.5.1


### PR DESCRIPTION
In pike/newton the version is attached to a tag, which is missing
the 'v' in front, this will be reverted once we get the fix
upstream.

Issue: [RI-575](https://rpc-openstack.atlassian.net/browse/RI-575)