### PR TITLE
Remove legacy Dockerfile [ocata]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y python2.7 python-pip build-essential python-dev libssl-dev libffi-dev sudo git
-RUN pip install virtualenv 'tox!=2.4.0,>=2.3' jenkinsapi
-RUN useradd jenkins --shell /bin/bash --create-home --uid 500
-RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Some time ago there was an attempt done to have RPC-O use Jenkinsfile.
This attempt was aborted, but there are remaining bits which were never
cleaned up. To reduce confusion we should clean up the previous attempt.

(cherry picked from commit daf5b7df540027003f20cbea124795707dc2085d)

Issue: [RE-2073](https://rpc-openstack.atlassian.net/browse/RE-2073)