### PR TITLE
Points Newton to use openstack_hosts stable/newton

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -5,7 +5,7 @@
 - name: openstack_hosts
   scm: git
   src: https://github.com/rcbops/openstack-ansible-openstack_hosts
-  version: 93366865089906c9223e76e2a6ed279e7c1a82b3
+  version: stable/newton
 # Note (odyssey4me) - RO-4147:
 # PBR released a new version after newton went EOL,
 # causing various builds to break. We therefore use


### PR DESCRIPTION
Changes newton branch to utilize openstack_hosts
stable/newton branch instead of a sha to pull in
https://github.com/rcbops/openstack-ansible-openstack_hosts/pull/4
and so we can avoid having to modify rpc-openstack in case
we need to make future changes to openstack_hosts for newton.

The change mainly drops off the linux-extra-* from being installed
due to the issues we were having with kernel version mismatches.

Mainly doing this so we can have this change in Newton and avoid having to change the Newton upgrade PR jobs that test this.

Fixes https://github.com/rcbops/rpc-upgrades/issues/368