### PR TITLE
[RI-675] Pin OSA_TEST_RELEASE and OSA_UPPER_CONSTRAINTS

### DIFF
--- a/gating/gating_vars.sh
+++ b/gating/gating_vars.sh
@@ -10,3 +10,9 @@ export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 export RE_JOB_NAME="${RE_JOB_NAME:-${RE_JOB_TRIGGER}_rpc-openstack-master-${RE_JOB_IMAGE}_no_artifacts-${RE_JOB_SCENARIO}-${RE_JOB_ACTION}}"
 export RE_JOB_PROJECT_NAME="${RE_JOB_PROJECT_NAME:-}"
+
+# OSA Tests SHA
+# # These variables pin the SHA for the OSA Testing repository
+export OSA_TEST_RELEASE=${OSA_TEST_RELEASE:-d90acf00b639496cd0669153534fe5588875f3ee}
+export OSA_UPPER_CONSTRAINTS=${OSA_UPPER_CONSTRAINTS:-377fde64ac16dc94da2e29e16a4102adcc081a6e}
+

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ setenv =
     # NOTE(cloudnull): This should be set to "master" as soon the gate is capable of
     #                  setting this option.
     OSA_RELEASE_BRANCH={env:OSA_RELEASE_BRANCH:stable/rocky}
-    OSA_TEST_RELEASE=d90acf00b639496cd0669153534fe5588875f3ee
-    OSA_UPPER_CONSTRAINTS=377fde64ac16dc94da2e29e16a4102adcc081a6e
+    OSA_TEST_RELEASE={env:OSA_TEST_RELEASE:master}
+    OSA_UPPER_CONSTRAINTS={env:OSA_UPPER_CONSTRAINTS:master}
     UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_UPPER_CONSTRAINTS:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TEST_RELEASE:master}
     OSA_ROLE_REQUIREMENTS=https://git.openstack.org/cgit/openstack/openstack-ansible/plain/ansible-role-requirements.yml?h={env:OSA_RELEASE_BRANCH:master}
@@ -89,10 +89,15 @@ commands =
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
                git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
-             fi; \
-             pushd {toxinidir}/tests/common; \
-               git checkout {env:OSA_TEST_RELEASE:master}; \
-             popd"
+               pushd {toxinidir}/tests/common; \
+                 git checkout {env:OSA_TEST_RELEASE:master}; \
+               popd; \
+             else \
+               pushd {toxinidir}/tests/common; \
+                 git fetch origin; \
+                 git checkout {env:OSA_TEST_RELEASE:master}; \
+               popd; \
+             fi"
 
 
 [testenv:pep8]


### PR DESCRIPTION
Due to ongoing upstream improvements we need to pin the
OSA_TEST_RELEASE and OSA_UPPER_CONSTRAINS that we're using for
linting via tox. This adds both of those variables to functions.sh
as well as provides the ability to specify SHAs via the command-line.

JIRA: RI-675

based-on: 1997378f144fea2ad8e2729c0c25a8f383812ccb

Issue: [RI-675](https://rpc-openstack.atlassian.net/browse/RI-675)