### PR TITLE
ASC-1371 Assign SYS_TEST_BRANCH via RE vars

### DIFF
--- a/gating/check/run_system_tests.sh
+++ b/gating/check/run_system_tests.sh
@@ -22,7 +22,15 @@ export SYS_VENV_NAME="${SYS_VENV_NAME:-venv-molecule}"
 SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
 SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
 SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
-SYS_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
+# Set SYS_TEST_BRANCH to either RE_JOB_BRANCH or RPC_GATING_BRANCH depending
+# on what was defined by the job.
+if [ -n "${RE_JOB_BRANCH}" ] ; then
+    SYS_TEST_BRANCH="${RE_JOB_BRANCH}"
+elif [ -n "${RPC_GATING_BRANCH}" ] ; then
+    SYS_TEST_BRANCH="${RPC_GATING_BRANCH}"
+else
+    SYS_TEST_BRANCH="master"
+fi
 
 # Switch system test branch to `dev` or `maas` on the experimental-asc job.
 # This job is specifically for running system tests under development.


### PR DESCRIPTION
This commit expands the conditional for assigning the value of
`SYS_TEST_BRANCH`.  PM jobs use `RE_JOB_BRANCH`, while PR jobs use
`RPC_GATING_BRANCH` to provide the branch value to the job.  These
parameters are inspected in turn to assign the value of
`SYS_TEST_BRANCH` to ensure that the system-tests branch is matched to
the RPC-Openstack version under test.

Issue: [ASC-1371](https://rpc-openstack.atlassian.net/browse/ASC-1371)