### PR TITLE
Fix for ubuntu kernel extra modules package name change

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,10 +1,11 @@
 # Note (Frank) - RLM-322:
 # this is a forked ansible role for removing
 # hardcoded period mark from hostname template.
+# Note (Shannon): Fix for ubuntu kernel modules package rename
 - name: openstack_hosts
   scm: git
   src: https://github.com/rcbops/openstack-ansible-openstack_hosts
-  version: c6bab1bd157ec807b6b696f65290a4549e041fc5
+  version: 93366865089906c9223e76e2a6ed279e7c1a82b3
 # Note (odyssey4me) - RO-4147:
 # PBR released a new version after newton went EOL,
 # causing various builds to break. We therefore use


### PR DESCRIPTION
Ubuntu has changed the name of its kernel extra modules package
from linux-image-extra to linux-modules-extra.  Changes were made
in the openstack_hosts role initially.  This change is to point
the ansible role requirment to the openstack_hosts fix sha.