### PR TITLE
Enable snapshot image creation for PUSH and TIMER [master]

### DIFF
--- a/gating/check/post_deploy.sh
+++ b/gating/check/post_deploy.sh
@@ -66,9 +66,10 @@ else
 fi
 echo "#### END DSTAT CHART GENERATION ###"
 
-# Only enable snapshot when triggered by a commit push.
-# This is to enable image updates whenever a PR is merged, but not before
-if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]] && [[ ${RE_JOB_STATUS:-SUCCESS} == "SUCCESS" ]]; then
+# Only enable snapshot when triggered by a commit push or a periodic job,
+# and only when the job succeeded. This is to enable snapshot image updates
+# based on committed code that works.
+if [[ "${RE_JOB_STATUS:-UNKNOWN}" == "SUCCESS" && ( "${RE_JOB_TRIGGER:-USER}" == "PUSH" || "${RE_JOB_TRIGGER:-USER}" == "TIMER" ) ]]; then
   echo "### BEGIN SNAPSHOT PREP ###"
   mkdir -p /gating/thaw
 


### PR DESCRIPTION
To ensure that the snapshot image creation happens more regularly,
we ensure that the preparation for it happens for both a PUSH and
a TIMER trigger.

This will ensure that the images are updated on a daily basis,
not just when a new patch merges.

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)