### PR TITLE
RI-575 Fix the ansible-sshd checkout version

### DIFF
--- a/ansible-role-newton-requirements.yml
+++ b/ansible-role-newton-requirements.yml
@@ -18,3 +18,7 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 86c8e3c6327b5958b5eb3124455e3c12cd280e75
+- name: sshd
+  scm: git
+  src: https://github.com/willshersystems/ansible-sshd
+  version: v0.4.5

--- a/ansible-role-pike-requirements.yml
+++ b/ansible-role-pike-requirements.yml
@@ -2,3 +2,7 @@
   scm: git
   src: https://github.com/rsoprivatecloud/openstack-ops
   version: 17ad9e0795cba56fd030edb1346076f79fdd5870
+- name: sshd
+  scm: git
+  src: https://github.com/willshersystems/ansible-sshd
+  version: v0.5.1


### PR DESCRIPTION
In pike/newton the version is attached to a tag, which is missing
the 'v' in front, this will be reverted once we get the fix
upstream.

(cherry picked from commit 4e86c8a966bfd1e32cb2e8acf92f808ae2a7de8c)

Issue: [RI-575](https://rpc-openstack.atlassian.net/browse/RI-575)