### PR TITLE
RI-575 Fix the ansible-sshd checkout version

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -42,3 +42,7 @@
   scm: git
   src: https://github.com/rcbops/openstack-ansible-pip_install
   version: 2480ab547e22f5b0a0bb27a1abce561a7832ec96
+- name: sshd
+  scm: git
+  src: https://github.com/willshersystems/ansible-sshd
+  version: v0.4.5


### PR DESCRIPTION
In pike/newton the version is attached to a tag, which is missing
the 'v' in front, this will be reverted once we get the fix
upstream.

Issue: [RI-575](https://rpc-openstack.atlassian.net/browse/RI-575)