### PR TITLE
ASC-1683 Enable Ceph MNAIO Deployments

### DIFF
--- a/gating/mnaio_vars.sh
+++ b/gating/mnaio_vars.sh
@@ -45,6 +45,13 @@ export DEPLOY_OSA="false"
 export RUN_OSA="false"
 export CONFIGURE_OPENSTACK="false"
 
+#
+# Enable Ceph backend if specified by the RE_JOB_SCENARIO
+#
+if [[ ${RE_JOB_SCENARIO} =~ .*ceph.* ]]; then
+  export ENABLE_CEPH_STORAGE="true"
+fi
+
 # If there is no set of images available yet, or this
 # is the deploy action, then we need to build from scratch.
 if [[ "${RPCO_IMAGES_AVAILABLE}" == "false" ]] || [[ "${RE_JOB_ACTION}" == "deploy" ]]; then
@@ -92,6 +99,7 @@ function run_mnaio_playbook() {
                  -e loadbalancer_vm_server_ram=${LOADBALANCER_VM_SERVER_RAM:-"2048"} \
                  -e logging_vm_server_ram=${LOGGING_VM_SERVER_RAM:-"16384"} \
                  -e swift_vm_server_ram=${SWIFT_VM_SERVER_RAM:-"2048"} \
+                 -e enable_ceph_storage=${ENABLE_CEPH_STORAGE=-"false"} \
                  -e container_tech=${CONTAINER_TECH:-"lxc"} \
                  -e ipxe_kernel_base_url=${IPXE_KERNEL_BASE_URL:-"http://boot.ipxe.org"} \
                  -e ipxe_path_url=${IPXE_PATH_URL:-""} ${MNAIO_ANSIBLE_PARAMETERS} \


### PR DESCRIPTION
This update will allow users to create RPC-O jobs that deploy Ceph backed
MNAIO images using the "RE_JOB_SCENARIO" to specify the desired backened.