### PR TITLE
(ASC-1552) Add health check tests before running system tests

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -50,3 +50,7 @@ fi
 if [[ ${RE_JOB_ACTION} == "elk" ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_elk_tests.sh)"
 fi
+
+if [[ ${RE_JOB_ACTION} == "health_check" ]]; then
+  bash -c "$(readlink -f $(dirname ${0})/run_health_check_tests.sh)"
+fi

--- a/gating/check/run_health_check_tests.sh
+++ b/gating/check/run_health_check_tests.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+## Deploy virtualenv for testing environment molecule/ansible-playbook/infratest
+
+## Shell Opts ----------------------------------------------------------------
+
+set -ex
+set -o pipefail
+
+## Variables -----------------------------------------------------------------
+
+# The RPC_PRODUCT_RELEASE and RPC_RELEASE need to be brought into scope
+# before running health check tests.
+if [[ ${RE_JOB_IMAGE} =~ .*mnaio.* ]]; then
+  source /opt/rpc-openstack/scripts/functions.sh
+fi
+
+RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
+export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
+HC_WORKING_DIR=$(mktemp  -d -t healthcheck_test_workingdir.XXXXXXXX)
+export HC_VENV_NAME="${HC_VENV_NAME:-healthcheck-molecule}"
+HC_TEST_SOURCE_BASE="${HC_TEST_SOURCE_BASE:-https://github.com/rcbops}"
+HC_TEST_SOURCE="${HC_TEST_SOURCE:-rpc-openstack-healthcheck}"
+HC_TEST_SOURCE_REPO="${HC_TEST_SOURCE_BASE}/${HC_TEST_SOURCE}"
+HC_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
+
+## Main ----------------------------------------------------------------------
+
+# 1. Clone test repository into working directory.
+pushd "${HC_WORKING_DIR}"
+git clone "${HC_TEST_SOURCE_REPO}"
+cd "${HC_TEST_SOURCE}"
+
+# Checkout defined branch
+git checkout "${HC_TEST_BRANCH}"
+echo "${HC_TEST_SOURCE} at SHA $(git rev-parse HEAD)"
+
+# fail softly if the tests or artifact gathering fails
+set +e
+
+# 2. Execute script from repository
+chmod 755 execute_tests.sh
+./execute_tests.sh
+[[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
+
+# 3. Collect results from script, if they exist
+mkdir -p "${RE_HOOK_RESULT_DIR}" || true  # ensure that result directory exists
+if [[ -e test_results.tar ]]; then
+  tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
+fi
+
+# 4. Collect logs from script, if they exist
+mkdir -p "${RE_HOOK_ARTIFACT_DIR}" || true  # ensure that artifact directory exists
+if [[ -e test_results.tar ]]; then
+  cp test_results.tar "${RE_HOOK_ARTIFACT_DIR}/molecule_test_results.tar"
+fi
+popd
+
+# if exit code is recorded, use it, otherwise let it exit naturally
+[[ -z ${RC+x} ]] && exit ${RC}


### PR DESCRIPTION
This PR adds an experimental test of running health check tests
in repo https://github.com/rcbops/rpc-openstack-healthcheck.
The health check tests in the above repo will be executed
right after RPC-O deployment without modification anything to ensure
that the deployment is in good status before entering system tests.