### PR TITLE
Enable snapshot image creation for PUSH and TIMER [newton]

### DIFF
--- a/gating/check/post_deploy.sh
+++ b/gating/check/post_deploy.sh
@@ -37,9 +37,10 @@ extract_rpc_release(){
   awk '/rpc_release/{print $2}' | tr -d '"'
 }
 
-# Only enable snapshot when triggered by a commit push.
-# This is to enable image updates whenever a PR is merged, but not before
-if [[ "${RE_JOB_TRIGGER:-USER}" == "PUSH" ]] && [[ ${RE_JOB_STATUS:-SUCCESS} == "SUCCESS" ]]; then
+# Only enable snapshot when triggered by a commit push or a periodic job,
+# and only when the job succeeded. This is to enable snapshot image updates
+# based on committed code that works.
+if [[ "${RE_JOB_STATUS:-UNKNOWN}" == "SUCCESS" && ( "${RE_JOB_TRIGGER:-USER}" == "PUSH" || "${RE_JOB_TRIGGER:-USER}" == "TIMER" ) ]]; then
   echo "### BEGIN SNAPSHOT PREP ###"
   mkdir -p /gating/thaw
 


### PR DESCRIPTION
To ensure that the snapshot image creation happens more regularly,
we ensure that the preparation for it happens for both a PUSH and
a TIMER trigger.

This will ensure that the images are updated on a daily basis,
not just when a new patch merges.

(cherry picked from commit e11f62aa8b2ee940619306378ddec935e58d9af8)

Issue: [RE-2278](https://rpc-openstack.atlassian.net/browse/RE-2278)