### PR TITLE
Replace grafana repo with new official one

### DIFF
--- a/scripts/artifacts-building/apt/aptly-vars.yml
+++ b/scripts/artifacts-building/apt/aptly-vars.yml
@@ -486,13 +486,13 @@ aptly_mirrors:
     do_update: "{{ aptly_mirror_do_updates }}"
 
   - name: grafana-jessie-ALL
-    archive_url: https://packagecloud.io/grafana/stable/debian
-    distribution: jessie
+    archive_url: https://packages.grafana.com/oss/deb
+    distribution: stable
     component1:
       - main
     state: "present"
     gpg:
-      key: "D59097AB"
+      key: "8c8c34c524098cb6"
       server: "hkp://keyserver.ubuntu.com:80"
       keyring: "trustedkeys.gpg"
     create_flags:


### PR DESCRIPTION
As of 7 January 2019, packagecloud is no longer used
as a repo for grafana. This updates the URL and key
so that the apt artifact repo can complete the mirror
process using the new repo.

ref: https://grafana.com/blog/2019/01/05/moving-to-packages.grafana.com/