### PR TITLE
RI-661 Implement RPC-Designate MNAIO job

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -50,3 +50,7 @@ fi
 if [[ ${RE_JOB_ACTION} == "elk" ]]; then
   bash -c "$(readlink -f $(dirname ${0})/run_elk_tests.sh)"
 fi
+
+if [[ ${RE_JOB_ACTION} == "designate" ]]; then
+  bash -c "$(readlink -f $(dirname ${0})/run_designate_tests.sh)"
+fi

--- a/gating/check/run_designate_tests.sh
+++ b/gating/check/run_designate_tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -exu
+
+echo "Installing the RPC-Designate on a RPC-O Multi Node AIO (MNAIO)"
+
+## Vars and Functions --------------------------------------------------------
+
+source "$(readlink -f $(dirname ${0}))/../gating_vars.sh"
+
+source /opt/rpc-openstack/scripts/functions.sh
+
+source "$(readlink -f $(dirname ${0}))/../mnaio_vars.sh"
+
+## Main --------------------------------------------------------------------
+
+${MNAIO_SSH} <<EOS
+  cd /opt/ && git clone https://github.com/rcbops/rpc-designate
+  cd /opt/rpc-designate/
+  ./gating/scripts/pre.sh
+  openstack-ansible ./gating/scripts/test_designate.yml
+EOS


### PR DESCRIPTION
Implement rpc-designate job as one 'action', which could be used
later in rpc-gating script. This way is re-using rpc-artifacts's
mnaio vm image and then apply rpc-designate testing upon it.