### PR TITLE
Update flavor and image setup for newer ansible and images

### DIFF
--- a/playbooks/openstack-flavor-setup.yml
+++ b/playbooks/openstack-flavor-setup.yml
@@ -22,18 +22,22 @@
       include_role:
         name: "openstack_openrc"
 
-    - name: Create flavors of nova VMs
-      os_nova_flavor:
-        endpoint_type: internal
-        cloud: default
-        state: present
-        name: "{{ item.name }}"
-        ram: "{{ item.ram }}"
-        vcpus: "{{ item.vcpus }}"
-        disk: "{{ item.disk }}"
-        swap: "{{ item.swap }}"
-        ephemeral: "{{ item.ephemeral }}"
-      with_items: "{{ openstack_vm_flavors }}"
+    - name: Create system images
+      vars:
+        ansible_python_interpreter: "/opt/rcbops-tools/bin/python"
+      block:
+        - name: Create flavors of nova VMs
+          os_nova_flavor:
+            endpoint_type: internal
+            cloud: default
+            state: present
+            name: "{{ item.name }}"
+            ram: "{{ item.ram }}"
+            vcpus: "{{ item.vcpus }}"
+            disk: "{{ item.disk }}"
+            swap: "{{ item.swap }}"
+            ephemeral: "{{ item.ephemeral }}"
+          with_items: "{{ openstack_vm_flavors }}"
 
   vars_files:
     - vars/openstack-service-config.yml

--- a/playbooks/openstack-image-setup.yml
+++ b/playbooks/openstack-image-setup.yml
@@ -14,36 +14,42 @@
 # limitations under the License.
 
 - name: OpenStack image setup
-  hosts: localhost
+  hosts: utility_all[0]
   environment: "{{ deployment_environment_variables | default({}) }}"
   user: root
+  vars:
+    image_virt_type: "kvm"
   tasks:
-    - name: Create OpenStack client configuration
-      include_role:
-        name: "openstack_openrc"
-
     - name: Download system image file
       get_url:
         url: "{{ item.url }}"
-        dest: "/var/tmp/os_image_{{ item.name }}"
+        dest: "/var/backup/os_image_{{ item.name }}"
         timeout: 1200
+      when:
+        - image_virt_type == item.properties.hypervisor_type
       with_items: "{{ openstack_images }}"
 
-    - name: Install system image
-      os_image:
-        endpoint_type: internal
-        cloud: default
-        state: present
-        is_public: true
-        name: "{{ item.name }}"
-        filename: "/var/tmp/os_image_{{ item.name }}"
-        disk_format: "{{ item.format }}"
-        properties: "{{ item.properties | default(omit) }}"
-      with_items: "{{ openstack_images }}"
+    - name: Create system images
+      vars:
+        ansible_python_interpreter: "/opt/rcbops-tools/bin/python"
+      block:
+        - name: Install system image
+          os_image:
+            endpoint_type: internal
+            cloud: default
+            state: present
+            is_public: true
+            name: "{{ item.name }}"
+            filename: "/var/backup/os_image_{{ item.name }}"
+            disk_format: "{{ item.format }}"
+            properties: "{{ item.properties }}"
+          when:
+            - image_virt_type == item.properties.hypervisor_type
+          with_items: "{{ openstack_images }}"
 
     - name: Clean up temp file
       file:
-        dest: "/var/tmp/os_image_{{ item.name }}"
+        dest: "/var/backup/os_image_{{ item.name }}"
         state: absent
       with_items: "{{ openstack_images }}"
 

--- a/playbooks/site-openstack.yml
+++ b/playbooks/site-openstack.yml
@@ -13,5 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: openstack-image-setup.yml
-- include: openstack-flavor-setup.yml
+- name: Create venv
+  command: "virtualenv --no-site-packages --no-setuptools /opt/rcbops-tools"
+  args:
+    creates: "/opt/rcbops-tools/bin/python"
+
+- name: Create virtualenv
+  vars:
+    ansible_python_interpreter: "/opt/rcbops-tools/bin/python"
+  block:
+    - name: Setup venv
+      pip:
+        name:
+          - setuptools
+          - pip
+        extra_args: "-U"
+        virtualenv: "/opt/rcbops-tools"
+
+    - name: Install openstacksdk
+      pip:
+        name: "openstacksdk"
+        state: "present"
+        virtualenv: "/opt/rcbops-tools/bin/python"
+      register: install_packages
+      until: install_packages is success
+      retries: 5
+      delay: 2
+
+- include_tasks: openstack-image-setup.yml
+
+- include_tasks: openstack-flavor-setup.yml

--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -19,7 +19,7 @@ set -eux
 set -o pipefail
 
 ## Vars ----------------------------------------------------------------------
-
+export DEPLOY_IMAGE_VIRT_TYPE=${DEPLOY_IMAGE_VIRT_TYPE:-kvm}
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
 ## Functions -----------------------------------------------------------------
@@ -45,7 +45,7 @@ fi
 # Begin the RPC installation by uploading images and creating flavors.
 pushd "${SCRIPT_PATH}/../playbooks"
   # Create default VM images and flavors
-  openstack-ansible site-openstack.yml
+  openstack-ansible site-openstack.yml -e "image_virt_type=${DEPLOY_IMAGE_VIRT_TYPE}"
 
   # Deploy RPC operational modifications
   openstack-ansible site-ops.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -64,7 +64,7 @@ if [ "${DEPLOY_AIO:-false}" != false ]; then
   popd
 
   # Deploy RPC-OpenStack.
-  bash -c "DEPLOY_AIO=true ${SCRIPT_PATH}/deploy-rpco.sh"
+  bash -c "DEPLOY_AIO=true DEPLOY_IMAGE_VIRT_TYPE='qemu' ${SCRIPT_PATH}/deploy-rpco.sh"
 else
   basic_install
   exit_notice


### PR DESCRIPTION
This change adds newer images and sets the playbook up to only
deploy images for a given virt-type, which will speed up the
general gate times and test cycles as only the images using the
supported virt type will be enabled.

The deploy scripts have been updated to default to qemu (the
current default) when deploying an AIO. When the playbooks are
executed outside of the gate environment the default will be
KVM, which is the openstack default.

Signed-off-by: Kevin Carter <kevin@cloudnull.com>