### PR TITLE
RI-631 Add logic to skip log_hosts tasks when empty

### DIFF
--- a/playbooks/site-logging.yml
+++ b/playbooks/site-logging.yml
@@ -15,4 +15,6 @@
 
 - include: openstack-ansible-ops-get.yml
 - include: deployment-osquery.yml
+  when: groups['log_hosts'] is defined and (groups['log_hosts'] | length>0)
 - include: deployment-elk.yml
+  when: groups['log_hosts'] is defined and (groups['log_hosts'] | length>0)


### PR DESCRIPTION
Disable logging related tasks when log_hosts is empty.

Issue: [RI-631](https://rpc-openstack.atlassian.net/browse/RI-631)