### PR TITLE
[RI-573] Update ELK MNAIO deployment

### DIFF
--- a/gating/check/run_elk_tests.sh
+++ b/gating/check/run_elk_tests.sh
@@ -31,6 +31,10 @@ source "$(readlink -f $(dirname ${0}))/../mnaio_vars.sh"
 ## Main --------------------------------------------------------------------
 
 ${MNAIO_SSH} <<EOS
-  cd /opt/rpc-openstack
-  openstack-ansible playbooks/site-logging.yml
+  cd /opt
+  git clone https://github.com/rcbops/magnanimous-turbo-chainsaw
+  cd /opt/magnanimous-turbo-chainsaw
+  git checkout ${MTC_BRANCH}
+  bash ./scripts/setup.sh
+  bash ./scripts/deploy-elk.sh
 EOS

--- a/gating/mnaio_vars.sh
+++ b/gating/mnaio_vars.sh
@@ -56,6 +56,7 @@ fi
 #
 export RPC_BRANCH="${RE_JOB_BRANCH}"
 export DEPLOY_MAAS=false
+export MTC_BRANCH="${MTC_BRANCH:-master}"
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,9 @@ setenv =
     # NOTE(cloudnull): This should be set to "master" as soon the gate is capable of
     #                  setting this option.
     OSA_RELEASE_BRANCH={env:OSA_RELEASE_BRANCH:master}
-    OSA_TEST_RELEASE=master
-    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_TEST_RELEASE:master}
+    OSA_TEST_RELEASE=d90acf00b639496cd0669153534fe5588875f3ee
+    OSA_UPPER_CONSTRAINTS=377fde64ac16dc94da2e29e16a4102adcc081a6e
+    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_UPPER_CONSTRAINTS:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_ROLE_REQUIREMENTS=https://git.openstack.org/cgit/openstack/openstack-ansible/plain/ansible-role-requirements.yml?h={env:OSA_RELEASE_BRANCH:master}
 basepython = python2.7
@@ -87,10 +88,10 @@ commands =
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
                git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
-               pushd {toxinidir}/tests/common; \
-                 git checkout {env:OSA_TEST_RELEASE:master}; \
-               popd; \
-             fi"
+             fi; \
+             pushd {toxinidir}/tests/common; \
+               git checkout {env:OSA_TEST_RELEASE:master}; \
+             popd"
 
 
 [testenv:pep8]


### PR DESCRIPTION
This updates the ELK MNAIO deployment methodology to use the new
MTC tooling developed by the Tools team.

This also updates the OSA test repository to a known good SHA.  The
SHA will need to be updated once master moves to T.

JIRA: RI-573

Issue: [RI-573](https://rpc-openstack.atlassian.net/browse/RI-573)