### PR TITLE
[RI-675] Pin OSA_TEST_RELEASE and OSA_UPPER_CONSTRAINTS

### DIFF
--- a/gating/gating_vars.sh
+++ b/gating/gating_vars.sh
@@ -10,3 +10,8 @@ export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 export RE_JOB_NAME="${RE_JOB_NAME:-${RE_JOB_TRIGGER}_rpc-openstack-master-${RE_JOB_IMAGE}_no_artifacts-${RE_JOB_SCENARIO}-${RE_JOB_ACTION}}"
 export RE_JOB_PROJECT_NAME="${RE_JOB_PROJECT_NAME:-}"
+
+# OSA Tests SHA
+# These variables pin the SHA for the OSA Testing repository
+export OSA_TEST_RELEASE=${OSA_TEST_RELEASE:-d90acf00b639496cd0669153534fe5588875f3ee}
+export OSA_UPPER_CONSTRAINTS=${OSA_UPPER_CONSTRAINTS:-377fde64ac16dc94da2e29e16a4102adcc081a6e}

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -20,11 +20,6 @@ export DEPLOY_MAAS=${DEPLOY_MAAS:-false}
 export DEPLOY_TELEGRAF=${DEPLOY_TELEGRAF:-false}
 export DEPLOY_INFLUX=${DEPLOY_INFLUX:-false}
 
-# Tox Variables
-# Known working for master 2/27/19
-export OSA_TEST_RELEASE=${OSA_TEST_RELEASE:-d90acf00b639496cd0669153534fe5588875f3ee}
-export OSA_UPPER_CONSTRAINTS=${OSA_UPPER_CONSTRAINTS:-377fde64ac16dc94da2e29e16a4102adcc081a6e}
-
 if [ ${DEPLOY_AIO} == true ]; then
   export DEPLOY_MAAS=false
 fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -20,6 +20,11 @@ export DEPLOY_MAAS=${DEPLOY_MAAS:-false}
 export DEPLOY_TELEGRAF=${DEPLOY_TELEGRAF:-false}
 export DEPLOY_INFLUX=${DEPLOY_INFLUX:-false}
 
+# Tox Variables
+# Known working for master 2/27/19
+export OSA_TEST_RELEASE=${OSA_TEST_RELEASE:-d90acf00b639496cd0669153534fe5588875f3ee}
+export OSA_UPPER_CONSTRAINTS=${OSA_UPPER_CONSTRAINTS:-377fde64ac16dc94da2e29e16a4102adcc081a6e}
+
 if [ ${DEPLOY_AIO} == true ]; then
   export DEPLOY_MAAS=false
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ commands =
                popd; \
              else; \
                pushd {toxinidir}/tests/common; \
-                 git fetch origin
+                 git fetch origin; \
                  git checkout {env:OSA_TEST_RELEASE:master}; \
                popd; \
              fi"

--- a/tox.ini
+++ b/tox.ini
@@ -88,10 +88,15 @@ commands =
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
                git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
-             fi; \
-             pushd {toxinidir}/tests/common; \
-               git checkout {env:OSA_TEST_RELEASE:master}; \
-             popd"
+	       pushd {toxinidir}/tests/common; \
+	         git checkout {env:OSA_TEST_RELEASE:master}; \
+	       popd; \
+             else; \
+               pushd {toxinidir}/tests/common; \
+	         git fetch origin
+                 git checkout {env:OSA_TEST_RELEASE:master}; \
+               popd; \
+	     fi"
 
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ commands =
                pushd {toxinidir}/tests/common; \
                  git checkout {env:OSA_TEST_RELEASE:master}; \
                popd; \
-             else; \
+             else \
                pushd {toxinidir}/tests/common; \
                  git fetch origin; \
                  git checkout {env:OSA_TEST_RELEASE:master}; \

--- a/tox.ini
+++ b/tox.ini
@@ -88,15 +88,15 @@ commands =
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
                git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
-	       pushd {toxinidir}/tests/common; \
-	         git checkout {env:OSA_TEST_RELEASE:master}; \
-	       popd; \
-             else; \
                pushd {toxinidir}/tests/common; \
-	         git fetch origin
                  git checkout {env:OSA_TEST_RELEASE:master}; \
                popd; \
-	     fi"
+             else; \
+               pushd {toxinidir}/tests/common; \
+                 git fetch origin
+                 git checkout {env:OSA_TEST_RELEASE:master}; \
+               popd; \
+             fi"
 
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,9 @@ setenv =
     # NOTE(cloudnull): This should be set to "master" as soon the gate is capable of
     #                  setting this option.
     OSA_RELEASE_BRANCH={env:OSA_RELEASE_BRANCH:master}
-    OSA_TEST_RELEASE=master
-    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_TEST_RELEASE:master}
+    OSA_TEST_RELEASE={env:OSA_TEST_RELEASE:master}
+    OSA_UPPER_CONSTRAINTS={env:OSA_UPPER_CONSTRAINTS:master}
+    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_UPPER_CONSTRAINTS:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_ROLE_REQUIREMENTS=https://git.openstack.org/cgit/openstack/openstack-ansible/plain/ansible-role-requirements.yml?h={env:OSA_RELEASE_BRANCH:master}
 basepython = python2.7
@@ -87,10 +88,10 @@ commands =
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
                git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
-               pushd {toxinidir}/tests/common; \
-                 git checkout {env:OSA_TEST_RELEASE:master}; \
-               popd; \
-             fi"
+             fi; \
+             pushd {toxinidir}/tests/common; \
+               git checkout {env:OSA_TEST_RELEASE:master}; \
+             popd"
 
 
 [testenv:pep8]


### PR DESCRIPTION
Due to ongoing upstream improvements we need to pin the
OSA_TEST_RELEASE and OSA_UPPER_CONSTRAINS that we're using for
linting via tox.  This adds both of those variables to functions.sh
as well as provides the ability to specify SHAs via the command-line.

JIRA: RI-675

Issue: [RI-675](https://rpc-openstack.atlassian.net/browse/RI-675)